### PR TITLE
broken(math): Add test cases that prove osmosis math is wrong

### DIFF
--- a/x/dex/types/shares.go
+++ b/x/dex/types/shares.go
@@ -57,7 +57,7 @@ func (pool Pool) maximalSharesFromExactRatioJoin(tokensIn sdk.Coins) (numShares 
 		// we have to calculate remCoins
 		for i, coin := range tokensIn {
 			if !coinShareRatios[i].Equal(minShareRatio) {
-				usedAmount := minShareRatio.MulInt(coin.Amount).Ceil().TruncateInt()
+				usedAmount := minShareRatio.MulInt(poolLiquidity.AmountOfNoDenomValidation(coin.Denom)).Ceil().TruncateInt()
 				remainingAmount := coin.Amount.Sub(usedAmount)
 				// add to RemCoins
 				if !remainingAmount.IsZero() {

--- a/x/dex/types/shares_test.go
+++ b/x/dex/types/shares_test.go
@@ -17,81 +17,51 @@ func TestMaximalSharesFromExactRatioJoin(t *testing.T) {
 		expectedRemCoins  sdk.Coins
 	}{
 		{
-			name: "all coins deposited",
-			poolAssets: []PoolAsset{
-				{
-					Token: sdk.NewInt64Coin("aaa", 100),
-				},
-				{
-					Token: sdk.NewInt64Coin("bbb", 100),
-				},
-			},
-			existingShares: 100,
-			tokensIn: sdk.NewCoins(
-				sdk.NewInt64Coin("aaa", 100),
-				sdk.NewInt64Coin("bbb", 100),
-			),
-			expectedNumShares: sdk.NewInt(100),
-			expectedRemCoins:  sdk.NewCoins(),
-		},
-		{
 			name: "some coins deposited",
 			poolAssets: []PoolAsset{
 				{
 					Token: sdk.NewInt64Coin("aaa", 100),
 				},
 				{
-					Token: sdk.NewInt64Coin("bbb", 100),
+					Token: sdk.NewInt64Coin("bbb", 200),
 				},
 			},
 			existingShares: 100,
+			// limiting coin is 'bbb' which accounts for 5% of pool 'bbb'
+			// so all 'bbb' tokens should be taken
+			// and exactly 5 'aaa' tokens should be taken
+			// but osmosis' math takes only 1 'aaa' token
 			tokensIn: sdk.NewCoins(
-				sdk.NewInt64Coin("aaa", 100),
-				sdk.NewInt64Coin("bbb", 50),
+				sdk.NewInt64Coin("aaa", 10),
+				sdk.NewInt64Coin("bbb", 10),
 			),
-			expectedNumShares: sdk.NewInt(50),
+			expectedNumShares: sdk.NewInt(5),
 			expectedRemCoins: sdk.NewCoins(
-				sdk.NewInt64Coin("aaa", 50),
+				sdk.NewInt64Coin("aaa", 5),
 			),
 		},
 		{
 			name: "limited by smallest amount",
 			poolAssets: []PoolAsset{
 				{
-					Token: sdk.NewInt64Coin("aaa", 100),
+					Token: sdk.NewInt64Coin("aaa", 1000),
 				},
 				{
-					Token: sdk.NewInt64Coin("bbb", 100),
+					Token: sdk.NewInt64Coin("bbb", 1000),
 				},
 			},
-			existingShares: 100,
+			existingShares: 1000,
+			// limiting coin is 'aaa' which accounts for 1% of pool 'aaa'
+			// so all 'aaa' tokens should be taken
+			// and exactly 10 'bbb' tokens should be taken
+			// but osmosis' math takes only 1 'bbb' token
 			tokensIn: sdk.NewCoins(
-				sdk.NewInt64Coin("aaa", 1),
+				sdk.NewInt64Coin("aaa", 10),
 				sdk.NewInt64Coin("bbb", 50),
 			),
-			expectedNumShares: sdk.NewInt(1),
+			expectedNumShares: sdk.NewInt(10),
 			expectedRemCoins: sdk.NewCoins(
-				sdk.NewInt64Coin("bbb", 49),
-			),
-		},
-		{
-			name: "right number of LP shares",
-			poolAssets: []PoolAsset{
-				{
-					Token: sdk.NewInt64Coin("aaa", 50),
-				},
-				{
-					Token: sdk.NewInt64Coin("bbb", 100),
-				},
-			},
-			existingShares: 150,
-			tokensIn: sdk.NewCoins(
-				sdk.NewInt64Coin("aaa", 50),
-				sdk.NewInt64Coin("bbb", 50),
-			),
-			expectedNumShares: sdk.NewInt(75),
-			expectedRemCoins: sdk.NewCoins(
-				sdk.NewInt64Coin("aaa", 25),
+				sdk.NewInt64Coin("bbb", 40),
 			),
 		},
 	} {


### PR DESCRIPTION
DO NOT MERGE

This PR is simply to demonstrate a couple of test cases where Osmosis' exact ratio join math is wrong for LPing two assets into a dex pool.

The tests in this PR test the osmosis `maximalExactRatioJoin` function [here](https://github.com/osmosis-labs/osmosis/blob/cc0ec41cf9f22693773006a886f2744e516e6816/x/gamm/pool-models/balancer/amm.go#L217).