### PR TITLE
fix(script): Update localnet.sh

### DIFF
--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -36,7 +36,7 @@ fi
 
 # Set localnet settings
 BINARY=./build/matrixd
-CHAIN_ID=matrix-test-chain-0
+CHAIN_ID=nibiru-test-chain-0
 CHAIN_DIR=./data
 RPC_PORT=26657
 GRPC_PORT=9090


### PR DESCRIPTION
- update chain-id to `matrix-test-chain-0`
- update chain directory to just `./data`
- set default keyring-backend to `test` (no more having to specify `--keyring-backend test` in commands)
- set default chain id in config (no more having to specify `--chain-id` in commands)
- added more error catching
- cleaned up commands

Run with `make localnet`