### PR TITLE
fix(build): Add build output dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 ###############################################################################
 
 # command for make build and make install
+build: BUILD_ARGS=-o $(BUILDDIR)/
 build install: go.sum $(BUILDDIR)/
 	go $@ -mod=readonly $(BUILD_FLAGS) $(BUILD_ARGS) ./...
 


### PR DESCRIPTION
Before, the `make build` command wasn't outputting the built binary to `./build/nibid`, so the `make localnet` command was failing. This PR addresses that by adding the output directory as a build argument to the `make build` command.