### PR TITLE
chore(perp): Remove unnecessary mockCtrl.Finish()

### DIFF
--- a/x/perp/keeper/perp_test.go
+++ b/x/perp/keeper/perp_test.go
@@ -24,7 +24,6 @@ func TestGetAndSetPosition(t *testing.T) {
 			name: "get - no positions set raises vpool not found error",
 			test: func() {
 				mockCtrl := gomock.NewController(t)
-				defer mockCtrl.Finish()
 				vpoolMock := mock.NewMockIVirtualPool(mockCtrl)
 
 				trader := sample.AccAddress()
@@ -41,7 +40,6 @@ func TestGetAndSetPosition(t *testing.T) {
 			name: "set - creating position with set works and shows up in get",
 			test: func() {
 				mockCtrl := gomock.NewController(t)
-				defer mockCtrl.Finish()
 				vpoolMock := mock.NewMockIVirtualPool(mockCtrl)
 				vpoolPair := "osmo:nusd"
 
@@ -88,7 +86,6 @@ func TestClearPosition(t *testing.T) {
 			name: "set - creating position with set works and shows up in get",
 			test: func() {
 				mockCtrl := gomock.NewController(t)
-				defer mockCtrl.Finish()
 				vpoolMock := mock.NewMockIVirtualPool(mockCtrl)
 				vpoolPair := "osmo:nusd"
 


### PR DESCRIPTION
```If you are using a Go version of 1.14+, a mockgen version of 1.5.0+, and are passing a *testing.T into gomock.NewController(t) you no longer need to call ctrl.Finish() explicitly. It will be called for you automatically from a self registered [Cleanup](https://pkg.go.dev/testing?tab=doc#T.Cleanup) function.```

https://github.com/golang/mock#building-mocks