### PR TITLE
fix (pricefeed): query price cli

### DIFF
--- a/x/pricefeed/client/cli/query.go
+++ b/x/pricefeed/client/cli/query.go
@@ -23,16 +23,14 @@ func GetQueryCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	commands := []*cobra.Command{
+	queryCmd.AddCommand(
 		CmdQueryParams(),
 		CmdPrice(),
 		CmdPrices(),
 		CmdRawPrices(),
 		CmdOracles(),
 		CmdPairs(),
-	}
-
-	queryCmd.AddCommand(commands...)
+	)
 
 	return queryCmd
 }


### PR DESCRIPTION
Command gives the expect behavior for a pair that exists:

![image](https://user-images.githubusercontent.com/51418232/170514217-20397ae5-31c3-4bd3-a1b5-cd6d4f76b88a.png)

It also works properly for a pair that hasn't been listed:

![image](https://user-images.githubusercontent.com/51418232/170514495-bf72ef90-8299-44f3-9501-95f35cc6ef59.png)

- closes #498 