### PR TITLE
fix(perp): Enable zero base asset limit

### DIFF
--- a/x/perp/types/msgs.go
+++ b/x/perp/types/msgs.go
@@ -68,11 +68,11 @@ func (msg *MsgOpenPosition) ValidateBasic() error {
 	if _, err := sdk.AccAddressFromBech32(msg.Sender); err != nil {
 		return err
 	}
-	if !msg.Leverage.GT(sdk.ZeroDec()) {
+	if msg.Leverage.LTE(sdk.ZeroDec()) {
 		return fmt.Errorf("leverage must always be greater than zero")
 	}
-	if !msg.BaseAssetAmountLimit.GT(sdk.ZeroInt()) {
-		return fmt.Errorf("base asset amount limit must always be greater than zero")
+	if msg.BaseAssetAmountLimit.LT(sdk.ZeroInt()) {
+		return fmt.Errorf("base asset amount limit must not be negative")
 	}
 	if !msg.QuoteAssetAmount.GT(sdk.ZeroInt()) {
 		return fmt.Errorf("quote asset amount must be always greater than zero")


### PR DESCRIPTION
- now it's possible to call the open position cli with zero base asset limit (indicating no limit on the base asset)

e.g. `nibid tx perp open-position buy ubtc:unusd 1 100000 0`