### PR TITLE
chore: update workflow timeout to 30m

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   integration-tests:
     runs-on: self-hosted
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
10 minutes is [too short](https://github.com/NibiruChain/nibiru/actions/runs/3114977768).