### PR TITLE
chore: update workflows to use GH hosted runners

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   changelog:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: dangoslen/changelog-enforcer@v3

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,6 +1,6 @@
 name: Linter
 
-# Run on every master merge and on PRs. 
+# Run on every master merge and on PRs.
 on:
   push:
     branches: ["master"]
@@ -14,7 +14,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
   pr-lint:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
-    - uses: seferov/pr-lint-action@master
-      with:
-        # taken from https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c
-        title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)'
-        title-regex-flags: 'g' # optional
-        error-message: 'Please follow conventional commit style: https://www.conventionalcommits.org/en/v1.0.0/' # optional
+      - uses: seferov/pr-lint-action@master
+        with:
+          # taken from https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c
+          title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)'
+          title-regex-flags: "g" # optional
+          error-message: "Please follow conventional commit style: https://www.conventionalcommits.org/en/v1.0.0/" # optional

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   install-runsim:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -21,7 +21,7 @@ jobs:
         run: go install github.com/cosmos/tools/cmd/runsim@v1.0.0
 
   test-sim-nondeterminism:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [install-runsim]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/skip-integration-tests.yml
+++ b/.github/workflows/skip-integration-tests.yml
@@ -4,13 +4,13 @@ name: Integration tests
 on:
   pull_request:
     # paths-ignore makes the action run when the given paths are unchanged
-    # See "Handling skipped but required checks" in 
+    # See "Handling skipped but required checks" in
     # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
     paths-ignore: ["**.go", "**.proto", "go.mod", "go.sum"]
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: skip-tests
         run: |

--- a/.github/workflows/skip-unit-tests.yml
+++ b/.github/workflows/skip-unit-tests.yml
@@ -4,13 +4,13 @@ name: Unit Tests
 on:
   pull_request:
     # paths-ignore makes the action run when the given paths are unchanged
-    # See "Handling skipped but required checks" in 
+    # See "Handling skipped but required checks" in
     # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
     paths-ignore: ["**.go", "**.proto", "go.mod", "go.sum"]
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: skip-tests
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
# Description

Use the GH-hosted runners instead of our own now that the repo is public.

# Purpose

Save on our compute resources.
