### PR TITLE
feat(vpool): Add governance proposal to edit the swap invariant of one or more vpools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1038](https://github.com/NibiruChain/nibiru/pull/1038) - feat(dex): add single asset join
 * [#1058](https://github.com/NibiruChain/nibiru/pull/1058) - feature: use collections external lib
 * [#1074](https://github.com/NibiruChain/nibiru/pull/1074) - feat(vpool): Add gov proposal for editing the vpool config without changing the reserves.
+* [#xxx](https://github.com/NibiruChain/nibiru/pull/xxx) - feat(vpool): Add gov proposal for editing the sswap invariant of a vpool..
 
 ### Improvements
 

--- a/proto/vpool/v1/gov.proto
+++ b/proto/vpool/v1/gov.proto
@@ -36,3 +36,35 @@ message EditPoolConfigProposal {
     (gogoproto.nullable) = false
   ];
 }
+
+// EditSwapInvariantsProposal is a governance proposal to change the swap 
+// invariant of the virtual pool for one or more trading pairs.
+message EditSwapInvariantsProposal {
+  string title = 1;
+  string description = 2;
+
+  // A map between a trading pair and a desired multiplier for its swap invariant. 
+  message SwapInvariantMultiple {
+    option (gogoproto.goproto_getters) = false;
+    option (gogoproto.goproto_stringer) = false;
+
+    // Pair is a string identifier for an asset pair. 
+    string pair = 3;
+
+    // Multiplier is a number representing the desired percentage change to the 
+    // swap invariant of the AMM pool underlying 'pair'
+    string multiplier = 4 [
+        (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
+        (gogoproto.nullable) = false
+    ];
+  }
+
+  // Map from pair ID to a multiple on the swap invariant. For example, a proposal containing 
+  // "swap_invariant_maps": [{ "uatom:unusd": "5" }, { "uosmo:unusd": "0.9" }]
+  // would mutliply the swap invariant of the ATOM and OSMO trading pairs by 
+  // 5 and 0.9 respectively. The price at which k changes is the instantaneous 
+  // mark price at the time of the proposal's execution.
+  repeated SwapInvariantMultiple swap_invariant_maps = 5 [
+    (gogoproto.nullable) = false
+  ];
+}

--- a/x/vpool/client/cli/cli_test.go
+++ b/x/vpool/client/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"github.com/NibiruChain/nibiru/x/common"
 	testutilcli "github.com/NibiruChain/nibiru/x/testutil/cli"
 	"github.com/NibiruChain/nibiru/x/vpool/client/cli"
+	"github.com/NibiruChain/nibiru/x/vpool/types"
 	vpooltypes "github.com/NibiruChain/nibiru/x/vpool/types"
 )
 
@@ -33,6 +35,33 @@ type IntegrationTestSuite struct {
 
 func TestIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(IntegrationTestSuite))
+}
+
+var START_VPOOLS = map[common.AssetPair]vpooltypes.Vpool{
+	common.Pair_ETH_NUSD: {
+		Pair:              common.Pair_ETH_NUSD,
+		BaseAssetReserve:  sdk.NewDec(10_000_000),
+		QuoteAssetReserve: sdk.NewDec(60_000_000_000),
+		Config: vpooltypes.VpoolConfig{
+			TradeLimitRatio:        sdk.MustNewDecFromStr("0.8"),
+			FluctuationLimitRatio:  sdk.MustNewDecFromStr("0.2"),
+			MaxOracleSpreadRatio:   sdk.MustNewDecFromStr("0.2"),
+			MaintenanceMarginRatio: sdk.MustNewDecFromStr("0.0625"),
+			MaxLeverage:            sdk.MustNewDecFromStr("15"),
+		},
+	},
+	common.Pair_NIBI_NUSD: {
+		Pair:              common.Pair_NIBI_NUSD,
+		BaseAssetReserve:  sdk.NewDec(5_000_000),
+		QuoteAssetReserve: sdk.NewDec(500_000),
+		Config: vpooltypes.VpoolConfig{
+			TradeLimitRatio:        sdk.MustNewDecFromStr("0.8"),
+			FluctuationLimitRatio:  sdk.MustNewDecFromStr("0.2"),
+			MaxOracleSpreadRatio:   sdk.MustNewDecFromStr("0.2"),
+			MaintenanceMarginRatio: sdk.MustNewDecFromStr("0.04"),
+			MaxLeverage:            sdk.MustNewDecFromStr("20"),
+		},
+	},
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
@@ -48,20 +77,11 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	genesisState := simapp.NewTestGenesisStateFromDefault()
 	vpoolGenesis := vpooltypes.DefaultGenesis()
 	vpoolGenesis.Vpools = []vpooltypes.Vpool{
-		{
-			Pair:              common.Pair_ETH_NUSD,
-			BaseAssetReserve:  sdk.NewDec(10_000_000),
-			QuoteAssetReserve: sdk.NewDec(60_000_000_000),
-			Config: vpooltypes.VpoolConfig{
-				TradeLimitRatio:        sdk.MustNewDecFromStr("0.8"),
-				FluctuationLimitRatio:  sdk.MustNewDecFromStr("0.2"),
-				MaxOracleSpreadRatio:   sdk.MustNewDecFromStr("0.2"),
-				MaintenanceMarginRatio: sdk.MustNewDecFromStr("0.0625"),
-				MaxLeverage:            sdk.MustNewDecFromStr("15"),
-			},
-		},
+		START_VPOOLS[common.Pair_ETH_NUSD],
+		START_VPOOLS[common.Pair_NIBI_NUSD],
 	}
-	genesisState[vpooltypes.ModuleName] = encodingConfig.Marshaler.MustMarshalJSON(vpoolGenesis)
+	genesisState[vpooltypes.ModuleName] = encodingConfig.Marshaler.
+		MustMarshalJSON(vpoolGenesis)
 
 	s.cfg = testutilcli.BuildNetworkConfig(genesisState)
 	s.network = testutilcli.NewNetwork(s.T(), s.cfg)
@@ -73,10 +93,94 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 	s.network.Cleanup()
 }
 
-func (s *IntegrationTestSuite) TestCmdCreatePoolProposal() {
+func (s *IntegrationTestSuite) PassGovProposal() {
 	val := s.network.Validators[0]
 	clientCtx := val.ClientCtx.WithOutputFormat("json")
 	govQueryClient := govtypes.NewQueryClient(clientCtx)
+
+	// ----------------------------------------------------------------------
+	s.T().Log(`Check that proposal was correctly submitted with gov client
+$ nibid query gov proposal 1`)
+	// ----------------------------------------------------------------------
+	proposalsQueryResp, err := govQueryClient.Proposals(
+		context.Background(), &govtypes.QueryProposalsRequest{
+			Depositor: val.Address.String(),
+		},
+	)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(proposalsQueryResp.Proposals)
+
+	s.Equalf(
+		govtypes.StatusDepositPeriod,
+		proposalsQueryResp.Proposals[0].Status,
+		"proposal should be in deposit period as it hasn't passed min deposit")
+	s.EqualValues(
+		sdk.NewCoins(sdk.NewInt64Coin("unibi", 1000)),
+		proposalsQueryResp.Proposals[0].TotalDeposit,
+	)
+
+	// ----------------------------------------------------------------------
+	s.T().Log(`Move proposal to vote status by meeting min deposit
+$ nibid tx gov deposit [proposal-id] [deposit] [flags]`)
+	// ----------------------------------------------------------------------
+	govDepositParams, err := govQueryClient.Params(
+		context.Background(),
+		&govtypes.QueryParamsRequest{
+			ParamsType: govtypes.ParamDeposit,
+		},
+	)
+	s.NoError(err)
+
+	proposalId := proposalsQueryResp.Proposals[0].ProposalId
+	args := []string{
+		/*proposal-id=*/ strconv.Itoa(int(proposalId)),
+		/*deposit=*/ govDepositParams.DepositParams.MinDeposit.String(),
+	}
+	txResp, err := testutilcli.ExecTx(s.network, govcli.NewCmdDeposit(), val.Address, args)
+	s.Require().NoError(err)
+	s.EqualValues(abcitypes.CodeTypeOK, txResp.Code)
+
+	proposalQueryResponse, err := govQueryClient.Proposal(
+		context.Background(),
+		&govtypes.QueryProposalRequest{
+			ProposalId: proposalId,
+		},
+	)
+	s.Require().NoError(err)
+	s.Equalf(
+		govtypes.StatusVotingPeriod,
+		proposalQueryResponse.Proposal.Status,
+		"proposal should be in voting period since min deposit has been met",
+	)
+
+	// ----------------------------------------------------------------------
+	s.T().Log(`Vote on the proposal.
+$ nibid tx gov vote [proposal-id] [option] [flags]
+e.g. $ nibid tx gov vote 1 yes`)
+	// ----------------------------------------------------------------------
+	args = []string{
+		/*proposal-id=*/ strconv.Itoa(int(proposalId)),
+		/*option=*/ "yes",
+	}
+
+	txResp, err = testutilcli.ExecTx(s.network, govcli.NewCmdVote(), val.Address, args)
+	s.NoError(err)
+	s.EqualValues(abcitypes.CodeTypeOK, txResp.Code)
+
+	s.Require().Eventuallyf(
+		func() bool {
+			proposalQueryResp, err := govQueryClient.Proposal(
+				context.Background(), &govtypes.QueryProposalRequest{ProposalId: proposalId})
+			s.Require().NoError(err)
+			return govtypes.StatusPassed == proposalQueryResp.Proposal.Status
+		},
+		20*time.Second,
+		2*time.Second,
+		"proposal should pass after voting period")
+}
+
+func (s *IntegrationTestSuite) TestCmdCreatePoolProposal() {
+	val := s.network.Validators[0]
 
 	// ----------------------------------------------------------------------
 	s.T().Log("load example proposal json as bytes")
@@ -117,85 +221,7 @@ func (s *IntegrationTestSuite) TestCmdCreatePoolProposal() {
 	s.Require().NoError(err)
 	s.EqualValues(abcitypes.CodeTypeOK, txResp.Code)
 
-	// ----------------------------------------------------------------------
-	s.T().Log(`Check that proposal was correctly submitted with gov client
-$ nibid query gov proposal 1`)
-	// ----------------------------------------------------------------------
-	proposalsQueryResp, err := govQueryClient.Proposals(
-		context.Background(), &govtypes.QueryProposalsRequest{
-			Depositor: val.Address.String(),
-		},
-	)
-	s.Require().NoError(err)
-	s.Require().NotEmpty(proposalsQueryResp.Proposals)
-
-	s.Equalf(
-		govtypes.StatusDepositPeriod,
-		proposalsQueryResp.Proposals[0].Status,
-		"proposal should be in deposit period as it hasn't passed min deposit")
-	s.EqualValues(
-		sdk.NewCoins(sdk.NewInt64Coin("unibi", 1000)),
-		proposalsQueryResp.Proposals[0].TotalDeposit,
-	)
-
-	// ----------------------------------------------------------------------
-	s.T().Log(`Move proposal to vote status by meeting min deposit
-$ nibid tx gov deposit [proposal-id] [deposit] [flags]`)
-	// ----------------------------------------------------------------------
-	govDepositParams, err := govQueryClient.Params(
-		context.Background(),
-		&govtypes.QueryParamsRequest{
-			ParamsType: govtypes.ParamDeposit,
-		},
-	)
-	s.NoError(err)
-
-	proposalId := proposalsQueryResp.Proposals[0].ProposalId
-	args = []string{
-		/*proposal-id=*/ strconv.Itoa(int(proposalId)),
-		/*deposit=*/ govDepositParams.DepositParams.MinDeposit.String(),
-	}
-	txResp, err = testutilcli.ExecTx(s.network, govcli.NewCmdDeposit(), val.Address, args)
-	s.Require().NoError(err)
-	s.EqualValues(abcitypes.CodeTypeOK, txResp.Code)
-
-	proposalQueryResponse, err := govQueryClient.Proposal(
-		context.Background(),
-		&govtypes.QueryProposalRequest{
-			ProposalId: proposalId,
-		},
-	)
-	s.Require().NoError(err)
-	s.Equalf(
-		govtypes.StatusVotingPeriod,
-		proposalQueryResponse.Proposal.Status,
-		"proposal should be in voting period since min deposit has been met",
-	)
-
-	// ----------------------------------------------------------------------
-	s.T().Log(`Vote on the proposal.
-$ nibid tx gov vote [proposal-id] [option] [flags]
-e.g. $ nibid tx gov vote 1 yes`)
-	// ----------------------------------------------------------------------
-	args = []string{
-		/*proposal-id=*/ strconv.Itoa(int(proposalId)),
-		/*option=*/ "yes",
-	}
-
-	txResp, err = testutilcli.ExecTx(s.network, govcli.NewCmdVote(), val.Address, args)
-	s.NoError(err)
-	s.EqualValues(abcitypes.CodeTypeOK, txResp.Code)
-
-	s.Require().Eventuallyf(
-		func() bool {
-			proposalQueryResp, err := govQueryClient.Proposal(
-				context.Background(), &govtypes.QueryProposalRequest{ProposalId: proposalId})
-			s.Require().NoError(err)
-			return govtypes.StatusPassed == proposalQueryResp.Proposal.Status
-		},
-		20*time.Second,
-		2*time.Second,
-		"proposal should pass after voting period")
+	s.PassGovProposal()
 
 	// ----------------------------------------------------------------------
 	s.T().Log("verify that the new proposed pool exists")
@@ -236,18 +262,17 @@ func (s *IntegrationTestSuite) TestGetPrices() {
 	s.NoError(err)
 }
 
-func (s *IntegrationTestSuite) TestCmdEditPoolProposal() {
+func (s *IntegrationTestSuite) TestCmdEditPoolConfigProposal() {
 	val := s.network.Validators[0]
-	clientCtx := val.ClientCtx.WithOutputFormat("json")
-	govQueryClient := govtypes.NewQueryClient(clientCtx)
 
 	// ----------------------------------------------------------------------
 	s.T().Log("load example proposal json as bytes")
 	// ----------------------------------------------------------------------
+	startVpool := START_VPOOLS[common.Pair_ETH_NUSD]
 	proposal := &vpooltypes.EditPoolConfigProposal{
 		Title:       "NIP-3: Edit config of the ueth:unusd vpool",
 		Description: "enables higher max leverage on ueth:unusd",
-		Pair:        common.Pair_ETH_NUSD.String(),
+		Pair:        startVpool.Pair.String(),
 		Config: vpooltypes.VpoolConfig{
 			TradeLimitRatio:        sdk.MustNewDecFromStr("0.8"),
 			FluctuationLimitRatio:  sdk.MustNewDecFromStr("0.2"),
@@ -278,85 +303,7 @@ func (s *IntegrationTestSuite) TestCmdEditPoolProposal() {
 	s.Require().NoError(err)
 	s.EqualValues(abcitypes.CodeTypeOK, txResp.Code)
 
-	// ----------------------------------------------------------------------
-	s.T().Log(`Check that proposal was correctly submitted with gov client
-$ nibid query gov proposal 1`)
-	// ----------------------------------------------------------------------
-	proposalsQueryResp, err := govQueryClient.Proposals(
-		context.Background(), &govtypes.QueryProposalsRequest{
-			Depositor: val.Address.String(),
-		},
-	)
-	s.Require().NoError(err)
-	s.Require().NotEmpty(proposalsQueryResp.Proposals)
-
-	s.Equalf(
-		govtypes.StatusDepositPeriod,
-		proposalsQueryResp.Proposals[0].Status,
-		"proposal should be in deposit period as it hasn't passed min deposit")
-	s.EqualValues(
-		sdk.NewCoins(sdk.NewInt64Coin("unibi", 1000)),
-		proposalsQueryResp.Proposals[0].TotalDeposit,
-	)
-
-	// ----------------------------------------------------------------------
-	s.T().Log(`Move proposal to vote status by meeting min deposit
-$ nibid tx gov deposit [proposal-id] [deposit] [flags]`)
-	// ----------------------------------------------------------------------
-	govDepositParams, err := govQueryClient.Params(
-		context.Background(),
-		&govtypes.QueryParamsRequest{
-			ParamsType: govtypes.ParamDeposit,
-		},
-	)
-	s.NoError(err)
-
-	proposalId := proposalsQueryResp.Proposals[0].ProposalId
-	args = []string{
-		/*proposal-id=*/ strconv.Itoa(int(proposalId)),
-		/*deposit=*/ govDepositParams.DepositParams.MinDeposit.String(),
-	}
-	txResp, err = testutilcli.ExecTx(s.network, govcli.NewCmdDeposit(), val.Address, args)
-	s.Require().NoError(err)
-	s.EqualValues(abcitypes.CodeTypeOK, txResp.Code)
-
-	proposalQueryResponse, err := govQueryClient.Proposal(
-		context.Background(),
-		&govtypes.QueryProposalRequest{
-			ProposalId: proposalId,
-		},
-	)
-	s.Require().NoError(err)
-	s.Equalf(
-		govtypes.StatusVotingPeriod,
-		proposalQueryResponse.Proposal.Status,
-		"proposal should be in voting period since min deposit has been met",
-	)
-
-	// ----------------------------------------------------------------------
-	s.T().Log(`Vote on the proposal.
-$ nibid tx gov vote [proposal-id] [option] [flags]
-e.g. $ nibid tx gov vote 1 yes`)
-	// ----------------------------------------------------------------------
-	args = []string{
-		/*proposal-id=*/ strconv.Itoa(int(proposalId)),
-		/*option=*/ "yes",
-	}
-
-	txResp, err = testutilcli.ExecTx(s.network, govcli.NewCmdVote(), val.Address, args)
-	s.NoError(err)
-	s.EqualValues(abcitypes.CodeTypeOK, txResp.Code)
-
-	s.Require().Eventuallyf(
-		func() bool {
-			proposalQueryResp, err := govQueryClient.Proposal(
-				context.Background(), &govtypes.QueryProposalRequest{ProposalId: proposalId})
-			s.Require().NoError(err)
-			return govtypes.StatusPassed == proposalQueryResp.Proposal.Status
-		},
-		20*time.Second,
-		2*time.Second,
-		"proposal should pass after voting period")
+	s.PassGovProposal()
 
 	// ----------------------------------------------------------------------
 	s.T().Log("verify that the newly proposed vpool config has been set")
@@ -371,9 +318,87 @@ e.g. $ nibid tx gov vote 1 yes`)
 		if vpool.Pair.String() == proposal.Pair {
 			s.EqualValues(vpooltypes.Vpool{
 				Pair:              common.MustNewAssetPair(proposal.Pair),
-				BaseAssetReserve:  vpool.BaseAssetReserve,
-				QuoteAssetReserve: vpool.QuoteAssetReserve,
+				BaseAssetReserve:  startVpool.BaseAssetReserve,
+				QuoteAssetReserve: startVpool.QuoteAssetReserve,
 				Config:            proposal.Config,
+			}, vpool)
+			found = true
+		}
+	}
+	s.True(found, "pool does not exist")
+}
+
+func (s *IntegrationTestSuite) TestCmdEditSwapInvariantsProposal() {
+	val := s.network.Validators[0]
+
+	// ----------------------------------------------------------------------
+	s.T().Log("load example proposal json as bytes")
+	// ----------------------------------------------------------------------
+	startVpool := START_VPOOLS[common.Pair_NIBI_NUSD]
+	proposal := &vpooltypes.EditSwapInvariantsProposal{
+		Title:       "NIP-4: Change the swap invariant for ATOM, OSMO, and BTC.",
+		Description: "increase swap invariant for many virtual pools",
+		SwapInvariantMaps: []types.EditSwapInvariantsProposal_SwapInvariantMultiple{
+			{Pair: startVpool.Pair.String(), Multiplier: sdk.NewDec(100)},
+		},
+	}
+	proposalFile := sdktestutil.WriteToNewTempFile(s.T(), string(val.ClientCtx.Codec.MustMarshalJSON(proposal)))
+	contents, err := os.ReadFile(proposalFile.Name())
+	s.Require().NoError(err)
+
+	s.T().Log("Unmarshal json bytes into proposal object; check validity")
+	proposal = &vpooltypes.EditSwapInvariantsProposal{}
+	val.ClientCtx.Codec.MustUnmarshalJSON(contents, proposal)
+	s.Require().NoError(proposal.ValidateBasic())
+
+	vpoolsQueryResp := new(vpooltypes.QueryAllPoolsResponse)
+	s.Require().NoError(testutilcli.ExecQuery(
+		s.network.Validators[0].ClientCtx,
+		cli.CmdGetVpools(), nil, vpoolsQueryResp))
+	var vpoolBefore vpooltypes.Vpool
+	for _, vpool := range vpoolsQueryResp.Pools {
+		if vpool.Pair.String() == proposal.SwapInvariantMaps[0].Pair {
+			vpoolBefore = vpool
+			break
+		}
+	}
+
+	// ----------------------------------------------------------------------
+	s.T().Log("Submit proposal and unmarshal tx response")
+	// ----------------------------------------------------------------------
+	args := []string{
+		proposalFile.Name(),
+		fmt.Sprintf("--%s=1000unibi", govcli.FlagDeposit),
+	}
+	cmd := cli.CmdEditSwapInvariantsProposal()
+	flags.AddTxFlagsToCmd(cmd)
+	txResp, err := testutilcli.ExecTx(s.network, cmd, val.Address, args)
+	s.Require().NoError(err)
+	s.EqualValues(abcitypes.CodeTypeOK, txResp.Code)
+
+	s.PassGovProposal()
+
+	// ----------------------------------------------------------------------
+	s.T().Log("verify that the newly proposed vpool config has been set")
+	// ----------------------------------------------------------------------
+	s.Require().NoError(s.network.WaitForNextBlock())
+
+	vpoolsQueryResp = new(vpooltypes.QueryAllPoolsResponse)
+	s.Require().NoError(testutilcli.ExecQuery(s.network.Validators[0].ClientCtx, cli.CmdGetVpools(), nil, vpoolsQueryResp))
+
+	found := false
+	for _, vpool := range vpoolsQueryResp.Pools {
+		proposalPair := proposal.SwapInvariantMaps[0].Pair
+		s.Assert().EqualValues(
+			float64(10),
+			math.Sqrt(proposal.SwapInvariantMaps[0].Multiplier.MustFloat64()))
+
+		if vpool.Pair.String() == proposalPair {
+			s.EqualValues(vpooltypes.Vpool{
+				Pair:              common.MustNewAssetPair(proposalPair),
+				BaseAssetReserve:  vpoolBefore.BaseAssetReserve.MulInt64(10), // multiplier = 100 = (c^2)
+				QuoteAssetReserve: vpoolBefore.QuoteAssetReserve.MulInt64(10),
+				Config:            vpoolBefore.Config,
 			}, vpool)
 			found = true
 		}

--- a/x/vpool/handler.go
+++ b/x/vpool/handler.go
@@ -31,6 +31,8 @@ func NewVpoolProposalHandler(k keeper.Keeper) govtypes.Handler {
 			return handleProposalCreatePool(ctx, k, proposal)
 		case *types.EditPoolConfigProposal:
 			return handleProposalEditPoolConfig(ctx, k, proposal)
+		case *types.EditSwapInvariantsProposal:
+			return handleProposalEditSwapInvariants(ctx, k, proposal)
 		default:
 			return sdkerrors.Wrapf(
 				sdkerrors.ErrUnknownRequest,
@@ -74,4 +76,19 @@ func handleProposalEditPoolConfig(
 	}
 
 	return k.EditPoolConfig(ctx, pair, proposal.Config)
+}
+
+func handleProposalEditSwapInvariants(
+	ctx sdk.Context, k keeper.Keeper, proposal *types.EditSwapInvariantsProposal,
+) error {
+	if err := proposal.ValidateBasic(); err != nil {
+		return err
+	}
+	for _, swapInvariantMap := range proposal.SwapInvariantMaps {
+		err := k.EditSwapInvariant(ctx, swapInvariantMap)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/x/vpool/types/codec.go
+++ b/x/vpool/types/codec.go
@@ -18,6 +18,7 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 
 	registry.RegisterImplementations((*govtypes.Content)(nil), &CreatePoolProposal{})
 	registry.RegisterImplementations((*govtypes.Content)(nil), &EditPoolConfigProposal{})
+	registry.RegisterImplementations((*govtypes.Content)(nil), &EditSwapInvariantsProposal{})
 
 	// msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/x/vpool/types/gov.go
+++ b/x/vpool/types/gov.go
@@ -1,24 +1,31 @@
 package types
 
 import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
 	"github.com/NibiruChain/nibiru/x/common"
 )
 
 const (
-	ProposalTypeCreatePool     = "CreatePool"
-	ProposalTypeEditPoolConfig = "EditPoolConfig"
+	ProposalTypeCreatePool         = "CreatePool"
+	ProposalTypeEditPoolConfig     = "EditPoolConfig"
+	ProposalTypeEditSwapInvariants = "EditSwapInvariants"
 )
 
 var _ govtypes.Content = &CreatePoolProposal{}
 var _ govtypes.Content = &EditPoolConfigProposal{}
+var _ govtypes.Content = &EditSwapInvariantsProposal{}
 
 func init() {
 	govtypes.RegisterProposalType(ProposalTypeCreatePool)
 	govtypes.RegisterProposalTypeCodec(&CreatePoolProposal{}, "nibiru/CreatePoolProposal")
 	govtypes.RegisterProposalType(ProposalTypeEditPoolConfig)
 	govtypes.RegisterProposalTypeCodec(&EditPoolConfigProposal{}, "nibiru/EditPoolConfigProposal")
+	govtypes.RegisterProposalType(ProposalTypeEditSwapInvariants)
+	govtypes.RegisterProposalTypeCodec(&EditSwapInvariantsProposal{}, "nibiru/EditSwapInvariantsProposal")
 }
 
 // CreatePoolProposal
@@ -72,4 +79,51 @@ func (proposal *EditPoolConfigProposal) ValidateBasic() error {
 
 	config := proposal.Config
 	return config.Validate()
+}
+
+// EditSwapInvariantsProposal
+
+func (proposal *EditSwapInvariantsProposal) ProposalRoute() string {
+	return RouterKey
+}
+
+func (proposal *EditSwapInvariantsProposal) ProposalType() string {
+	return ProposalTypeEditSwapInvariants
+}
+
+func (proposal *EditSwapInvariantsProposal) ValidateBasic() error {
+	if err := govtypes.ValidateAbstract(proposal); err != nil {
+		return err
+	}
+
+	for _, kv := range proposal.SwapInvariantMaps {
+		if err := kv.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (kv *EditSwapInvariantsProposal_SwapInvariantMultiple) Validate() error {
+	var comboError []string
+	_, err := common.NewAssetPair(kv.Pair)
+	if err != nil {
+		comboError = append(comboError, err.Error())
+	}
+
+	_, err = sdk.NewDecFromStr(kv.Multiplier.String())
+	if err != nil {
+		comboError = append(comboError, err.Error())
+	}
+
+	if len(comboError) > 0 {
+		return fmt.Errorf("swap_invariant_multiple err: %s", comboError)
+	}
+
+	return nil
+}
+
+func (kv *EditSwapInvariantsProposal_SwapInvariantMultiple) String() string {
+	return fmt.Sprintf(`{ "pair": "%s", "multiplier": "%s" }`, kv.Pair, kv.Multiplier)
 }

--- a/x/vpool/types/gov.pb.go
+++ b/x/vpool/types/gov.pb.go
@@ -165,38 +165,156 @@ func (m *EditPoolConfigProposal) GetConfig() VpoolConfig {
 	return VpoolConfig{}
 }
 
+// EditSwapInvariantsProposal is a governance proposal to change the swap
+// invariant of the virtual pool for one or more trading pairs.
+type EditSwapInvariantsProposal struct {
+	Title       string `protobuf:"bytes,1,opt,name=title,proto3" json:"title,omitempty"`
+	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	// Map from pair ID to a multiple on the swap invariant. For example, a proposal containing
+	// "swap_invariant_maps": [{ "uatom:unusd": "5" }, { "uosmo:unusd": "0.9" }]
+	// would mutliply the swap invariant of the ATOM and OSMO trading pairs by
+	// 5 and 0.9 respectively. The price at which k changes is the instantaneous
+	// mark price at the time of the proposal's execution.
+	SwapInvariantMaps []EditSwapInvariantsProposal_SwapInvariantMultiple `protobuf:"bytes,5,rep,name=swap_invariant_maps,json=swapInvariantMaps,proto3" json:"swap_invariant_maps"`
+}
+
+func (m *EditSwapInvariantsProposal) Reset()         { *m = EditSwapInvariantsProposal{} }
+func (m *EditSwapInvariantsProposal) String() string { return proto.CompactTextString(m) }
+func (*EditSwapInvariantsProposal) ProtoMessage()    {}
+func (*EditSwapInvariantsProposal) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8a393460ab414204, []int{2}
+}
+func (m *EditSwapInvariantsProposal) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *EditSwapInvariantsProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_EditSwapInvariantsProposal.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *EditSwapInvariantsProposal) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EditSwapInvariantsProposal.Merge(m, src)
+}
+func (m *EditSwapInvariantsProposal) XXX_Size() int {
+	return m.Size()
+}
+func (m *EditSwapInvariantsProposal) XXX_DiscardUnknown() {
+	xxx_messageInfo_EditSwapInvariantsProposal.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_EditSwapInvariantsProposal proto.InternalMessageInfo
+
+func (m *EditSwapInvariantsProposal) GetTitle() string {
+	if m != nil {
+		return m.Title
+	}
+	return ""
+}
+
+func (m *EditSwapInvariantsProposal) GetDescription() string {
+	if m != nil {
+		return m.Description
+	}
+	return ""
+}
+
+func (m *EditSwapInvariantsProposal) GetSwapInvariantMaps() []EditSwapInvariantsProposal_SwapInvariantMultiple {
+	if m != nil {
+		return m.SwapInvariantMaps
+	}
+	return nil
+}
+
+// A map between a trading pair and a desired multiplier for its swap invariant.
+type EditSwapInvariantsProposal_SwapInvariantMultiple struct {
+	// Pair is a string identifier for an asset pair.
+	Pair string `protobuf:"bytes,3,opt,name=pair,proto3" json:"pair,omitempty"`
+	// Multiplier is a number representing the desired percentage change to the
+	// swap invariant of the AMM pool underlying 'pair'
+	Multiplier github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,4,opt,name=multiplier,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"multiplier"`
+}
+
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) Reset() {
+	*m = EditSwapInvariantsProposal_SwapInvariantMultiple{}
+}
+func (*EditSwapInvariantsProposal_SwapInvariantMultiple) ProtoMessage() {}
+func (*EditSwapInvariantsProposal_SwapInvariantMultiple) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8a393460ab414204, []int{2, 0}
+}
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_EditSwapInvariantsProposal_SwapInvariantMultiple.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EditSwapInvariantsProposal_SwapInvariantMultiple.Merge(m, src)
+}
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) XXX_Size() int {
+	return m.Size()
+}
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) XXX_DiscardUnknown() {
+	xxx_messageInfo_EditSwapInvariantsProposal_SwapInvariantMultiple.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_EditSwapInvariantsProposal_SwapInvariantMultiple proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*CreatePoolProposal)(nil), "nibiru.vpool.v1.CreatePoolProposal")
 	proto.RegisterType((*EditPoolConfigProposal)(nil), "nibiru.vpool.v1.EditPoolConfigProposal")
+	proto.RegisterType((*EditSwapInvariantsProposal)(nil), "nibiru.vpool.v1.EditSwapInvariantsProposal")
+	proto.RegisterType((*EditSwapInvariantsProposal_SwapInvariantMultiple)(nil), "nibiru.vpool.v1.EditSwapInvariantsProposal.SwapInvariantMultiple")
 }
 
 func init() { proto.RegisterFile("vpool/v1/gov.proto", fileDescriptor_8a393460ab414204) }
 
 var fileDescriptor_8a393460ab414204 = []byte{
-	// 361 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x92, 0xc1, 0x4e, 0xea, 0x40,
-	0x14, 0x86, 0x5b, 0x2e, 0x70, 0x73, 0x87, 0xc5, 0xbd, 0x77, 0x24, 0xa6, 0x21, 0xa6, 0x10, 0x16,
-	0x86, 0xc4, 0x38, 0x13, 0x74, 0xe7, 0x4e, 0x90, 0xad, 0x21, 0x5d, 0xb8, 0x30, 0x46, 0x32, 0x2d,
-	0x63, 0x99, 0x58, 0x7a, 0xea, 0xcc, 0xd0, 0xe8, 0x5b, 0xf8, 0x08, 0x3e, 0x0e, 0x4b, 0x96, 0x86,
-	0x05, 0x31, 0xf0, 0x22, 0xa6, 0x53, 0x82, 0xc8, 0x4e, 0x13, 0x57, 0x3d, 0x3d, 0xff, 0x7f, 0xbe,
-	0x39, 0xf9, 0x73, 0x10, 0x4e, 0x13, 0x80, 0x88, 0xa6, 0x6d, 0x1a, 0x42, 0x4a, 0x12, 0x09, 0x1a,
-	0xf0, 0xdf, 0x58, 0xf8, 0x42, 0x4e, 0x88, 0x91, 0x48, 0xda, 0xae, 0x55, 0x43, 0x08, 0xc1, 0x68,
-	0x34, 0xab, 0x72, 0x5b, 0xad, 0xba, 0x19, 0x55, 0x9a, 0x69, 0x9e, 0x77, 0x9b, 0xf3, 0x02, 0xc2,
-	0x5d, 0xc9, 0x99, 0xe6, 0x7d, 0x80, 0xa8, 0x2f, 0x21, 0x01, 0xc5, 0x22, 0x5c, 0x45, 0x25, 0x2d,
-	0x74, 0xc4, 0x1d, 0xbb, 0x61, 0xb7, 0xfe, 0x78, 0xf9, 0x0f, 0x6e, 0xa0, 0xca, 0x90, 0xab, 0x40,
-	0x8a, 0x44, 0x0b, 0x88, 0x9d, 0x82, 0xd1, 0xb6, 0x5b, 0x18, 0xa3, 0x62, 0xc2, 0x84, 0x74, 0x7e,
-	0x19, 0xc9, 0xd4, 0xf8, 0x16, 0xed, 0x3d, 0x4c, 0x40, 0xf3, 0x01, 0x53, 0x8a, 0xeb, 0x81, 0xe4,
-	0x8a, 0xcb, 0x94, 0x3b, 0xa5, 0xcc, 0xd2, 0x21, 0xd3, 0x45, 0xdd, 0x9a, 0x2f, 0xea, 0x87, 0xa1,
-	0xd0, 0xa3, 0x89, 0x4f, 0x02, 0x18, 0xd3, 0x00, 0xd4, 0x18, 0xd4, 0xfa, 0x73, 0xac, 0x86, 0xf7,
-	0x54, 0x3f, 0x25, 0x5c, 0x91, 0x0b, 0x1e, 0x78, 0xff, 0x0d, 0xea, 0x3c, 0x23, 0x79, 0x39, 0x08,
-	0xdf, 0x20, 0xec, 0x33, 0xb5, 0x8b, 0x2f, 0x7f, 0x0b, 0xff, 0x2f, 0x23, 0x7d, 0xa2, 0x9f, 0xa1,
-	0x72, 0x00, 0xf1, 0x9d, 0x08, 0x9d, 0xdf, 0x0d, 0xbb, 0x55, 0x39, 0x39, 0x20, 0x3b, 0x71, 0x93,
-	0xab, 0xac, 0xe8, 0x1a, 0x4f, 0xa7, 0x98, 0xbd, 0xe7, 0xad, 0x27, 0x9a, 0x2f, 0x36, 0xda, 0xef,
-	0x0d, 0x85, 0xee, 0x6f, 0x0c, 0x3f, 0x12, 0xf0, 0xc7, 0x8a, 0xc5, 0xaf, 0xae, 0xd8, 0xe9, 0x4d,
-	0x97, 0xae, 0x3d, 0x5b, 0xba, 0xf6, 0xdb, 0xd2, 0xb5, 0x9f, 0x57, 0xae, 0x35, 0x5b, 0xb9, 0xd6,
-	0xeb, 0xca, 0xb5, 0xae, 0x8f, 0xb6, 0x22, 0xbb, 0x34, 0xbc, 0xee, 0x88, 0x89, 0x98, 0xe6, 0x6c,
-	0xfa, 0x48, 0xf3, 0x7b, 0x32, 0xd9, 0xf9, 0x65, 0x73, 0x4d, 0xa7, 0xef, 0x01, 0x00, 0x00, 0xff,
-	0xff, 0xe3, 0xd7, 0x1d, 0x46, 0xa0, 0x02, 0x00, 0x00,
+	// 463 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x93, 0x31, 0x6f, 0xd3, 0x40,
+	0x14, 0xc7, 0xed, 0x34, 0x09, 0x70, 0x19, 0xa0, 0xd7, 0x80, 0xac, 0x08, 0x39, 0x51, 0x07, 0x14,
+	0x09, 0x71, 0xa7, 0x96, 0xad, 0x5b, 0x13, 0x3a, 0x30, 0x50, 0x45, 0x41, 0x62, 0x40, 0x88, 0xe8,
+	0xe2, 0x1c, 0xee, 0x09, 0xc7, 0xef, 0xb8, 0x77, 0x71, 0xe0, 0x03, 0x20, 0x31, 0x32, 0x32, 0xe6,
+	0xe3, 0x74, 0xec, 0x82, 0x84, 0x3a, 0x54, 0x28, 0xf9, 0x22, 0xc8, 0xe7, 0x50, 0x92, 0x52, 0x86,
+	0x80, 0x98, 0xfc, 0xfc, 0xfe, 0xef, 0xfd, 0xee, 0xef, 0xbf, 0x7c, 0x84, 0x66, 0x1a, 0x20, 0xe1,
+	0xd9, 0x1e, 0x8f, 0x21, 0x63, 0xda, 0x80, 0x05, 0x7a, 0x3b, 0x55, 0x43, 0x65, 0x26, 0xcc, 0x49,
+	0x2c, 0xdb, 0x6b, 0xd4, 0x63, 0x88, 0xc1, 0x69, 0x3c, 0xaf, 0x8a, 0xb1, 0x46, 0xfd, 0x72, 0x15,
+	0xad, 0xb0, 0xb2, 0xe8, 0xee, 0x9e, 0x97, 0x08, 0xed, 0x1a, 0x29, 0xac, 0xec, 0x01, 0x24, 0x3d,
+	0x03, 0x1a, 0x50, 0x24, 0xb4, 0x4e, 0x2a, 0x56, 0xd9, 0x44, 0x06, 0x7e, 0xcb, 0x6f, 0xdf, 0xea,
+	0x17, 0x2f, 0xb4, 0x45, 0x6a, 0x23, 0x89, 0x91, 0x51, 0xda, 0x2a, 0x48, 0x83, 0x92, 0xd3, 0x56,
+	0x5b, 0x94, 0x92, 0xb2, 0x16, 0xca, 0x04, 0x5b, 0x4e, 0x72, 0x35, 0x7d, 0x4d, 0x76, 0xde, 0x4d,
+	0xc0, 0xca, 0x81, 0x40, 0x94, 0x76, 0x60, 0x24, 0x4a, 0x93, 0xc9, 0xa0, 0x92, 0x8f, 0x74, 0xd8,
+	0xe9, 0x45, 0xd3, 0x3b, 0xbf, 0x68, 0x3e, 0x88, 0x95, 0x3d, 0x99, 0x0c, 0x59, 0x04, 0x63, 0x1e,
+	0x01, 0x8e, 0x01, 0x97, 0x8f, 0x47, 0x38, 0x7a, 0xcb, 0xed, 0x07, 0x2d, 0x91, 0x3d, 0x91, 0x51,
+	0x7f, 0xdb, 0xa1, 0x0e, 0x73, 0x52, 0xbf, 0x00, 0xd1, 0x57, 0x84, 0x0e, 0x05, 0x5e, 0xc5, 0x57,
+	0xff, 0x0a, 0x7f, 0x27, 0x27, 0xad, 0xd1, 0x0f, 0x48, 0x35, 0x82, 0xf4, 0x8d, 0x8a, 0x83, 0x1b,
+	0x2d, 0xbf, 0x5d, 0xdb, 0xbf, 0xcf, 0xae, 0xc4, 0xcd, 0x5e, 0xe4, 0x45, 0xd7, 0xcd, 0x74, 0xca,
+	0xf9, 0x79, 0xfd, 0xe5, 0xc6, 0xee, 0xcc, 0x27, 0xf7, 0x8e, 0x46, 0xca, 0xf6, 0x2e, 0x07, 0xfe,
+	0x4b, 0xc0, 0xbf, 0x2c, 0x96, 0x37, 0xb6, 0xf8, 0xb5, 0x44, 0x1a, 0xb9, 0xc5, 0xe7, 0x53, 0xa1,
+	0x9f, 0xa6, 0x99, 0x30, 0x4a, 0xa4, 0x16, 0xff, 0xd9, 0xe6, 0x94, 0xec, 0xe0, 0x54, 0xe8, 0x81,
+	0xfa, 0x89, 0x1c, 0x8c, 0x85, 0xc6, 0xa0, 0xd2, 0xda, 0x6a, 0xd7, 0xf6, 0x0f, 0x7f, 0xf3, 0xf7,
+	0x67, 0x07, 0x6c, 0xad, 0xfd, 0x6c, 0x92, 0x58, 0xa5, 0x13, 0xb9, 0xfc, 0x88, 0x6d, 0x5c, 0x13,
+	0x85, 0xc6, 0xc6, 0x47, 0x9f, 0xdc, 0xbd, 0x76, 0xe5, 0xda, 0xe4, 0x8e, 0x09, 0x19, 0x17, 0xba,
+	0x92, 0xc6, 0xa5, 0xb7, 0xf9, 0x2f, 0xb3, 0x42, 0x38, 0xb8, 0xf9, 0x69, 0xd6, 0xf4, 0xbe, 0xcc,
+	0x9a, 0x5e, 0xe7, 0xe8, 0x74, 0x1e, 0xfa, 0x67, 0xf3, 0xd0, 0xff, 0x3e, 0x0f, 0xfd, 0xcf, 0x8b,
+	0xd0, 0x3b, 0x5b, 0x84, 0xde, 0xb7, 0x45, 0xe8, 0xbd, 0x7c, 0xb8, 0xc2, 0x3d, 0x76, 0x39, 0x74,
+	0x4f, 0x84, 0x4a, 0x79, 0x91, 0x09, 0x7f, 0xcf, 0x8b, 0x7b, 0xea, 0x0e, 0x18, 0x56, 0xdd, 0x2d,
+	0x7d, 0xfc, 0x23, 0x00, 0x00, 0xff, 0xff, 0xbb, 0xee, 0x03, 0xc5, 0xf8, 0x03, 0x00, 0x00,
 }
 
 func (m *CreatePoolProposal) Marshal() (dAtA []byte, err error) {
@@ -327,6 +445,97 @@ func (m *EditPoolConfigProposal) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 
+func (m *EditSwapInvariantsProposal) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EditSwapInvariantsProposal) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *EditSwapInvariantsProposal) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.SwapInvariantMaps) > 0 {
+		for iNdEx := len(m.SwapInvariantMaps) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.SwapInvariantMaps[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintGov(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
+	if len(m.Description) > 0 {
+		i -= len(m.Description)
+		copy(dAtA[i:], m.Description)
+		i = encodeVarintGov(dAtA, i, uint64(len(m.Description)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Title) > 0 {
+		i -= len(m.Title)
+		copy(dAtA[i:], m.Title)
+		i = encodeVarintGov(dAtA, i, uint64(len(m.Title)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size := m.Multiplier.Size()
+		i -= size
+		if _, err := m.Multiplier.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintGov(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x22
+	if len(m.Pair) > 0 {
+		i -= len(m.Pair)
+		copy(dAtA[i:], m.Pair)
+		i = encodeVarintGov(dAtA, i, uint64(len(m.Pair)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintGov(dAtA []byte, offset int, v uint64) int {
 	offset -= sovGov(v)
 	base := offset
@@ -384,6 +593,44 @@ func (m *EditPoolConfigProposal) Size() (n int) {
 		n += 1 + l + sovGov(uint64(l))
 	}
 	l = m.Config.Size()
+	n += 1 + l + sovGov(uint64(l))
+	return n
+}
+
+func (m *EditSwapInvariantsProposal) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Title)
+	if l > 0 {
+		n += 1 + l + sovGov(uint64(l))
+	}
+	l = len(m.Description)
+	if l > 0 {
+		n += 1 + l + sovGov(uint64(l))
+	}
+	if len(m.SwapInvariantMaps) > 0 {
+		for _, e := range m.SwapInvariantMaps {
+			l = e.Size()
+			n += 1 + l + sovGov(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Pair)
+	if l > 0 {
+		n += 1 + l + sovGov(uint64(l))
+	}
+	l = m.Multiplier.Size()
 	n += 1 + l + sovGov(uint64(l))
 	return n
 }
@@ -796,6 +1043,270 @@ func (m *EditPoolConfigProposal) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if err := m.Config.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGov(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthGov
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *EditSwapInvariantsProposal) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGov
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: EditSwapInvariantsProposal: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: EditSwapInvariantsProposal: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Title", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGov
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGov
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGov
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Title = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Description", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGov
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGov
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGov
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Description = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SwapInvariantMaps", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGov
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGov
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGov
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SwapInvariantMaps = append(m.SwapInvariantMaps, EditSwapInvariantsProposal_SwapInvariantMultiple{})
+			if err := m.SwapInvariantMaps[len(m.SwapInvariantMaps)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGov(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthGov
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *EditSwapInvariantsProposal_SwapInvariantMultiple) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGov
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SwapInvariantMultiple: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SwapInvariantMultiple: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Pair", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGov
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGov
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGov
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Pair = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Multiplier", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGov
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGov
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGov
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Multiplier.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex


### PR DESCRIPTION
# Purpose

- Closes #1071

# Change 1 - EditSwapInvariantsProposal

This PR implements a proposal type that maps one or more trading pairs to corresponding multiplers on the swap invariant. The multiplier then changes the virtual reserves in-place without altering the mark price. 
$$
\begin{aligned}
\text{markPrice} = \frac{y}{x} \\
k := x y \\
\text{markPrice}_{\text{new}} = \frac{cy}{cx} = \text{markPrice} \\
k_{\text{new}} = (cx)(cy) = c^2xy = c^2 k
\end{aligned}
$$

The "multiplier" is $c^2$. Notice this implies that a multipying both the base and quote reserves by $c$ results in the new value for $k$ without changing price.

This logic is implemented in `vpool/keeper/pool_state.go` in the `EditSwapInvariant` function. The function and its governance proposal have related unit tests, types tests, marshalling tests, and a CLI test.

# Change 2 - Lower default reserves in localnet.sh

