### PR TITLE
fix: pin cosmos-sdk version to v0.45.10

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-nibiru_chain_version=v0.45.9
+nibiru_chain_version=v0.45.10
 
 protoc_gen_gocosmos() {
   if ! grep "github.com/gogo/protobuf => github.com/regen-network/protobuf" go.mod &>/dev/null; then


### PR DESCRIPTION
This should fix the `make proto-gen` and its effects on the dependencies.