### PR TITLE
fix: sort tokens in join pool to avoid panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * [#1100](https://github.com/NibiruChain/nibiru/pull/1100) - fix(oracle): fix flaky oracle test
+* [#1110](https://github.com/NibiruChain/nibiru/pull/1110) - fix(dex): fix dex issue on unsorted join pool
 
 ## [v0.16.0](https://github.com/NibiruChain/nibiru/releases/tag/v0.16.0) - 2022-11-23
 

--- a/x/dex/types/pool.go
+++ b/x/dex/types/pool.go
@@ -113,6 +113,7 @@ func (pool *Pool) AddTokensToPool(tokensIn sdk.Coins) (
 		return sdk.ZeroInt(), sdk.Coins{}, err
 	}
 
+	tokensIn.Sort()
 	if err := pool.incrementBalances(numShares, tokensIn.Sub(remCoins)); err != nil {
 		return sdk.ZeroInt(), sdk.Coins{}, err
 	}


### PR DESCRIPTION
# Description

Join pool for unsorted token generate a panic and it should not be up to the user to sort them in the transaction.

found in py-sdk with:
```python
nibiru.msg.MsgJoinPool(
                sender=agent.address,
                pool_id=pool_ids["uusdc:unusd"],
                tokens=[Coin(100, "uusdc"), Coin(100, "unusd")],
            ),
```

# Purpose

QoL
