### PR TITLE
fix(oracle): local min voters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* [#1194](https://github.com/NibiruChain/nibiru/pull/1194) - fix(oracle): local min voters
 * [#1126](https://github.com/NibiruChain/nibiru/pull/1126) - test(oracle): stop the tyrannical behavior of TestFuzz_PickReferencePair
 * [#1131](https://github.com/NibiruChain/nibiru/pull/1131) - fix(oracle): use correct distribution module account
 * [#1151](https://github.com/NibiruChain/nibiru/pull/1151) - fix(dex): fix swap calculation for stableswap pools

--- a/contrib/make/chaosnet.mk
+++ b/contrib/make/chaosnet.mk
@@ -10,7 +10,7 @@ chaosnet-build:
 # Run a chaosnet testnet locally
 .PHONY: chaosnet
 chaosnet: chaosnet-down
-	docker compose -f ./contrib/docker-compose/docker-compose-chaosnet.yml up --detach
+	docker compose -f ./contrib/docker-compose/docker-compose-chaosnet.yml up --detach --build
 
 # Stop chaosnet
 .PHONY: chaosnet-down

--- a/contrib/scripts/chaosnet.sh
+++ b/contrib/scripts/chaosnet.sh
@@ -96,6 +96,7 @@ add_genesis_param '.app_state.perp.pair_metadata[1].latest_cumulative_premium_fr
 # x/oracle
 add_genesis_param '.app_state.oracle.params.twap_lookback_window = "900s"'
 add_genesis_param '.app_state.oracle.params.vote_period = "10"'
+add_genesis_param '.app_state.oracle.params.min_voters = "1"'
 add_genesis_param '.app_state.oracle.exchange_rates[0].pair = "ubtc:unusd"'
 add_genesis_param '.app_state.oracle.exchange_rates[0].exchange_rate = "20000"'
 add_genesis_param '.app_state.oracle.exchange_rates[1].pair = "ueth:unusd"'

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -242,7 +242,7 @@ add_genesis_param '.app_state.perp.pair_metadata[1].latest_cumulative_premium_fr
 
 add_genesis_param '.app_state.oracle.params.twap_lookback_window = "900s"'
 add_genesis_param '.app_state.oracle.params.vote_period = "10"'
-add_genesis_param '.app_state.oracle.params.min_voeters = "1"'
+add_genesis_param '.app_state.oracle.params.min_voters = "1"'
 add_genesis_param '.app_state.oracle.exchange_rates[0].pair = "ubtc:unusd"'
 add_genesis_param '.app_state.oracle.exchange_rates[0].exchange_rate = "20000"'
 add_genesis_param '.app_state.oracle.exchange_rates[1].pair = "ueth:unusd"'

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -242,6 +242,7 @@ add_genesis_param '.app_state.perp.pair_metadata[1].latest_cumulative_premium_fr
 
 add_genesis_param '.app_state.oracle.params.twap_lookback_window = "900s"'
 add_genesis_param '.app_state.oracle.params.vote_period = "10"'
+add_genesis_param '.app_state.oracle.params.min_voeters = "1"'
 add_genesis_param '.app_state.oracle.exchange_rates[0].pair = "ubtc:unusd"'
 add_genesis_param '.app_state.oracle.exchange_rates[0].exchange_rate = "20000"'
 add_genesis_param '.app_state.oracle.exchange_rates[1].pair = "ueth:unusd"'


### PR DESCRIPTION
# Description

Sets the `min_voters` locally to 1, for testing purposes.

# Purpose

Local testing is broken because the oracle enforces at least 4 voters for pairs.