### PR TITLE
ci(release): remove unused flags on goreleaser-cross

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1188](https://github.com/NibiruChain/nibiru/pull/1188) - fix(spot): remove A precision and clean up borked logic
 * [#1190](https://github.com/NibiruChain/nibiru/pull/1190) - ci(release): fix TM_VERSION not being set on releases
 * [#1203](https://github.com/NibiruChain/nibiru/pull/1203) - ci: make chaosnet pull nibiru image if --build is not specified
+* [#1209](https://github.com/NibiruChain/nibiru/pull/1209) - ci(release): remove unused flags on goreleaser-cross
 
 ### Bug Fixes
 

--- a/contrib/make/build.mk
+++ b/contrib/make/build.mk
@@ -23,7 +23,7 @@ BUILDDIR ?= $(CURDIR)/build
 export GO111MODULE = on
 
 # process build tags
-build_tags = netgo
+build_tags = netgo osusergo
 build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
@@ -38,7 +38,7 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=nibiru \
 		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
-			-X github.com/tendermint/tendermint/version.TMCoreSemVer=$(TM_VERSION)
+		  -X github.com/tendermint/tendermint/version.TMCoreSemVer=$(TM_VERSION)
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 

--- a/contrib/make/release.mk
+++ b/contrib/make/release.mk
@@ -9,8 +9,6 @@ release:
 	docker run \
 		--rm \
 		--platform=linux/amd64 \
-		--privileged \
-		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v "$(CURDIR)":/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		-e CGO_ENABLED=1 \


### PR DESCRIPTION
Removing `--privileged` and  `docker.sock` mount as we will probably not use goreleaser for building docker.