### PR TITLE
ci: create workflow to test make proto-gen when the script or .proto files change

### DIFF
--- a/.github/workflows/proto-gen.yml
+++ b/.github/workflows/proto-gen.yml
@@ -1,0 +1,18 @@
+name: Proto Generation
+
+on:
+  pull_request:
+    paths: ["**.proto", "**protocgen**"]
+
+jobs:
+  proto-gen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+          cache: true
+
+      - name: Generate proto code
+        run: make proto-gen

--- a/.github/workflows/proto-gen.yml
+++ b/.github/workflows/proto-gen.yml
@@ -2,7 +2,7 @@ name: Proto Generation
 
 on:
   pull_request:
-    paths: ["**.proto", "**protocgen**"]
+    paths: ["**.proto", "**protocgen-any.sh", "**protocgen.sh"]
 
 jobs:
   proto-gen:

--- a/.github/workflows/skip-proto-gen.yml
+++ b/.github/workflows/skip-proto-gen.yml
@@ -1,17 +1,17 @@
-# skip-unit-tests.yml runs when unit-tests.yml is skipped
-name: Unit Tests
+# skip-proto-gen.yml runs when proto-gen.yml is skipped
+name: Proto Generation
 
 on:
   pull_request:
     # paths-ignore makes the action run when the given paths are unchanged
     # See "Handling skipped but required checks" in
     # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-    paths-ignore: ["**.go", "**.proto", "go.mod", "go.sum"]
-
+    paths-ignore: ["**.proto", "**protocgen**"]
+  
 jobs:
-  unit-tests:
+  proto-gen:
     runs-on: ubuntu-latest
     steps:
-      - name: skip-tests
-        run: |
-          echo "unit-tests.yml skipped since Golang files were not changed."
+    - name: skip-tests
+      run: |
+        echo "proto-gen.yml skipped since proto files were not changed."

--- a/.github/workflows/skip-proto-gen.yml
+++ b/.github/workflows/skip-proto-gen.yml
@@ -6,7 +6,7 @@ on:
     # paths-ignore makes the action run when the given paths are unchanged
     # See "Handling skipped but required checks" in
     # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-    paths-ignore: ["**.proto", "**protocgen**"]
+    paths-ignore: ["**.proto", "**protocgen-any.sh", "**protocgen.sh"]
   
 jobs:
   proto-gen:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+* [#1240](https://github.com/NibiruChain/nibiru/pull/1240) - ci: Test `make proto-gen` when the proto gen scripts or .proto files change
 * [#1199](https://github.com/NibiruChain/nibiru/pull/1199) - chore(deps): bump golang.org/x/net from 0.4.0 to 0.7.0
 * [#1211](https://github.com/NibiruChain/nibiru/pull/1211) - chore(deps): Bump github.com/stretchr/testify from 1.8.1 to 1.8.2
 * [#1203](https://github.com/NibiruChain/nibiru/pull/1203) - ci: make chaosnet pull nibiru image if --build is not specified
@@ -60,7 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-* [#xx](https://github.com/NibiruChain/nibiru/pull/xx) - ci: Fix and test make proto-gen
 * [#1210](https://github.com/NibiruChain/nibiru/pull/1210) - fix(ci): fix docker push workflow
 
 ## [v0.19.2](https://github.com/NibiruChain/nibiru/releases/tag/v0.19.2) - 2023-02-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* [#xx](https://github.com/NibiruChain/nibiru/pull/xx) - ci: Fix and test make proto-gen
 * [#1210](https://github.com/NibiruChain/nibiru/pull/1210) - fix(ci): fix docker push workflow
 
 ## [v0.19.2](https://github.com/NibiruChain/nibiru/releases/tag/v0.19.2) - 2023-02-24

--- a/contrib/scripts/protocgen.sh
+++ b/contrib/scripts/protocgen.sh
@@ -13,7 +13,7 @@ protoc_gen_gocosmos() {
   # get protoc executions
   go get github.com/regen-network/cosmos-proto/protoc-gen-gocosmos@latest 2>/dev/null
 
-  # get cosmos sdk from github
+  # get cosmos sdk
   go get github.com/cosmos/cosmos-sdk@$nibiru_chain_version 2>/dev/null
 }
 


### PR DESCRIPTION
This PR adds a workflow to verify that `make proto-gen`  works whenever the `.proto` files change or the proto generation scripts change.
