### PR TITLE
fix: change init pool share supply exponent from 18 to 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#1210](https://github.com/NibiruChain/nibiru/pull/1210) - fix(ci): fix docker push workflow
 
+### State Machine Breaking
+
+* [#1242](https://github.com/NibiruChain/nibiru/pull/1242) - refactor(spot)!: change pool share exponent from 18 to 6
+
 ## [v0.19.2](https://github.com/NibiruChain/nibiru/releases/tag/v0.19.2) - 2023-02-24
 
 ### Features

--- a/x/spot/keeper/keeper.go
+++ b/x/spot/keeper/keeper.go
@@ -369,7 +369,7 @@ func (k Keeper) NewPool(
 	}
 
 	// Mint the initial 100.000000000000000000 pool share tokens to the sender
-	if err = k.mintPoolShareToAccount(ctx, pool.Id, sender, types.InitPoolSharesSupply); err != nil {
+	if err = k.mintPoolShareToAccount(ctx, pool.Id, sender, sdk.NewInt(types.InitPoolShareSupply)); err != nil {
 		return 0, err
 	}
 

--- a/x/spot/keeper/keeper_test.go
+++ b/x/spot/keeper/keeper_test.go
@@ -286,7 +286,7 @@ func TestNewPool(t *testing.T) {
 			},
 		},
 		TotalWeight: sdk.NewInt(2 << 30),
-		TotalShares: sdk.NewCoin("nibiru/pool/1", sdk.NewIntWithDecimal(100, 18)),
+		TotalShares: sdk.NewCoin("nibiru/pool/1", sdk.NewIntWithDecimal(100, 6)),
 	}, retrievedPool)
 }
 

--- a/x/spot/types/constants.go
+++ b/x/spot/types/constants.go
@@ -10,23 +10,20 @@ const (
 	// maximum number of assets a pool may have
 	MaxPoolAssets = 2
 
-	// the exponent of a pool display share compared to a pool base share (one pool display share = 10^18 pool base shares)
-	DisplayPoolShareExponent = 18
-
 	// Scaling factor for every weight. The pool weight is:
 	// weight_in_MsgCreateBalancerPool * GuaranteedWeightPrecision
 	//
 	// This is done so that smooth weight changes have enough precision to actually be smooth.
 	GuaranteedWeightPrecision int64 = 1 << 30
+
+	// OneDisplayPoolShare represents one display pool share
+	OneDisplayPoolShare = 1e6
+
+	// InitPoolSharesSupply is the amount of new shares to initialize a pool with.
+	InitPoolShareSupply = 100e6
 )
 
 var (
-	// OneDisplayPoolShare represents one display pool share
-	OneDisplayPoolShare sdk.Int = sdk.NewIntWithDecimal(1, DisplayPoolShareExponent)
-
-	// InitPoolSharesSupply is the amount of new shares to initialize a pool with.
-	InitPoolSharesSupply sdk.Int = OneDisplayPoolShare.MulRaw(100)
-
 	// Pool creators can specify a weight in [1, MaxUserSpecifiedWeight)
 	// for every token in the balancer pool.
 	//

--- a/x/spot/types/pool.go
+++ b/x/spot/types/pool.go
@@ -71,7 +71,7 @@ func NewPool(
 		PoolParams:  poolParams,
 		PoolAssets:  nil,
 		TotalWeight: sdk.ZeroInt(),
-		TotalShares: sdk.NewCoin(GetPoolShareBaseDenom(poolId), InitPoolSharesSupply),
+		TotalShares: sdk.NewCoin(GetPoolShareBaseDenom(poolId), sdk.NewInt(InitPoolShareSupply)),
 	}
 
 	err = pool.setInitialPoolAssets(poolAssets)
@@ -120,7 +120,7 @@ func (pool *Pool) AddTokensToPool(tokensIn sdk.Coins) (
 ) {
 	if pool.TotalShares.Amount.IsZero() {
 		// Mint the initial 100.000000000000000000 pool share tokens to the sender
-		numShares = InitPoolSharesSupply
+		numShares = sdk.NewInt(InitPoolShareSupply)
 		remCoins = sdk.Coins{}
 	} else if pool.PoolParams.PoolType == PoolType_STABLESWAP {
 		numShares, err = pool.numSharesOutFromTokensInStableSwap(tokensIn)


### PR DESCRIPTION
# Description

Changes the pool share supply exponent from 18 (atto) to 6 (micro)

# Purpose

If the initial pool share supply is too large, we may get integer overflow when users add a lot of pool liquidity.