### PR TITLE
fix(localnet.sh): force localnet.sh to work even if coingecko is down

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: Test Coverage
 
 on:
   pull_request:
+    paths: ["**.go", "**.proto", "go.mod", "go.sum"]
 
 jobs:
   unit-tests:

--- a/.github/workflows/skip-coverage.yml
+++ b/.github/workflows/skip-coverage.yml
@@ -1,0 +1,17 @@
+# skip-coverage.yml runs when coverage.yml is skipped
+name: Test Coverage
+
+on:
+  pull_request:
+    # paths-ignore makes the action run when the given paths are unchanged
+    # See "Handling skipped but required checks" in
+    # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+    paths-ignore: ["**.go", "**.proto", "go.mod", "go.sum"]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: skip-tests
+        run: |
+          echo "coverage.yml skipped since Golang files were not changed."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+* [#1245](https://github.com/NibiruChain/nibiru/pull/1245) - fix(localnet.sh): force localnet.sh to work even if Coingecko is down
 * [#1230](https://github.com/NibiruChain/nibiru/pull/1230) - chore(deps): Bump github.com/holiman/uint256 from 1.2.1 to 1.2.2
 * [#1240](https://github.com/NibiruChain/nibiru/pull/1240) - ci: Test `make proto-gen` when the proto gen scripts or .proto files change
 * [#1199](https://github.com/NibiruChain/nibiru/pull/1199) - chore(deps): bump golang.org/x/net from 0.4.0 to 0.7.0

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -193,10 +193,16 @@ add_genesis_vpools_with_coingecko_prices() {
 
   price_btc=$(cat tmp_vpool_prices.json | jq -r '.bitcoin.usd')
   price_btc=${price_btc%.*}
+  if [ -z "$price_btc" ]; then
+    return 1
+  fi
   base_amt_btc=$(($quote_amt / $price_btc))
 
   price_eth=$(cat tmp_vpool_prices.json | jq -r '.ethereum.usd')
   price_eth=${price_eth%.*}
+  if [ -z "$price_eth" ]; then
+    return 1
+  fi
   base_amt_eth=$(($quote_amt / $price_eth))
 
   nibid add-genesis-vpool --pair=ubtc:unusd --base-amt=$base_amt_btc --quote-amt=$quote_amt --max-leverage=12


### PR DESCRIPTION
# Purpose

Right now, the Coingecko API request is returning an error code 1020 for "access denied". Since the request technically succeeds but doesn't return the necessary prices in JSON format, the `localnet.sh` halts when dividing numbers to compute the price. 

This PR adds a condition to return out of the Coingecko function in the script if there aren't prices, which makes it default to hard-coded values for the price of BTC and ETH.

#### Change 2  

I noticed that a 7 minute workflow ran for Go tests after adding the `localnet.sh` change. For consistency with the unit and integration test workflows, this PR also adds a path-based condition to the `coverage.yml` workflow so that it only runs when .go or .proto files change. 