### PR TITLE
fix: revert to goleveldb for localnet

### DIFF
--- a/contrib/make/build.mk
+++ b/contrib/make/build.mk
@@ -23,7 +23,7 @@ BUILDDIR ?= $(CURDIR)/build
 export GO111MODULE = on
 
 # process build tags
-build_tags = netgo osusergo rocksdb
+build_tags = netgo osusergo
 build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
@@ -39,7 +39,6 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=nibiru \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 		  -X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)" \
 		  -X github.com/tendermint/tendermint/version.TMCoreSemVer=$(TM_VERSION) \
-		  -X github.com/cosmos/cosmos-sdk/types.DBBackend=rocksdb \
 			-w -s
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -68,9 +68,6 @@ fi
 echo_info "Removing previous chain data from $CHAIN_DIR..."
 rm -rf $CHAIN_DIR
 
-# Rocksdb somehow doesn't create required folder metadata.db
-mkdir -p $HOME/.nibid/data/snapshots/metadata.db
-
 # Add directory for chain, exit if error
 if ! mkdir -p $CHAIN_DIR 2>/dev/null; then
   echo_error "Failed to create chain folder. Aborting..."
@@ -256,4 +253,4 @@ add_genesis_param '.app_state.oracle.exchange_rates[1].exchange_rate = "2000"'
 
 # Start the network
 echo_info "Starting $CHAIN_ID in $CHAIN_DIR..."
-$BINARY start --db_backend rocksdb
+$BINARY start --db_backend goleveldb


### PR DESCRIPTION
# Description

Setting up rocksdb locally requires some extra linking, so we'll revert to local leveldb for now and use rocksdb in our production nodes

# Purpose

Why is this PR important?
