### PR TITLE
ci: test build of nibid on PRs

### DIFF
--- a/.github/workflows/skip-unit-tests.yml
+++ b/.github/workflows/skip-unit-tests.yml
@@ -14,4 +14,12 @@ jobs:
     steps:
       - name: skip-tests
         run: |
-          echo "unit-tests.yml skipped since Golang files were not changed."
+          echo "job: unit-tests was skipped since Golang files were not changed."
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: skip-build
+        run: |
+          echo "job: build was skipped since Golang files were not changed."
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,3 +18,16 @@ jobs:
 
       - name: Run all unit tests.
         run: make test-unit
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+
+    - name: Build the nibid binary 
+      run: make build


### PR DESCRIPTION
# Purpose

This will help ensure that we aren't breaking the build step of `nibid`, which will help make the [docker push workflow](https://github.com/NibiruChain/nibiru/actions/runs/4975049381/jobs/8901858020) more stable.

