### PR TITLE
refactor(oracle): send rewards from perpv2 instead of perpv1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1365](https://github.com/NibiruChain/nibiru/pull/1365) - refactor(perp): split `perp` module into v1/ and v2/
 * [#1366](https://github.com/NibiruChain/nibiru/pull/1366) - feat: fix bindings test in cw_test
 * [#1362](https://github.com/NibiruChain/nibiru/pull/1362) - feat(perp): add `perpv2` cli
+* [#1369](https://github.com/NibiruChain/nibiru/pull/1369) - refactor(oracle): divert rewards from `perpv2` instead of `perpv1`
 
 ### Bug Fixes
 

--- a/x/oracle/keeper/hooks.go
+++ b/x/oracle/keeper/hooks.go
@@ -1,15 +1,12 @@
 package keeper
 
 import (
+	"github.com/NibiruChain/nibiru/x/epochs/types"
+	oracletypes "github.com/NibiruChain/nibiru/x/oracle/types"
+	perptypes "github.com/NibiruChain/nibiru/x/perp/v2/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
-
-	perptypes "github.com/NibiruChain/nibiru/x/perp/v1/types"
-
-	oracletypes "github.com/NibiruChain/nibiru/x/oracle/types"
-
-	"github.com/NibiruChain/nibiru/x/epochs/types"
 )
 
 var _ types.EpochHooks = Hooks{}

--- a/x/oracle/keeper/hooks.go
+++ b/x/oracle/keeper/hooks.go
@@ -1,12 +1,13 @@
 package keeper
 
 import (
-	"github.com/NibiruChain/nibiru/x/epochs/types"
-	oracletypes "github.com/NibiruChain/nibiru/x/oracle/types"
-	perptypes "github.com/NibiruChain/nibiru/x/perp/v2/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+
+	"github.com/NibiruChain/nibiru/x/epochs/types"
+	oracletypes "github.com/NibiruChain/nibiru/x/oracle/types"
+	perptypes "github.com/NibiruChain/nibiru/x/perp/v2/types"
 )
 
 var _ types.EpochHooks = Hooks{}

--- a/x/oracle/keeper/hooks_test.go
+++ b/x/oracle/keeper/hooks_test.go
@@ -3,13 +3,14 @@ package keeper_test
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
 	"github.com/NibiruChain/nibiru/x/common/testutil/testapp"
 	"github.com/NibiruChain/nibiru/x/epochs/types"
 	"github.com/NibiruChain/nibiru/x/oracle/keeper"
 	oracletypes "github.com/NibiruChain/nibiru/x/oracle/types"
 	perptypes "github.com/NibiruChain/nibiru/x/perp/v2/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestHooks_AfterEpochEnd(t *testing.T) {

--- a/x/oracle/keeper/hooks_test.go
+++ b/x/oracle/keeper/hooks_test.go
@@ -3,15 +3,13 @@ package keeper_test
 import (
 	"testing"
 
-	perptypes "github.com/NibiruChain/nibiru/x/perp/v1/types"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/require"
-
 	"github.com/NibiruChain/nibiru/x/common/testutil/testapp"
 	"github.com/NibiruChain/nibiru/x/epochs/types"
 	"github.com/NibiruChain/nibiru/x/oracle/keeper"
 	oracletypes "github.com/NibiruChain/nibiru/x/oracle/types"
+	perptypes "github.com/NibiruChain/nibiru/x/perp/v2/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHooks_AfterEpochEnd(t *testing.T) {


### PR DESCRIPTION
# Description

Diverts rewards from the perpv2 module instead of perpv1 module.

# Purpose

#1310
