### PR TITLE
fix: make localnet

### DIFF
--- a/x/perp/v2/client/cli/cli_test.go
+++ b/x/perp/v2/client/cli/cli_test.go
@@ -444,7 +444,7 @@ func (s *IntegrationTestSuite) TestDonateToEcosystemFund() {
 		testutilcli.ExecQuery(
 			s.network.Validators[0].ClientCtx,
 			bankcli.GetBalancesCmd(),
-			[]string{"nibi1trh2mamq64u4g042zfeevvjk4cukrthvppfnc7", "--denom", "unusd"}, // nibi1trh2mamq64u4g042zfeevvjk4cukrthvppfnc7 is the perp_ef module account address
+			[]string{"nibi1hx8s48gr5f385letde09fwxk9kltyejy77d6e9", "--denom", "unusd"}, // nibi1hx8s48gr5f385letde09fwxk9kltyejy77d6e9 is the v2perp_ef module account address
 			resp,
 		),
 	)

--- a/x/perp/v2/types/keys.go
+++ b/x/perp/v2/types/keys.go
@@ -1,10 +1,10 @@
 package types
 
 const (
-	ModuleName           = "perp"
-	VaultModuleAccount   = "vault"
-	PerpEFModuleAccount  = "perp_ef"
-	FeePoolModuleAccount = "fee_pool"
+	ModuleName           = "v2perp"
+	VaultModuleAccount   = "v2vault"
+	PerpEFModuleAccount  = "v2perp_ef"
+	FeePoolModuleAccount = "v2fee_pool"
 )
 
 var (


### PR DESCRIPTION
# Description

For some reason, the perpv2 module name key cannot start with `perp`, or else the `perpv1` genesis state gets passed into `perpv2`'s `InitGenesis`.

# Purpose

#1310
