### PR TITLE
fix: fix build makefile

### DIFF
--- a/contrib/make/build.mk
+++ b/contrib/make/build.mk
@@ -17,7 +17,7 @@ endif
 
 
 OS_NAME := $(shell uname -s | tr A-Z a-z)
-ifeq ($(shell uname -p),x86_64)
+ifeq ($(shell uname -m),x86_64)
 	ARCH_NAME := amd64
 else
 	ARCH_NAME := arm64


### PR DESCRIPTION
# Description

- Use the `uname -m` for determining computer arch instead of `uname -p`, which does not resolve to `x86_64` ever.

# Purpose

x86_64 machines were not able to build locally because it kept downloading the wrong librocksdb library.
