### PR TITLE
refactor(oracle): update default params

### DIFF
--- a/x/common/testutil/cli/network.go
+++ b/x/common/testutil/cli/network.go
@@ -542,7 +542,7 @@ func (n *Network) LatestHeight() (int64, error) {
 // committed after a given block. If that height is not reached within a timeout,
 // an error is returned. Regardless, the latest height queried is returned.
 func (n *Network) WaitForHeight(h int64) (int64, error) {
-	return n.WaitForHeightWithTimeout(h, 20*time.Second)
+	return n.WaitForHeightWithTimeout(h, 40*time.Second)
 }
 
 // WaitForHeightWithTimeout is the same as WaitForHeight except the caller can

--- a/x/oracle/keeper/slash_test.go
+++ b/x/oracle/keeper/slash_test.go
@@ -46,7 +46,7 @@ func TestSlashAndResetMissCounters(t *testing.T) {
 
 	votePeriodsPerWindow := sdk.NewDec(int64(input.OracleKeeper.SlashWindow(input.Ctx))).QuoInt64(int64(input.OracleKeeper.VotePeriod(input.Ctx))).TruncateInt64()
 	slashFraction := input.OracleKeeper.SlashFraction(input.Ctx)
-	minValidVotes := input.OracleKeeper.MinValidPerWindow(input.Ctx).MulInt64(votePeriodsPerWindow).TruncateInt64()
+	minValidVotes := input.OracleKeeper.MinValidPerWindow(input.Ctx).MulInt64(votePeriodsPerWindow).Ceil().TruncateInt64()
 	// Case 1, no slash
 	input.OracleKeeper.MissCounters.Insert(input.Ctx, ValAddrs[0], uint64(votePeriodsPerWindow-minValidVotes))
 	input.OracleKeeper.SlashAndResetMissCounters(input.Ctx)

--- a/x/oracle/types/params.go
+++ b/x/oracle/types/params.go
@@ -27,13 +27,11 @@ var (
 )
 
 // Default parameter values
-// TODO(mercilex): need to adjust this based on expected genesis parameters, this assumes block times are 1s
-// DefaultVotePeriod: 10s
-// DefaultSlashWindow: 1 Week
+// Assumes block times are 2s
 const (
-	DefaultVotePeriod  = 10     // vote every 10s
-	DefaultSlashWindow = 604800 // 1 week
-	DefaultMinVoters   = 4      // minimum of 4 voters for a pair to become valid
+	DefaultVotePeriod  = 30   // vote every 1 minute
+	DefaultSlashWindow = 3600 // 2 hours
+	DefaultMinVoters   = 4    // minimum of 4 voters for a pair to become valid
 )
 
 // Default parameter values
@@ -68,10 +66,10 @@ var (
 		// asset.Registry.Pair(denoms.SOL, denoms.USD),
 		// asset.Registry.Pair(denoms.ADA, denoms.USD),
 	}
-	DefaultSlashFraction      = sdk.NewDecWithPrec(1, 4)        // 0.01%
-	DefaultMinValidPerWindow  = sdk.NewDecWithPrec(5, 2)        // 5%
+	DefaultSlashFraction      = sdk.NewDecWithPrec(5, 3)        // 0.5%
+	DefaultMinValidPerWindow  = sdk.NewDecWithPrec(69, 2)       // 69%
 	DefaultTwapLookbackWindow = time.Duration(15 * time.Minute) // 15 minutes
-	DefaultValidatorFeeRatio  = sdk.MustNewDecFromStr("0.05")   // 1%
+	DefaultValidatorFeeRatio  = sdk.NewDecWithPrec(5, 2)        // 0.05%
 )
 
 // DefaultParams creates default oracle module parameters

--- a/x/wasm/binding/exec_oracle_test.go
+++ b/x/wasm/binding/exec_oracle_test.go
@@ -132,7 +132,7 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 	// Slash Fraction
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(sdk.NewDecWithPrec(1, 4), params.SlashFraction)
+	s.Require().Equal(sdk.NewDecWithPrec(5, 3), params.SlashFraction)
 
 	slashFraction := sdk.MustNewDecFromStr("0.5")
 	cwMsg = &cw_struct.EditOracleParams{
@@ -149,7 +149,7 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 	// Slash Window
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(uint64(604800), params.SlashWindow)
+	s.Require().Equal(uint64(3600), params.SlashWindow)
 
 	slashWindow := sdk.NewInt(2)
 	cwMsg = &cw_struct.EditOracleParams{
@@ -166,7 +166,7 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 	// Min valid per window
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(sdk.NewDecWithPrec(5, 2), params.MinValidPerWindow)
+	s.Require().Equal(sdk.NewDecWithPrec(69, 2), params.MinValidPerWindow)
 
 	minValidPerWindow := sdk.MustNewDecFromStr("0.5")
 	cwMsg = &cw_struct.EditOracleParams{


### PR DESCRIPTION
# Description

Some of the parameters changed after today's oracle discussion:
- vote period of 30 blocks (~1 minute)
- slash window of 3600 blocks (~2 hours)
- slash fraction 0.5% (50 bps)
- min valid per window 69% (validator must vote in at least 69% of vote periods in a slash window to be safe from penalization)
- updated tests to reflect the changes in default params

# Purpose

Ensure more pricefeeders in the decentralized oracle
