### PR TITLE
fix(oracle): handle zero oracle rewards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1406](https://github.com/NibiruChain/nibiru/pull/1406) - feat(perp): emit additional event info
 * [#1408](https://github.com/NibiruChain/nibiru/pull/1408) - feat(spot): idempotent events
 * [#1420](https://github.com/NibiruChain/nibiru/pull/1420) - refactor(oracle): update default params
+* [#1422](https://github.com/NibiruChain/nibiru/pull/1422) - fix(oracle): handle zero oracle rewards
 
 ### Bug Fixes
 


### PR DESCRIPTION
# Description

- handles the case where oracle rewards are truncated to zeor
- removes panics from oracle's AfterEpoch hook

# Purpose

#1375 
