### PR TITLE
refactor: cleanup unused code

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -70,7 +70,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/upgrade"
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	ibcfee "github.com/cosmos/ibc-go/v7/modules/apps/29-fee"
 	ibcfeekeeper "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/keeper"
 	ibcfeetypes "github.com/cosmos/ibc-go/v7/modules/apps/29-fee/types"
@@ -359,11 +358,6 @@ func NewNibiruApp(
 
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
-
-	app.upgradeKeeper.SetUpgradeHandler("v0.10.0", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		// no-op
-		return fromVM, nil
-	})
 
 	// add test gRPC service for testing gRPC queries in isolation
 	testdata.RegisterQueryServer(app.GRPCQueryRouter(), testdata.QueryImpl{})

--- a/x/perp/v2/keeper/hooks.go
+++ b/x/perp/v2/keeper/hooks.go
@@ -56,10 +56,6 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, _ uint64)
 			PremiumFraction:           premiumFraction,
 			CumulativePremiumFraction: market.LatestCumulativePremiumFraction,
 		})
-
-		_ = ctx.EventManager().EmitTypedEvent(&types.MarketUpdatedEvent{
-			FinalMarket: market,
-		})
 	}
 }
 


### PR DESCRIPTION
# Description

- delete the `v0.10.0` upgrade handler
- delete an extra `MarketUpdatedEvent`

# Purpose


