### PR TITLE
fix(oracle): ignore abstain votes when calculating std dev

### DIFF
--- a/x/oracle/types/ballot.go
+++ b/x/oracle/types/ballot.go
@@ -136,12 +136,17 @@ func (pb ExchangeRateBallots) StandardDeviation(median sdk.Dec) (standardDeviati
 	}()
 
 	sum := sdk.ZeroDec()
+	n := 0
 	for _, v := range pb {
-		deviation := v.ExchangeRate.Sub(median)
-		sum = sum.Add(deviation.Mul(deviation))
+		// ignore abstain votes in std dev calculation
+		if v.ExchangeRate.IsPositive() {
+			deviation := v.ExchangeRate.Sub(median)
+			sum = sum.Add(deviation.Mul(deviation))
+			n += 1
+		}
 	}
 
-	variance := sum.QuoInt64(int64(len(pb)))
+	variance := sum.QuoInt64(int64(n))
 
 	floatNum, _ := strconv.ParseFloat(variance.String(), 64)
 	floatNum = math.Sqrt(floatNum)

--- a/x/oracle/types/ballot_test.go
+++ b/x/oracle/types/ballot_test.go
@@ -267,6 +267,13 @@ func TestPBStandardDeviation(t *testing.T) {
 			[]bool{true, true, true, true},
 			sdk.NewDecWithPrec(0, 0),
 		},
+		{
+			// Abstain votes are ignored
+			[]float64{1.0, 2.0, 10.0, 100000.0, -99999999999.0, 0},
+			[]int64{1, 1, 100, 1, 1, 1},
+			[]bool{true, true, true, true, true, true},
+			sdk.NewDecWithPrec(4999500036300, types.OracleDecPrecision),
+		},
 	}
 
 	base := math.Pow10(types.OracleDecPrecision)


### PR DESCRIPTION
# Description

Disallows large negative price votes (also considered abstain votes) from altering the standard deviation.

# Purpose

An audit issue caught by Zellic, which could let validators to collude on oracle prices. 
