### PR TITLE
fix(root.go): add custom InitCmd that sets the desired Tendermint consensus parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1417](https://github.com/NibiruChain/nibiru/pull/1417) - fix: run end blocker on block end for perp v2
 * [#1425](https://github.com/NibiruChain/nibiru/pull/1425) - fix: remove positions from state when closed with reverse position
 * [#1441](https://github.com/NibiruChain/nibiru/pull/1441) - fix(oracle): ignore abstain votes in std dev calculation
+* [#xxx](/xxx) - fix(cmd): Add custom InitCmd to set set desired Tendermint consensus params for each node.
 
 ## [v0.19.2](https://github.com/NibiruChain/nibiru/releases/tag/v0.19.2) - 2023-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,7 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1417](https://github.com/NibiruChain/nibiru/pull/1417) - fix: run end blocker on block end for perp v2
 * [#1425](https://github.com/NibiruChain/nibiru/pull/1425) - fix: remove positions from state when closed with reverse position
 * [#1441](https://github.com/NibiruChain/nibiru/pull/1441) - fix(oracle): ignore abstain votes in std dev calculation
-* [#xxx](/xxx) - fix(cmd): Add custom InitCmd to set set desired Tendermint consensus params for each node.
+* [#1446](https://github.com/NibiruChain/nibiru/pull/1446) - fix(cmd): Add custom InitCmd to set set desired Tendermint consensus params for each node.
 
 ## [v0.19.2](https://github.com/NibiruChain/nibiru/releases/tag/v0.19.2) - 2023-02-24
 

--- a/cmd/nibid/cmd/init.go
+++ b/cmd/nibid/cmd/init.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 
-	// cfg "github.com/cometbft/cometbft/config"
 	tmcli "github.com/cometbft/cometbft/libs/cli"
 	tmrand "github.com/cometbft/cometbft/libs/rand"
 	tmtypes "github.com/cometbft/cometbft/types"

--- a/cmd/nibid/cmd/init.go
+++ b/cmd/nibid/cmd/init.go
@@ -5,6 +5,28 @@ import (
 
 	db "github.com/cometbft/cometbft-db"
 	tmcfg "github.com/cometbft/cometbft/config"
+
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	// cfg "github.com/cometbft/cometbft/config"
+	tmcli "github.com/cometbft/cometbft/libs/cli"
+	tmrand "github.com/cometbft/cometbft/libs/rand"
+	tmtypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/go-bip39"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/input"
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
 )
 
 const (
@@ -13,24 +35,192 @@ const (
 
 	// FlagSeed defines a flag to initialize the private validator key from a specific seed.
 	FlagRecover = "recover"
+
+	// FlagDefaultBondDenom defines the default denom to use in the genesis file.
+	FlagDefaultBondDenom = "default-denom"
 )
 
 func customTendermintConfig() *tmcfg.Config {
 	cfg := tmcfg.DefaultConfig()
 
+	// Overwrite consensus config
 	ms := func(n time.Duration) time.Duration {
 		return n * time.Millisecond
 	}
-	consensus := cfg.Consensus
-	consensus.TimeoutPropose = ms(3_000)
-	consensus.TimeoutProposeDelta = ms(500)
-	consensus.TimeoutPrevote = ms(1_000)
-	consensus.TimeoutPrevoteDelta = ms(500)
-	consensus.TimeoutPrecommit = ms(1_000)
-	consensus.TimeoutPrecommitDelta = ms(500)
-	consensus.TimeoutCommit = ms(1_000)
+	cfg.Consensus.TimeoutPropose = ms(3_000)
+	cfg.Consensus.TimeoutProposeDelta = ms(500)
+	cfg.Consensus.TimeoutPrevote = ms(1_000)
+	cfg.Consensus.TimeoutPrevoteDelta = ms(500)
+	cfg.Consensus.TimeoutPrecommit = ms(1_000)
+	cfg.Consensus.TimeoutPrecommitDelta = ms(500)
+	cfg.Consensus.TimeoutCommit = ms(1_000)
 
 	cfg.DBBackend = string(db.RocksDBBackend)
-
 	return cfg
+}
+
+/*
+InitCmd is a stand-in replacement for genutilcli.InitCmd that overwrites the
+consensus configutation in the `config.toml` prior to writing it to the disk.
+This helps keep consistency on between nodes without requiring extra work as
+much manual work for node operators.
+
+InitCmd returns a command that initializes all files needed for Tendermint
+and the respective application.
+
+Intended usage:
+
+	```go
+	import  genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
+	import "github.com/spf13/cobra"
+
+	func initRootCmd(rootCmd *cobra.Command, encodingConfig app.EncodingConfig) {
+		a := appCreator{encodingConfig}
+		rootCmd.AddCommand(
+			InitCmd(app.ModuleBasics, app.DefaultNodeHome),
+		)
+	}
+	```
+*/
+func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init [moniker]",
+		Short: "Initialize private validator, p2p, genesis, and application configuration files",
+		Long:  `Initialize validators's and node's configuration files.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			cdc := clientCtx.Codec
+
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			config := serverCtx.Config
+			config.SetRoot(clientCtx.HomeDir)
+
+			chainID, _ := cmd.Flags().GetString(sdkflags.FlagChainID)
+			switch {
+			case chainID != "":
+			case clientCtx.ChainID != "":
+				chainID = clientCtx.ChainID
+			default:
+				chainID = fmt.Sprintf("test-chain-%v", tmrand.Str(6))
+			}
+
+			// Get bip39 mnemonic
+			var mnemonic string
+			recover, _ := cmd.Flags().GetBool(FlagRecover)
+			if recover {
+				inBuf := bufio.NewReader(cmd.InOrStdin())
+				value, err := input.GetString("Enter your bip39 mnemonic", inBuf)
+				if err != nil {
+					return err
+				}
+
+				mnemonic = value
+				if !bip39.IsMnemonicValid(mnemonic) {
+					return errors.New("invalid mnemonic")
+				}
+			}
+
+			// Get initial height
+			initHeight, _ := cmd.Flags().GetInt64(sdkflags.FlagInitHeight)
+			if initHeight < 1 {
+				initHeight = 1
+			}
+
+			nodeID, _, err := genutil.InitializeNodeValidatorFilesFromMnemonic(config, mnemonic)
+			if err != nil {
+				return err
+			}
+
+			config.Moniker = args[0]
+
+			genFile := config.GenesisFile()
+			overwrite, _ := cmd.Flags().GetBool(FlagOverwrite)
+			defaultDenom, _ := cmd.Flags().GetString(FlagDefaultBondDenom)
+
+			// use os.Stat to check if the file exists
+			_, err = os.Stat(genFile)
+			if !overwrite && !os.IsNotExist(err) {
+				return fmt.Errorf("genesis.json file already exists: %v", genFile)
+			}
+
+			// Overwrites the SDK default denom for side-effects
+			if defaultDenom != "" {
+				sdk.DefaultBondDenom = defaultDenom
+			}
+			appGenState := mbm.DefaultGenesis(cdc)
+
+			appState, err := json.MarshalIndent(appGenState, "", " ")
+			if err != nil {
+				return errors.Wrap(err, "Failed to marshal default genesis state")
+			}
+
+			genDoc := &tmtypes.GenesisDoc{}
+			if _, err := os.Stat(genFile); err != nil {
+				if !os.IsNotExist(err) {
+					return err
+				}
+			} else {
+				genDoc, err = tmtypes.GenesisDocFromFile(genFile)
+				if err != nil {
+					return errors.Wrap(err, "Failed to read genesis doc from file")
+				}
+			}
+
+			genDoc.ChainID = chainID
+			genDoc.Validators = nil
+			genDoc.AppState = appState
+			genDoc.InitialHeight = initHeight
+
+			if err = genutil.ExportGenesisFile(genDoc, genFile); err != nil {
+				return errors.Wrap(err, "Failed to export genesis file")
+			}
+
+			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "", appState)
+
+			customCfg := customTendermintConfig()
+			config.Consensus = customCfg.Consensus
+			config.DBBackend = customCfg.DBBackend
+			tmcfg.WriteConfigFile(filepath.Join(config.RootDir, "config", "config.toml"), config)
+			return displayInfo(toPrint)
+		},
+	}
+
+	cmd.Flags().String(tmcli.HomeFlag, defaultNodeHome, "node's home directory")
+	cmd.Flags().BoolP(FlagOverwrite, "o", false, "overwrite the genesis.json file")
+	cmd.Flags().Bool(FlagRecover, false, "provide seed phrase to recover existing key instead of creating")
+	cmd.Flags().String(sdkflags.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
+	cmd.Flags().String(FlagDefaultBondDenom, "", "genesis file default denomination, if left blank default value is 'stake'")
+	cmd.Flags().Int64(sdkflags.FlagInitHeight, 1, "specify the initial block height at genesis")
+
+	return cmd
+}
+
+type printInfo struct {
+	Moniker    string          `json:"moniker" yaml:"moniker"`
+	ChainID    string          `json:"chain_id" yaml:"chain_id"`
+	NodeID     string          `json:"node_id" yaml:"node_id"`
+	GenTxsDir  string          `json:"gentxs_dir" yaml:"gentxs_dir"`
+	AppMessage json.RawMessage `json:"app_message" yaml:"app_message"`
+}
+
+func newPrintInfo(moniker, chainID, nodeID, genTxsDir string, appMessage json.RawMessage) printInfo {
+	return printInfo{
+		Moniker:    moniker,
+		ChainID:    chainID,
+		NodeID:     nodeID,
+		GenTxsDir:  genTxsDir,
+		AppMessage: appMessage,
+	}
+}
+
+func displayInfo(info printInfo) error {
+	out, err := json.MarshalIndent(info, "", " ")
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(os.Stderr, "%s\n", sdk.MustSortJSON(out))
+
+	return err
 }

--- a/cmd/nibid/cmd/root.go
+++ b/cmd/nibid/cmd/root.go
@@ -134,7 +134,7 @@ Args:
 func initRootCmd(rootCmd *cobra.Command, encodingConfig app.EncodingConfig) {
 	a := appCreator{encodingConfig}
 	rootCmd.AddCommand(
-		genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
+		InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		AddGenesisAccountCmd(app.DefaultNodeHome),
 		perpv2cli.AddMarketGenesisCmd(app.DefaultNodeHome),
 		tmcli.NewCompletionCmd(rootCmd, true),


### PR DESCRIPTION
## Video of updated block times

https://github.com/NibiruChain/nibiru/assets/51418232/1153a7b7-8cdb-4ed4-8922-e4435ae8266c

---

## Meant to Address

> "...realized that with the new v47 upgrade ...we're seeing 5 second block times. Was there an update to the config anywhere?"
