### PR TITLE
fix(oracle): continue with abci hook during error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1425](https://github.com/NibiruChain/nibiru/pull/1425) - fix: remove positions from state when closed with reverse position
 * [#1441](https://github.com/NibiruChain/nibiru/pull/1441) - fix(oracle): ignore abstain votes in std dev calculation
 * [#1446](https://github.com/NibiruChain/nibiru/pull/1446) - fix(cmd): Add custom InitCmd to set set desired Tendermint consensus params for each node.
+* [#1452](https://github.com/NibiruChain/nibiru/pull/1452) - fix(oracle): continue with abci hook during error
 
 ## [v0.19.2](https://github.com/NibiruChain/nibiru/releases/tag/v0.19.2) - 2023-02-24
 

--- a/x/inflation/keeper/hooks.go
+++ b/x/inflation/keeper/hooks.go
@@ -65,6 +65,7 @@ func (k Keeper) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumb
 			"SKIPPING INFLATION: failed to mint and allocate inflation",
 			"error", err,
 		)
+		return
 	}
 
 	// If period is passed, update the period. A period is

--- a/x/oracle/keeper/reward.go
+++ b/x/oracle/keeper/reward.go
@@ -67,6 +67,7 @@ func (k Keeper) GatherRewardsForVotePeriod(ctx sdk.Context) sdk.Coins {
 		pairReward, err := k.Rewards.Get(ctx, rewardId)
 		if err != nil {
 			k.Logger(ctx).Error("Failed to get reward", "err", err)
+			continue
 		}
 		coins = coins.Add(pairReward.Coins...)
 

--- a/x/oracle/keeper/slash.go
+++ b/x/oracle/keeper/slash.go
@@ -36,6 +36,7 @@ func (k Keeper) SlashAndResetMissCounters(ctx sdk.Context) {
 				consAddr, err := validator.GetConsAddr()
 				if err != nil {
 					k.Logger(ctx).Error("fail to get consensus address", "validator", validator.GetOperator().String())
+					continue
 				}
 
 				k.StakingKeeper.Slash(


### PR DESCRIPTION
# Description

- continue with processing the oracle abci hook even in the presence of partial errors

# Purpose

Auditors found an issue where objects could be nil because we continue with the code flow even in the presence of partial errors.
