### PR TITLE
feat: add connect-es plugin

### DIFF
--- a/proto/buf.gen.ts.yaml
+++ b/proto/buf.gen.ts.yaml
@@ -3,6 +3,9 @@ version: v1
 managed:
   enabled: true
 plugins:
+  - plugin: buf.build/bufbuild/connect-es:v0.10.1
+    opt: target=ts
+    out: .
   - plugin: buf.build/bufbuild/es:v1.2.1
     opt: target=ts
     out: .


### PR DESCRIPTION
# Description

- adds the connect-es plugin to the Buf config

# Purpose

`connect-es` generates TypeScript gRPC code, which was missing from just the `es` plugin
