### PR TITLE
feat(oracle): add genesis cmd to create pricefeeder delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+* [#1463](https://github.com/NibiruChain/nibiru/pull/1463) - feat(oracle): add genesis pricefeeder delegation
+
 ### Bug Fixes
 
 * [#1459](https://github.com/NibiruChain/nibiru/pull/1459) - fix(spot): wire `x/spot` msgService into app router

--- a/cmd/nibid/cmd/root.go
+++ b/cmd/nibid/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/NibiruChain/nibiru/app"
+	oraclecli "github.com/NibiruChain/nibiru/x/oracle/client/cli"
 	perpv2cli "github.com/NibiruChain/nibiru/x/perp/v2/client/cli"
 )
 
@@ -136,7 +137,6 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig app.EncodingConfig) {
 	rootCmd.AddCommand(
 		InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		AddGenesisAccountCmd(app.DefaultNodeHome),
-		perpv2cli.AddMarketGenesisCmd(app.DefaultNodeHome),
 		tmcli.NewCompletionCmd(rootCmd, true),
 		testnetCmd(app.ModuleBasics, banktypes.GenesisBalancesIterator{}),
 		debug.Cmd(),
@@ -149,7 +149,11 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig app.EncodingConfig) {
 	// add keybase, auxiliary RPC, query, and tx child commands
 	rootCmd.AddCommand(
 		rpc.StatusCommand(),
-		genesisCommand(encodingConfig),
+		genesisCommand(
+			encodingConfig,
+			oraclecli.AddGenesisPricefeederDelegationCmd(app.DefaultNodeHome),
+			perpv2cli.AddMarketGenesisCmd(app.DefaultNodeHome),
+		),
 		queryCommand(),
 		txCommand(),
 		keys.Commands(app.DefaultNodeHome),

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -205,8 +205,8 @@ add_genesis_perp_markets_with_coingecko_prices() {
     fi 
   }
 
-  nibid add-genesis-perp-market --pair=ubtc:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_btc
-  check_fail nibid add-genesis-perp-market
+  nibid genesis add-genesis-perp-market --pair=ubtc:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_btc
+  check_fail nibid genesis add-genesis-perp-market
 
   price_eth=$(cat tmp_market_prices.json | jq -r '.ethereum.usd')
   price_eth=${price_eth%.*}
@@ -214,8 +214,8 @@ add_genesis_perp_markets_with_coingecko_prices() {
     return 1
   fi
 
-  nibid add-genesis-perp-market --pair=ueth:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_eth
-  check_fail nibid add-genesis-perp-market
+  nibid genesis add-genesis-perp-market --pair=ueth:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_eth
+  check_fail nibid genesis add-genesis-perp-market
 
   echo 'tmp_market_prices: '
   cat $temp_json_fname | jq .

--- a/x/oracle/client/cli/gen_pricefeeder_delegation.go
+++ b/x/oracle/client/cli/gen_pricefeeder_delegation.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/spf13/cobra"
+
+	"github.com/NibiruChain/nibiru/x/oracle/types"
+)
+
+const (
+	FlagValidator   = "validator"
+	FlagPricefeeder = "pricefeeder"
+)
+
+func AddGenesisPricefeederDelegationCmd(defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add-genesis-pricefeeder-delegation",
+		Short: "Add a pricefeeder delegation to genesis.json.",
+		Long:  `Add a pricefeeder delegation to genesis.json.`,
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			serverCtx := server.GetServerContextFromCmd(cmd)
+			config := serverCtx.Config
+			config.SetRoot(clientCtx.HomeDir)
+			genFile := config.GenesisFile()
+
+			genState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
+			if err != nil {
+				return err
+			}
+
+			valAddr, err := cmd.Flags().GetString(FlagValidator)
+			if err != nil {
+				return err
+			}
+
+			_, err = sdk.ValAddressFromBech32(valAddr)
+			if err != nil {
+				return err
+			}
+
+			pricefeederAddr, err := cmd.Flags().GetString(FlagPricefeeder)
+			if err != nil {
+				return err
+			}
+
+			_, err = sdk.AccAddressFromBech32(pricefeederAddr)
+			if err != nil {
+				return err
+			}
+
+			oracleGenState := types.GetGenesisStateFromAppState(clientCtx.Codec, genState)
+			oracleGenState.FeederDelegations = append(oracleGenState.FeederDelegations, types.FeederDelegation{
+				FeederAddress:    pricefeederAddr,
+				ValidatorAddress: valAddr,
+			})
+
+			oracleGenStateBz, err := clientCtx.Codec.MarshalJSON(oracleGenState)
+			if err != nil {
+				return fmt.Errorf("failed to marshal market genesis state: %w", err)
+			}
+
+			genState[types.ModuleName] = oracleGenStateBz
+
+			appStateJSON, err := json.Marshal(genState)
+			if err != nil {
+				return fmt.Errorf("failed to marshal application genesis state: %w", err)
+			}
+
+			genDoc.AppState = appStateJSON
+			return genutil.ExportGenesisFile(genDoc, genFile)
+		},
+	}
+
+	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+
+	flagSet := flag.NewFlagSet("flags-add-genesis-pricefeeder-delegation", flag.ContinueOnError)
+
+	flagSet.String(FlagValidator, "", "validator address")
+	_ = cmd.MarkFlagRequired(FlagValidator)
+
+	flagSet.String(FlagPricefeeder, "", "pricefeeder address")
+	_ = cmd.MarkFlagRequired(FlagPricefeeder)
+
+	cmd.Flags().AddFlagSet(flagSet)
+
+	return cmd
+}

--- a/x/oracle/client/cli/gen_pricefeeder_delegation_test.go
+++ b/x/oracle/client/cli/gen_pricefeeder_delegation_test.go
@@ -1,0 +1,102 @@
+package cli_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/NibiruChain/nibiru/app"
+	"github.com/NibiruChain/nibiru/x/oracle/client/cli"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+
+	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutiltest "github.com/cosmos/cosmos-sdk/x/genutil/client/testutil"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests "add-genesis-perp-market", a command that adds a market to genesis.json
+func TestAddGenesisPricefeederDelegation(t *testing.T) {
+	app.SetPrefixes(app.AccountAddressPrefix)
+
+	tests := []struct {
+		name        string
+		validator   string
+		pricefeeder string
+
+		expectErr bool
+	}{
+		{
+			name:        "valid",
+			validator:   "nibivaloper1zaavvzxez0elundtn32qnk9lkm8kmcszuwx9jz",
+			pricefeeder: "nibi1zaavvzxez0elundtn32qnk9lkm8kmcsz44g7xl",
+			expectErr:   false,
+		},
+		{
+			name:        "invalid pricefeeder",
+			validator:   "nibivaloper1zaavvzxez0elundtn32qnk9lkm8kmcszuwx9jz",
+			pricefeeder: "nibi1foobar",
+			expectErr:   true,
+		},
+		{
+			name:        "empty pricefeeder",
+			validator:   "nibivaloper1zaavvzxez0elundtn32qnk9lkm8kmcszuwx9jz",
+			pricefeeder: "",
+			expectErr:   true,
+		},
+		{
+			name:        "invalid validator",
+			validator:   "nibivaloper1foobar",
+			pricefeeder: "nibi1zaavvzxez0elundtn32qnk9lkm8kmcsz44g7xl",
+			expectErr:   true,
+		},
+		{
+			name:        "empty validator",
+			validator:   "",
+			pricefeeder: "nibi1zaavvzxez0elundtn32qnk9lkm8kmcsz44g7xl",
+			expectErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			logger := log.NewNopLogger()
+
+			home := t.TempDir()
+			cfg, err := genutiltest.CreateDefaultTendermintConfig(home)
+			require.NoError(t, err)
+
+			testModuleBasicManager := module.NewBasicManager(genutil.AppModuleBasic{})
+			appCodec := moduletestutil.MakeTestEncodingConfig().Codec
+			err = genutiltest.ExecInitCmd(testModuleBasicManager, home, appCodec)
+			require.NoError(t, err)
+
+			serverCtx := server.NewContext(viper.New(), cfg, logger)
+			clientCtx := client.Context{}.WithCodec(appCodec).WithHomeDir(home)
+
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, client.ClientContextKey, &clientCtx)
+			ctx = context.WithValue(ctx, server.ServerContextKey, serverCtx)
+
+			cmd := cli.AddGenesisPricefeederDelegationCmd(home)
+			cmd.SetArgs([]string{
+				fmt.Sprintf("--%s=%s", cli.FlagValidator, tc.validator),
+				fmt.Sprintf("--%s=%s", cli.FlagPricefeeder, tc.pricefeeder),
+				fmt.Sprintf("--%s=home", flags.FlagHome),
+			})
+
+			if tc.expectErr {
+				require.Error(t, cmd.ExecuteContext(ctx))
+			} else {
+				require.NoError(t, cmd.ExecuteContext(ctx))
+			}
+		})
+	}
+}

--- a/x/oracle/client/cli/gen_pricefeeder_delegation_test.go
+++ b/x/oracle/client/cli/gen_pricefeeder_delegation_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+
 	"github.com/NibiruChain/nibiru/app"
 	"github.com/NibiruChain/nibiru/x/oracle/client/cli"
-	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -66,7 +67,6 @@ func TestAddGenesisPricefeederDelegation(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
 			logger := log.NewNopLogger()
 
 			home := t.TempDir()


### PR DESCRIPTION
# Description

- creates a genesis cmd `add-genesis-pricefeeder-delegation` which allows adding pricefeeder delegations to the genesis state
- moves the `add-genesis-perp-market` cmd under the `genesis` sub-command

# Purpose

It makes setting up a devnet/testnet much easier.
