### PR TITLE
fix(gov): legacy proposals were not wired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * [#1459](https://github.com/NibiruChain/nibiru/pull/1459) - fix(spot): wire `x/spot` msgService into app router
+* [#1464](https://github.com/NibiruChain/nibiru/pull/1464) - fix(gov): wire legacy proposal handlers
 
 ### Dependencies
 

--- a/app/keepers.go
+++ b/app/keepers.go
@@ -638,8 +638,6 @@ func (app *NibiruApp) InitModuleManager(
 
 	// see https://github.com/cosmos/cosmos-sdk/blob/666c345ad23ddda9523cc5cd1b71187d91c26f34/simapp/upgrades.go#L35-L57
 	for _, subspace := range app.paramsKeeper.GetSubspaces() {
-		subspace := subspace
-
 		switch subspace.Name() {
 		case authtypes.ModuleName:
 			subspace.WithKeyTable(authtypes.ParamKeyTable()) //nolint:staticcheck

--- a/app/keepers.go
+++ b/app/keepers.go
@@ -636,24 +636,25 @@ func (app *NibiruApp) InitModuleManager(
 		app.appCodec, app.MsgServiceRouter(), app.GRPCQueryRouter())
 	app.mm.RegisterServices(app.configurator)
 
+	// see https://github.com/cosmos/cosmos-sdk/blob/666c345ad23ddda9523cc5cd1b71187d91c26f34/simapp/upgrades.go#L35-L57
 	for _, subspace := range app.paramsKeeper.GetSubspaces() {
 		subspace := subspace
 
 		switch subspace.Name() {
 		case authtypes.ModuleName:
-			subspace.WithKeyTable(authtypes.ParamKeyTable())
+			subspace.WithKeyTable(authtypes.ParamKeyTable()) //nolint:staticcheck
 		case banktypes.ModuleName:
-			subspace.WithKeyTable(banktypes.ParamKeyTable())
+			subspace.WithKeyTable(banktypes.ParamKeyTable()) //nolint:staticcheck
 		case stakingtypes.ModuleName:
-			subspace.WithKeyTable(stakingtypes.ParamKeyTable())
+			subspace.WithKeyTable(stakingtypes.ParamKeyTable()) //nolint:staticcheck
 		case distrtypes.ModuleName:
-			subspace.WithKeyTable(distrtypes.ParamKeyTable())
+			subspace.WithKeyTable(distrtypes.ParamKeyTable()) //nolint:staticcheck
 		case slashingtypes.ModuleName:
-			subspace.WithKeyTable(slashingtypes.ParamKeyTable())
+			subspace.WithKeyTable(slashingtypes.ParamKeyTable()) //nolint:staticcheck
 		case govtypes.ModuleName:
-			subspace.WithKeyTable(govv1types.ParamKeyTable())
+			subspace.WithKeyTable(govv1types.ParamKeyTable()) //nolint:staticcheck
 		case crisistypes.ModuleName:
-			subspace.WithKeyTable(crisistypes.ParamKeyTable())
+			subspace.WithKeyTable(crisistypes.ParamKeyTable()) //nolint:staticcheck
 		}
 	}
 }


### PR DESCRIPTION
# Description

- wire legacy proposal handlers to the `gov` keeper
- initialize param key tables so that legacy gov proposals can modify params

# Purpose

Without this PR, legacy governance proposals cannot update module params.

# Error Stack Trace

The below is an example of what happens when trying to change the `MaxValidators` param of the `x/staking` module on the current nibid version (localnet).

```json
{
	"height": "4",
	"txhash": "45E00592BBAB2840F271D9A6AF1EB57C816F76C2C84F59405DF7AC90C5040E66",
	"codespace": "undefined",
	"code": 111222,
	"data": "",
	"raw_log": "recovered: runtime error: invalid memory address or nil pointer dereference\nstack:\ngoroutine 30 [running]:\nruntime/debug.Stack()\n\t/opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/debug/stack.go:24 +0x64\ngithub.com/cosmos/cosmos-sdk/baseapp.newDefaultRecoveryMiddleware.func1({0x105e22380, 0x1077becf0})\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/recovery.go:71 +0x24\ngithub.com/cosmos/cosmos-sdk/baseapp.newRecoveryMiddleware.func1({0x105e22380?, 0x1077becf0?})\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/recovery.go:39 +0x34\ngithub.com/cosmos/cosmos-sdk/baseapp.processRecovery({0x105e22380, 0x1077becf0}, 0x1400017e090?)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/recovery.go:28 +0x38\ngithub.com/cosmos/cosmos-sdk/baseapp.processRecovery({0x105e22380, 0x1077becf0}, 0x106218aa0?)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/recovery.go:33 +0x60\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx.func1()\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/baseapp.go:641 +0xa8\npanic({0x105e22380, 0x1077becf0})\n\t/opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/panic.go:890 +0x258\ngithub.com/cosmos/cosmos-sdk/x/gov/keeper.msgServer.ExecLegacyContent({0x105f14380?}, {0x1062043e8?, 0x14004defcb0?}, 0x14004cf2f30)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/x/gov/keeper/msg_server.go:101 +0x210\ngithub.com/cosmos/cosmos-sdk/x/gov/types/v1._Msg_ExecLegacyContent_Handler.func1({0x1062043e8, 0x14004defcb0}, {0x1061243e0?, 0x14004cf2f30})\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/x/gov/types/v1/tx.pb.go:939 +0x74\ngithub.com/cosmos/cosmos-sdk/baseapp.(*MsgServiceRouter).RegisterService.func2.1({0x106205d10, 0x14004cd18c0}, {0x14004dd6a98?, 0x103524b24?}, 0x1061b6640?, 0x14004cf2fd8)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/msg_service_router.go:118 +0x98\ngithub.com/cosmos/cosmos-sdk/x/gov/types/v1._Msg_ExecLegacyContent_Handler({0x1061a9680?, 0x14001b980a8}, {0x106205d10, 0x14004cd18c0}, 0x1061cc238, 0x140015d27c0)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/x/gov/types/v1/tx.pb.go:941 +0x138\ngithub.com/cosmos/cosmos-sdk/baseapp.(*MsgServiceRouter).RegisterService.func2({{0x1062043e8, 0x140015d56b0}, {0x106218aa0, 0x140015c6fc0}, {{0xb, 0x0}, {0x140014f7a28, 0x11}, 0x4, {0x3b6df188, ...}, ...}, ...}, ...)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/msg_service_router.go:139 +0x2e4\ngithub.com/cosmos/cosmos-sdk/x/gov/keeper.Keeper.SubmitProposal({{0x106205e60, 0x140000650e0}, {0x1303805e8, 0x14000db0210}, {0x1061f72f0, 0x140015e2ea0}, {0x10620a5c0, 0x107851f20}, {0x1061e3938, 0x14001ba4500}, ...}, ...)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/x/gov/keeper/proposal.go:69 +0x46c\ngithub.com/cosmos/cosmos-sdk/x/gov/keeper.msgServer.SubmitProposal({0x14004dd9a08?}, {0x1062043e8?, 0x14004deeab0?}, 0x14004de8d90)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/x/gov/keeper/msg_server.go:50 +0x21c\ngithub.com/cosmos/cosmos-sdk/x/gov/keeper.legacyMsgServer.SubmitProposal({{0x140001acb70?, 0x102b71610?}, {0x10620bc50?, 0x14001b980a8?}}, {0x1062043e8, 0x14004deeab0}, 0x140015d4540)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/x/gov/keeper/msg_server.go:236 +0x1bc\ngithub.com/cosmos/cosmos-sdk/x/gov/types/v1beta1._Msg_SubmitProposal_Handler.func1({0x1062043e8, 0x14004deeab0}, {0x106167460?, 0x140015d4540})\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/x/gov/types/v1beta1/tx.pb.go:547 +0x74\ngithub.com/cosmos/cosmos-sdk/baseapp.(*MsgServiceRouter).RegisterService.func2.1({0x106205d10, 0x14004cd0b00}, {0x14004dd9b68?, 0x103524b24?}, 0x1061b6640?, 0x14004cf2f18)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/msg_service_router.go:118 +0x98\ngithub.com/cosmos/cosmos-sdk/x/gov/types/v1beta1._Msg_SubmitProposal_Handler({0x105ee23e0?, 0x14001b83080}, {0x106205d10, 0x14004cd0b00}, 0x1061cc238, 0x140015d2660)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/x/gov/types/v1beta1/tx.pb.go:549 +0x138\ngithub.com/cosmos/cosmos-sdk/baseapp.(*MsgServiceRouter).RegisterService.func2({{0x1062043e8, 0x140015d56b0}, {0x106218aa0, 0x140015c6f80}, {{0xb, 0x0}, {0x140014f7a28, 0x11}, 0x4, {0x3b6df188, ...}, ...}, ...}, ...)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/msg_service_router.go:139 +0x2e4\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runMsgs(_, {{0x1062043e8, 0x140015d56b0}, {0x106218aa0, 0x140015c6f80}, {{0xb, 0x0}, {0x140014f7a28, 0x11}, 0x4, ...}, ...}, ...)\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/baseapp.go:800 +0x1ac\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).runTx(0x140013485a0, 0x3, {0x14004b065a0, 0x1d4, 0x1d4})\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/baseapp.go:743 +0xa68\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).DeliverTx(0x140013485a0, {{0x14004b065a0?, 0x1028b75f0?, 0x14004dde0c8?}})\n\t/Users/kevinyang/go/pkg/mod/github.com/cosmos/cosmos-sdk@v0.47.3/baseapp/abci.go:409 +0xf0\ngithub.com/cometbft/cometbft/abci/client.(*localClient).DeliverTxAsync(0x1400150aae0, {{0x14004b065a0?, 0x0?, 0x0?}})\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/abci/client/local_client.go:82 +0xf0\ngithub.com/cometbft/cometbft/proxy.(*appConnConsensus).DeliverTxAsync(0x1400040ed38, {{0x14004b065a0?, 0x20?, 0xb?}})\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/proxy/app_conn.go:106 +0xf0\ngithub.com/cometbft/cometbft/state.execBlockOnProxyApp({0x106205cd8?, 0x14001132370}, {0x106215480, 0x1400040ed38}, 0x14004cb23c0, {0x1062196d0, 0x1400000e438}, 0x3?)\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/state/execution.go:376 +0x540\ngithub.com/cometbft/cometbft/state.(*BlockExecutor).ApplyBlock(_, {{{0xb, 0x0}, {0x140013ccdd8, 0x6}}, {0x14000ce1530, 0x11}, 0x1, 0x3, {{0x1400446ec20, ...}, ...}, ...}, ...)\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/state/execution.go:197 +0xe4\ngithub.com/cometbft/cometbft/consensus.(*State).finalizeCommit(0x14001068380, 0x4)\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/consensus/state.go:1700 +0x964\ngithub.com/cometbft/cometbft/consensus.(*State).tryFinalizeCommit(0x14001068380, 0x4)\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/consensus/state.go:1609 +0x28c\ngithub.com/cometbft/cometbft/consensus.(*State).enterCommit.func1()\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/consensus/state.go:1544 +0xa0\ngithub.com/cometbft/cometbft/consensus.(*State).enterCommit(0x14001068380, 0x4, 0x0)\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/consensus/state.go:1582 +0xb90\ngithub.com/cometbft/cometbft/consensus.(*State).addVote(0x14001068380, 0x14004b66460, {0x0, 0x0})\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/consensus/state.go:2212 +0x1790\ngithub.com/cometbft/cometbft/consensus.(*State).tryAddVote(0x14001068380, 0x14004b66460, {0x0?, 0x1028f81f0?})\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/consensus/state.go:2001 +0x28\ngithub.com/cometbft/cometbft/consensus.(*State).handleMsg(0x14001068380, {{0x1061da5e0, 0x140007a4958}, {0x0, 0x0}})\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/consensus/state.go:861 +0x37c\ngithub.com/cometbft/cometbft/consensus.(*State).receiveRoutine(0x14001068380, 0x0)\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/consensus/state.go:788 +0x350\ncreated by github.com/cometbft/cometbft/consensus.(*State).OnStart\n\t/Users/kevinyang/go/pkg/mod/github.com/cometbft/cometbft@v0.37.2/consensus/state.go:379 +0xf4\n: panic",
	"logs": [],
	"info": "",
	"gas_wanted": "200000",
	"gas_used": "34477",
	"tx": {
		"@type": "/cosmos.tx.v1beta1.Tx",
		"body": {
			"messages": [{
				"@type": "/cosmos.gov.v1beta1.MsgSubmitProposal",
				"content": {
					"@type": "/cosmos.params.v1beta1.ParameterChangeProposal",
					"title": "Increase Max Validators to 200",
					"description": "Submit param change in x/staking to increase the size of the active validator set",
					"changes": [{
						"subspace": "staking",
						"key": "MaxValidators",
						"value": "200"
					}]
				},
				"initial_deposit": [{
					"denom": "unibi",
					"amount": "10000000"
				}],
				"proposer": "nibi1zaavvzxez0elundtn32qnk9lkm8kmcsz44g7xl"
			}],
			"memo": "",
			"timeout_height": "0",
			"extension_options": [],
			"non_critical_extension_options": []
		},
		"auth_info": {
			"signer_infos": [{
				"public_key": {
					"@type": "/cosmos.crypto.secp256k1.PubKey",
					"key": "AvzwBOriY8sVwEXrXf1gXanhT9imlfWeUWLQ8pMxrRsg"
				},
				"mode_info": {
					"single": {
						"mode": "SIGN_MODE_DIRECT"
					}
				},
				"sequence": "1"
			}],
			"fee": {
				"amount": [],
				"gas_limit": "200000",
				"payer": "",
				"granter": ""
			},
			"tip": null
		},
		"signatures": ["C133JMKhLKLOXgB9bxAldnHlKU6bCV4KcpHhnf+FMbwVoXnjsPVayF3DihymbH9SqrBAEVBdOfKRp/naCQh2CQ=="]
	},
	"timestamp": "2023-06-29T20:30:19Z",
	"events": [{
		"type": "tx",
		"attributes": [{
			"key": "fee",
			"value": "",
			"index": true
		}, {
			"key": "fee_payer",
			"value": "nibi1zaavvzxez0elundtn32qnk9lkm8kmcsz44g7xl",
			"index": true
		}]
	}, {
		"type": "tx",
		"attributes": [{
			"key": "acc_seq",
			"value": "nibi1zaavvzxez0elundtn32qnk9lkm8kmcsz44g7xl/1",
			"index": true
		}]
	}, {
		"type": "tx",
		"attributes": [{
			"key": "signature",
			"value": "C133JMKhLKLOXgB9bxAldnHlKU6bCV4KcpHhnf+FMbwVoXnjsPVayF3DihymbH9SqrBAEVBdOfKRp/naCQh2CQ==",
			"index": true
		}]
	}]
}
```
