### PR TITLE
fix(proto): update ts proto gen config

### DIFF
--- a/proto/buf.gen.ts.yaml
+++ b/proto/buf.gen.ts.yaml
@@ -1,8 +1,8 @@
-# buf.gen.yaml
+# buf.gen.ts.yaml
 version: v1
 managed:
   enabled: true
 plugins:
   - plugin: buf.build/community/stephenh-ts-proto:v1.150.1
-    opt: esModuleInterop=true,forceLong=long,useOptionals=messages,outputTypeRegistry=true
+    opt: esModuleInterop=true,forceLong=long,useOptionals=messages
     out: .

--- a/proto/buf.gen.ts.yaml
+++ b/proto/buf.gen.ts.yaml
@@ -3,9 +3,6 @@ version: v1
 managed:
   enabled: true
 plugins:
-  - plugin: buf.build/bufbuild/connect-es:v0.10.1
-    opt: target=ts
-    out: .
-  - plugin: buf.build/bufbuild/es:v1.2.1
-    opt: target=ts
+  - plugin: buf.build/community/stephenh-ts-proto:v1.150.1
+    opt: esModuleInterop=true,forceLong=long,useOptionals=messages,outputTypeRegistry=true
     out: .


### PR DESCRIPTION
# Description

- revert to ts-proto plugin

# Purpose

ts-proto is the only TypeScript proto-gen plugin that is compatible with CosmJS.
