### PR TITLE
fix(perp): event field assertion tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-go/v7 v7.2.0
-	github.com/gogo/protobuf v1.3.3
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3
 	github.com/google/gofuzz v1.2.0
@@ -89,6 +88,7 @@ require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
+	github.com/gogo/protobuf v1.3.3 // indirect
 	github.com/golang/glog v1.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/x/oracle/simulation/decoder.go
+++ b/x/oracle/simulation/decoder.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
-	gogotypes "github.com/gogo/protobuf/types"
+	gogotypes "github.com/cosmos/gogoproto/types"
 
 	"github.com/NibiruChain/collections"
 

--- a/x/oracle/simulation/decoder_test.go
+++ b/x/oracle/simulation/decoder_test.go
@@ -6,18 +6,14 @@ import (
 
 	"github.com/NibiruChain/nibiru/x/common/asset"
 	"github.com/NibiruChain/nibiru/x/common/denoms"
-
-	gogotypes "github.com/gogo/protobuf/types"
-	"github.com/stretchr/testify/require"
-
-	"github.com/cometbft/cometbft/crypto/ed25519"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/kv"
-
 	"github.com/NibiruChain/nibiru/x/oracle/keeper"
 	sim "github.com/NibiruChain/nibiru/x/oracle/simulation"
 	"github.com/NibiruChain/nibiru/x/oracle/types"
+	"github.com/cometbft/cometbft/crypto/ed25519"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/kv"
+	gogotypes "github.com/cosmos/gogoproto/types"
+	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/x/oracle/simulation/decoder_test.go
+++ b/x/oracle/simulation/decoder_test.go
@@ -4,16 +4,17 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/NibiruChain/nibiru/x/common/asset"
-	"github.com/NibiruChain/nibiru/x/common/denoms"
-	"github.com/NibiruChain/nibiru/x/oracle/keeper"
-	sim "github.com/NibiruChain/nibiru/x/oracle/simulation"
-	"github.com/NibiruChain/nibiru/x/oracle/types"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 	gogotypes "github.com/cosmos/gogoproto/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/NibiruChain/nibiru/x/common/asset"
+	"github.com/NibiruChain/nibiru/x/common/denoms"
+	"github.com/NibiruChain/nibiru/x/oracle/keeper"
+	sim "github.com/NibiruChain/nibiru/x/oracle/simulation"
+	"github.com/NibiruChain/nibiru/x/oracle/types"
 )
 
 var (

--- a/x/perp/v2/integration/assertion/event.go
+++ b/x/perp/v2/integration/assertion/event.go
@@ -7,7 +7,7 @@ import (
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cosmos/gogoproto/proto"
 
 	"github.com/NibiruChain/nibiru/app"
 	"github.com/NibiruChain/nibiru/x/common/testutil"

--- a/x/spot/keeper/grpc_query.go
+++ b/x/spot/keeper/grpc_query.go
@@ -8,7 +8,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	gogotypes "github.com/gogo/protobuf/types"
+	gogotypes "github.com/cosmos/gogoproto/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/x/spot/keeper/keeper.go
+++ b/x/spot/keeper/keeper.go
@@ -14,7 +14,7 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	gogotypes "github.com/gogo/protobuf/types"
+	gogotypes "github.com/cosmos/gogoproto/types"
 
 	"github.com/NibiruChain/nibiru/x/spot/types"
 )

--- a/x/stablecoin/client/cli/cli_test.go
+++ b/x/stablecoin/client/cli/cli_test.go
@@ -11,7 +11,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/NibiruChain/nibiru/app"

--- a/x/sudo/cli/cli_test.go
+++ b/x/sudo/cli/cli_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gogo/protobuf/jsonpb"
+	"github.com/cosmos/gogoproto/jsonpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"


### PR DESCRIPTION
# Description

This PR fixes the event field assertion logic in tests. 

We were using the `gogo/protobuf` type registry for checking `MessageName()`, which always returned an empty string since the `gogo/protobuf` module is no longer used in the SDK. That meant that https://github.com/NibiruChain/nibiru/blob/master/x/perp/v2/integration/assertion/event.go#L157 never succeeded and we were skipping event field assertions.

After fixing the check, I noticed that certain event fields weren't in the proper format (e.g. `badDebt` and `transactionFee` came in JSON format from `EventAttributes`, but we were wanting the `String()` representation), so I fixed those fields too.

There's also some code cleanup in this PR. I thought about why we needed an interface for the `eventEquals` struct but couldn't think of any reason, so I removed it and used plain functions for simplicity.

# Purpose

Ensures proper testing of event fields.
