### PR TITLE
fix(wasm)!: call `ValidateBasic` before all `sdk.Msg` calls for the bindings-perp contract + remove sudo permissioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### State Machine Breaking
 
+* [#xxx](https://github.com/NibiruChain/nibiru/pull/xxx) - fix(wasm)!: call `ValidateBasic` before all `sdk.Msg` calls for the bindings-perp contract + remove sudo permissioning
 * [#1154](https://github.com/NibiruChain/nibiru/pull/1154) - refactor(asset-pair)!: refactors `common.AssetPair` as an extension of string
 * [#1156](https://github.com/NibiruChain/nibiru/pull/1156) - refactor: remove lockup & incentivation module
 

--- a/x/wasm/binding/exec.go
+++ b/x/wasm/binding/exec.go
@@ -55,32 +55,20 @@ func (messenger *CustomWasmExecutor) DispatchMsg(
 		}
 
 		switch {
-		// Perp module
+		// Perp module | bindings-perp: for trading with smart contracts
 		case contractExecuteMsg.ExecuteMsg.MarketOrder != nil:
-			if err := messenger.Sudo.CheckPermissions(contractAddr, ctx); err != nil {
-				return events, data, err
-			}
 			cwMsg := contractExecuteMsg.ExecuteMsg.MarketOrder
 			_, err = messenger.Perp.MarketOrder(cwMsg, contractAddr, ctx)
 			return events, data, err
 		case contractExecuteMsg.ExecuteMsg.ClosePosition != nil:
-			if err := messenger.Sudo.CheckPermissions(contractAddr, ctx); err != nil {
-				return events, data, err
-			}
 			cwMsg := contractExecuteMsg.ExecuteMsg.ClosePosition
 			_, err = messenger.Perp.ClosePosition(cwMsg, contractAddr, ctx)
 			return events, data, err
 		case contractExecuteMsg.ExecuteMsg.AddMargin != nil:
-			if err := messenger.Sudo.CheckPermissions(contractAddr, ctx); err != nil {
-				return events, data, err
-			}
 			cwMsg := contractExecuteMsg.ExecuteMsg.AddMargin
 			_, err = messenger.Perp.AddMargin(cwMsg, contractAddr, ctx)
 			return events, data, err
 		case contractExecuteMsg.ExecuteMsg.RemoveMargin != nil:
-			if err := messenger.Sudo.CheckPermissions(contractAddr, ctx); err != nil {
-				return events, data, err
-			}
 			cwMsg := contractExecuteMsg.ExecuteMsg.RemoveMargin
 			_, err = messenger.Perp.RemoveMargin(cwMsg, contractAddr, ctx)
 			return events, data, err

--- a/x/wasm/binding/exec_perp.go
+++ b/x/wasm/binding/exec_perp.go
@@ -49,6 +49,9 @@ func (exec *ExecutorPerp) MarketOrder(
 		Leverage:             cwMsg.Leverage,
 		BaseAssetAmountLimit: cwMsg.BaseAmountLimit,
 	}
+	if err := sdkMsg.ValidateBasic(); err != nil {
+		return sdkResp, err
+	}
 
 	goCtx := sdk.WrapSDKContext(ctx)
 	return exec.MsgServer().MarketOrder(goCtx, sdkMsg)
@@ -71,6 +74,9 @@ func (exec *ExecutorPerp) ClosePosition(
 	sdkMsg := &perpv2types.MsgClosePosition{
 		Sender: sender.String(),
 		Pair:   pair,
+	}
+	if err := sdkMsg.ValidateBasic(); err != nil {
+		return sdkResp, err
 	}
 
 	goCtx := sdk.WrapSDKContext(ctx)
@@ -96,6 +102,9 @@ func (exec *ExecutorPerp) AddMargin(
 		Pair:   pair,
 		Margin: cwMsg.Margin,
 	}
+	if err := sdkMsg.ValidateBasic(); err != nil {
+		return sdkResp, err
+	}
 
 	goCtx := sdk.WrapSDKContext(ctx)
 	return exec.MsgServer().AddMargin(goCtx, sdkMsg)
@@ -119,6 +128,9 @@ func (exec *ExecutorPerp) RemoveMargin(
 		Sender: sender.String(),
 		Pair:   pair,
 		Margin: cwMsg.Margin,
+	}
+	if err := sdkMsg.ValidateBasic(); err != nil {
+		return sdkResp, err
 	}
 
 	goCtx := sdk.WrapSDKContext(ctx)

--- a/x/wasm/binding/exec_perp_test.go
+++ b/x/wasm/binding/exec_perp_test.go
@@ -76,7 +76,7 @@ func (s *TestSuitePerpExecutor) SetupSuite() {
 
 func (s *TestSuitePerpExecutor) OnSetupEnd() {
 	s.contractPerp = ContractMap[wasmbin.WasmKeyPerpBinding]
-	s.ratesMap = SetExchangeRates(s.Suite, s.nibiru, s.ctx)
+	s.ratesMap = SetExchangeRates(&s.Suite, s.nibiru, s.ctx)
 }
 
 // Happy path coverage of MarketOrder, AddMargin, RemoveMargin, and ClosePosition

--- a/x/wasm/binding/exec_test.go
+++ b/x/wasm/binding/exec_test.go
@@ -104,7 +104,7 @@ func (s *TestSuiteExecutor) SetupSuite() {
 }
 
 func (s *TestSuiteExecutor) OnSetupEnd() {
-	SetExchangeRates(s.Suite, s.nibiru, s.ctx)
+	SetExchangeRates(&s.Suite, s.nibiru, s.ctx)
 }
 
 func (s *TestSuiteExecutor) TestOpenAddRemoveClose() {

--- a/x/wasm/binding/querier_perp_test.go
+++ b/x/wasm/binding/querier_perp_test.go
@@ -27,7 +27,7 @@ func TestSuitePerpQuerier_RunAll(t *testing.T) {
 }
 
 func SetExchangeRates(
-	testSuite suite.Suite,
+	testSuite *suite.Suite,
 	nibiru *app.NibiruApp,
 	ctx sdk.Context,
 ) (exchangeRateMap map[asset.Pair]sdk.Dec) {
@@ -108,7 +108,7 @@ func (s *TestSuitePerpQuerier) SetupSuite() {
 }
 
 func (s *TestSuitePerpQuerier) OnSetupEnd() {
-	s.ratesMap = SetExchangeRates(s.Suite, s.nibiru, s.ctx)
+	s.ratesMap = SetExchangeRates(&s.Suite, s.nibiru, s.ctx)
 }
 
 // ————————————————————————————————————————————————————————————————————————————

--- a/x/wasm/binding/querier_test.go
+++ b/x/wasm/binding/querier_test.go
@@ -148,7 +148,7 @@ func (s *TestSuiteQuerier) SetupSuite() {
 }
 
 func (s *TestSuiteQuerier) OnSetupEnd() {
-	SetExchangeRates(s.Suite, s.nibiru, s.ctx)
+	SetExchangeRates(&s.Suite, s.nibiru, s.ctx)
 }
 
 func (s *TestSuiteQuerier) TestQueryReserves() {


### PR DESCRIPTION
- Fixes #1457 
