### PR TITLE
fix(test): position changed event comparison

### DIFF
--- a/x/common/testutil/events.go
+++ b/x/common/testutil/events.go
@@ -5,12 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"encoding/json"
-
 	"github.com/cosmos/gogoproto/proto"
-
-	"github.com/cosmos/cosmos-sdk/codec"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -67,24 +62,14 @@ func RequireContainsTypedEvent(t require.TestingT, ctx sdk.Context, event proto.
 	t.Errorf("event not found, event: %+v, found events: %+v", event, foundEvents)
 }
 
-// ProtoToJson converts a proto message into a JSON string using the proto codec.
-// A codec defines a functionality for serializing other objects. The proto
-// codec provides full Protobuf serialization compatibility.
-func ProtoToJson(protoMsg proto.Message) (jsonOut string, err error) {
-	protoCodec := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
-	var jsonBz json.RawMessage
-	jsonBz, err = protoCodec.MarshalJSON(protoMsg)
-	return string(jsonBz), err
-}
-
-// EventHasAttribueValue parses the given ABCI event at a key to see if it
+// EventHasAttributeValue parses the given ABCI event at a key to see if it
 // matches (contains) the wanted value.
 //
 // Args:
 //   - abciEvent: The event under test
 //   - key: The key for which we'll check the value
 //   - want: The desired value
-func EventHasAttribueValue(abciEvent sdk.Event, key string, want string) error {
+func EventHasAttributeValue(abciEvent sdk.Event, key string, want string) error {
 	attr, ok := abciEvent.GetAttribute(key)
 	if !ok {
 		return fmt.Errorf("abci event does not contain key: %s", key)

--- a/x/perp/v2/integration/assertion/event.go
+++ b/x/perp/v2/integration/assertion/event.go
@@ -51,9 +51,9 @@ func (act containsLiquidateEvent) Do(_ *app.NibiruApp, ctx sdk.Context) (
 
 		liquidationFailedEvent, ok := typedEvent.(*types.LiquidationFailedEvent)
 		if !ok {
-			return ctx, errors.New(
-				fmt.Sprintf("expected event of type %s, got %s", proto.MessageName(act.expectedEvent), abciEvent.Type),
-			), false
+			return ctx,
+				fmt.Errorf("expected event of type %s, got %s", proto.MessageName(act.expectedEvent), abciEvent.Type),
+				false
 		}
 
 		if reflect.DeepEqual(act.expectedEvent, liquidationFailedEvent) {

--- a/x/perp/v2/integration/assertion/event.go
+++ b/x/perp/v2/integration/assertion/event.go
@@ -52,8 +52,8 @@ func (act containsLiquidateEvent) Do(_ *app.NibiruApp, ctx sdk.Context) (
 
 		liquidationFailedEvent, ok := typedEvent.(*types.LiquidationFailedEvent)
 		if !ok {
-			return ctx, errors.New(
-				fmt.Sprintf("expected event of type %s, got %s", proto.MessageName(act.expectedEvent), abciEvent.Type),
+			return ctx, fmt.Errorf(
+				"expected event of type %s, got %s", proto.MessageName(act.expectedEvent), abciEvent.Type,
 			), false
 		}
 

--- a/x/perp/v2/keeper/liquidate_test.go
+++ b/x/perp/v2/keeper/liquidate_test.go
@@ -160,7 +160,7 @@ func TestMultiLiquidate(t *testing.T) {
 						},
 					),
 				),
-				ContainsLiquidateEvent(types.LiquidationFailedEvent{
+				ContainsLiquidateEvent(&types.LiquidationFailedEvent{
 					Pair:       pairBtcUsdc,
 					Trader:     alice.String(),
 					Liquidator: liquidator.String(),
@@ -222,19 +222,19 @@ func TestMultiLiquidate(t *testing.T) {
 					),
 				),
 
-				ContainsLiquidateEvent(types.LiquidationFailedEvent{
+				ContainsLiquidateEvent(&types.LiquidationFailedEvent{
 					Pair:       pairAtomUsdc,
 					Trader:     alice.String(),
 					Liquidator: liquidator.String(),
 					Reason:     types.LiquidationFailedEvent_POSITION_HEALTHY,
 				}),
-				ContainsLiquidateEvent(types.LiquidationFailedEvent{
+				ContainsLiquidateEvent(&types.LiquidationFailedEvent{
 					Pair:       pairSolUsdc,
 					Trader:     alice.String(),
 					Liquidator: liquidator.String(),
 					Reason:     types.LiquidationFailedEvent_NONEXISTENT_PAIR,
 				}),
-				ContainsLiquidateEvent(types.LiquidationFailedEvent{
+				ContainsLiquidateEvent(&types.LiquidationFailedEvent{
 					Pair:       pairBtcUsdc,
 					Trader:     bob.String(),
 					Liquidator: liquidator.String(),


### PR DESCRIPTION
# Description

This PR refactors the event comparison logic to use `reflect.DeepEqual` instead of rolling our own comparison logic. `reflect.DeepEqual` is more robust at handling proto structs and automatically picks up new proto fields by introspecting the type at runtime (test time).

# Purpose

Without it, we won't be able to properly assert events.
