### PR TITLE
revert(gha): use checkout and codecov action v3

### DIFF
--- a/.github/workflows/changelog-deps.yml
+++ b/.github/workflows/changelog-deps.yml
@@ -10,7 +10,7 @@ jobs:
       # TODO: feat: try to use author of the commit(s) to see if it's dependabot
       # ${{ any(contains(commit.author.username, 'dependabot') for commit in github.event.commits) }}
     steps: 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.NIBIRU_PM }}
           # to avoid checking out the repo in a detached state

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
   test-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,4 +28,4 @@ jobs:
         run: make test-coverage-integration
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Get version
         id: get_version

--- a/.github/workflows/e2e-wasm.yml
+++ b/.github/workflows/e2e-wasm.yml
@@ -14,7 +14,7 @@ jobs:
   get-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Download release

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -21,7 +21,7 @@ jobs:
   #     runs-on: ubuntu-latest
   #     timeout-minutes: 5
   #     steps:
-  #       - uses: actions/checkout@v4
+  #       - uses: actions/checkout@v3
   #       - uses: bufbuild/buf-setup-action@v1.26.1
   #       - uses: bufbuild/buf-lint-action@v1
   #         with:
@@ -30,7 +30,7 @@ jobs:
   break-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1.26.1
       - uses: bufbuild/buf-breaking-action@v1
         with:

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -8,7 +8,7 @@ jobs:
   install-runsim:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version: 1.19
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install-runsim]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:
           SUFFIX_FILTER: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -27,7 +27,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v4


### PR DESCRIPTION
# Description

Reverts the gha checkout action to v3
Reverts the gha codecov action to v3

# Purpose

Checkout v4 is causing our golangci-lint workflow to [fail](https://github.com/NibiruChain/nibiru/actions/runs/6211228223/job/16868063322?pr=1586).

Codecov v4 is causing our workflows to fail.