### PR TITLE
ci: fix coverage report publishing

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,19 +2,20 @@ name: Integration tests
 
 on:
   workflow_dispatch: # Runs on manual calls
-  schedule: 
+  schedule:
     - cron: "0 0 * * *" # Runs automatically every day
   pull_request:
     # paths makes the action run only when the given paths are changed
     paths: ["**.go", "**.proto", "go.mod", "go.sum"]
 
-# Allow concurrent runs on main/release branches but isolates other branches 
+# Allow concurrent runs on main/release branches but isolates other branches
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
   cancel-in-progress: ${{ ! (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) }}
 
 jobs:
   integration-tests:
+    # Job that runs all tests and publishes code coverage reports.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/contrib/make/test.mk
+++ b/contrib/make/test.mk
@@ -14,7 +14,7 @@ test-coverage:
 
 .PHONY: test-coverage-integration
 test-coverage-integration:
-	go test ./... -v \
+	go test ./... \
 		-coverprofile=coverage.txt \
 		-covermode=atomic \
 		-race | grep -v "no test" | grep -v "no statement"

--- a/contrib/make/test.mk
+++ b/contrib/make/test.mk
@@ -14,7 +14,7 @@ test-coverage:
 
 .PHONY: test-coverage-integration
 test-coverage-integration:
-	go test ./... -v $(PACKAGES_NOSIMULATION) \
+	go test ./... -v \
 		-coverprofile=coverage.txt \
 		-covermode=atomic \
 		-race | grep -v "no test" | grep -v "no statement"

--- a/contrib/make/test.mk
+++ b/contrib/make/test.mk
@@ -1,17 +1,18 @@
-###############################################################################
-###                            		  Tests 					                        ###
-###############################################################################
+#########################################################################
+# Tests
+#########################################################################
 
 PACKAGES_NOSIMULATION = ${shell go list ./... | grep -v simapp}
 
-# Used for CI by Codecov
 .PHONY: test-coverage
 test-coverage:
-	go test ./... -v $(PACKAGES_NOSIMULATION) -short \
+	go test ./... $(PACKAGES_NOSIMULATION) -short \
 		-coverprofile=coverage.txt \
 		-covermode=atomic \
 		-race | grep -v "no test" | grep -v "no statement"
 
+# NOTE: Using the verbose flag breaks the coverage reporting in CI.
+# Used for CI by Codecov
 .PHONY: test-coverage-integration
 test-coverage-integration:
 	go test ./... \

--- a/x/perp/v2/keeper/clearing_house.go
+++ b/x/perp/v2/keeper/clearing_house.go
@@ -838,7 +838,6 @@ func (k Keeper) PartialClose(
 	pair asset.Pair,
 	traderAddr sdk.AccAddress,
 	sizeAmt sdk.Dec, // unsigned
-
 ) (*types.PositionResp, error) {
 	market, err := k.GetMarket(ctx, pair)
 	if err != nil {


### PR DESCRIPTION
# Purpose

The codecov reports stopped being published and used to work in prior commits like https://github.com/NibiruChain/nibiru/commit/d0bc88444037e6a6ab4b21bd28081d0ee6f1f284 and tag v0.21.8. 

This PR is intended to restore the functionality for publishing coverage reports (I think it's simply removing a flag).