### PR TITLE
ci(proto-lint): add github token to prevent rate limit + compare against branch

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -32,7 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1.26.1
+        with:
+          github_token: ${{ github.token }}
       - uses: bufbuild/buf-breaking-action@v1
         with:
           input: "proto"
-          against: "https://github.com/${{ github.repository }}.git#branch=${{ github.event.pull_request.base.ref }},ref=HEAD~1,subdir=proto"
+          against: "https://github.com/${{ github.repository }}.git#branch=${{ github.event.pull_request.base.ref }},subdir=proto"


### PR DESCRIPTION
# Purpose

- Fixes bug where we were only comparing for proto breaks using the previous commit rather than the current branch of the PR.
- Adds `github.token` to the `buf-setup-action` since we were getting rate llimited without it
