### PR TITLE
feat(ante)!: Ante handler to add a maximum commission rate of 25% for validators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [#1609](https://github.com/NibiruChain/nibiru/pull/1609) - refactor(app)!: Remove x/stablecoin module.
 * [#1613](https://github.com/NibiruChain/nibiru/pull/1613) - feat(app)!: enforce min commission by changing default and genesis validation
+* [#1615](https://github.com/NibiruChain/nibiru/pull/1613) - feat(ante)!: Ante
+  handler to add a maximum commission rate of 25% for validators.
 
 ### Improvements
 

--- a/app/ante.go
+++ b/app/ante.go
@@ -61,6 +61,7 @@ func NewAnteHandler(options AnteHandlerOptions) (sdk.AnteHandler, error) {
 		sdkante.NewTxTimeoutHeightDecorator(),
 		sdkante.NewValidateMemoDecorator(options.AccountKeeper),
 		ante.NewPostPriceFixedPriceDecorator(),
+		ante.AnteDecoratorStakingCommission{},
 		sdkante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		// Replace fee ante from cosmos auth with a custom one.
 		sdkante.NewDeductFeeDecorator(

--- a/app/ante/commission.go
+++ b/app/ante/commission.go
@@ -1,0 +1,37 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+func MAX_COMMISSION() sdk.Dec { return sdk.MustNewDecFromStr("0.25") }
+
+var _ sdk.AnteDecorator = (*AnteDecoratorStakingCommission)(nil)
+
+// AnteDecoratorStakingCommission: Implements sdk.AnteDecorator, enforcing the
+// maximum staking commission for validators on the network.
+type AnteDecoratorStakingCommission struct{}
+
+func (a AnteDecoratorStakingCommission) AnteHandle(
+	ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler,
+) (newCtx sdk.Context, err error) {
+	for _, msg := range tx.GetMsgs() {
+		switch msg := msg.(type) {
+		case *stakingtypes.MsgCreateValidator:
+			rate := msg.Commission.Rate
+			if rate.GT(MAX_COMMISSION()) {
+				return ctx, NewErrMaxValidatorCommission(rate)
+			}
+		case *stakingtypes.MsgEditValidator:
+			rate := msg.CommissionRate
+			if rate != nil && msg.CommissionRate.GT(MAX_COMMISSION()) {
+				return ctx, NewErrMaxValidatorCommission(*rate)
+			}
+		default:
+			continue
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/app/ante/commission_test.go
+++ b/app/ante/commission_test.go
@@ -1,0 +1,138 @@
+package ante_test
+
+import (
+	"testing"
+
+	sdkclienttx "github.com/cosmos/cosmos-sdk/client/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+
+	"github.com/NibiruChain/nibiru/app"
+	"github.com/NibiruChain/nibiru/app/ante"
+	"github.com/NibiruChain/nibiru/x/common/testutil"
+)
+
+func (s *AnteTestSuite) TestAnteDecoratorStakingCommission() {
+	// nextAnteHandler: A no-op next handler to make this a unit test.
+	var nextAnteHandler sdk.AnteHandler = func(
+		ctx sdk.Context, tx sdk.Tx, simulate bool,
+	) (newCtx sdk.Context, err error) {
+		return ctx, nil
+	}
+
+	mockDescription := stakingtypes.Description{
+		Moniker:         "mock-moniker",
+		Identity:        "mock-identity",
+		Website:         "mock-website",
+		SecurityContact: "mock-security-contact",
+		Details:         "mock-details",
+	}
+
+	valAddr := sdk.ValAddress(testutil.AccAddress()).String()
+	commissionRatePointer := new(sdk.Dec)
+	*commissionRatePointer = sdk.NewDecWithPrec(10, 2)
+	happyMsgs := []sdk.Msg{
+		&stakingtypes.MsgCreateValidator{
+			Description: mockDescription,
+			Commission: stakingtypes.CommissionRates{
+				Rate:          sdk.NewDecWithPrec(6, 2), // 6%
+				MaxRate:       sdk.NewDec(420),
+				MaxChangeRate: sdk.NewDec(420),
+			},
+			MinSelfDelegation: sdk.NewInt(1),
+			DelegatorAddress:  testutil.AccAddress().String(),
+			ValidatorAddress:  valAddr,
+			Pubkey:            &codectypes.Any{},
+			Value:             sdk.NewInt64Coin("unibi", 1),
+		},
+		&stakingtypes.MsgEditValidator{
+			Description:       mockDescription,
+			ValidatorAddress:  valAddr,
+			CommissionRate:    commissionRatePointer, // 10%
+			MinSelfDelegation: nil,
+		},
+	}
+
+	createSadMsgs := func() []sdk.Msg {
+		sadMsgCreateVal := new(stakingtypes.MsgCreateValidator)
+		*sadMsgCreateVal = *(happyMsgs[0]).(*stakingtypes.MsgCreateValidator)
+		sadMsgCreateVal.Commission.Rate = sdk.NewDecWithPrec(26, 2)
+
+		sadMsgEditVal := new(stakingtypes.MsgEditValidator)
+		*sadMsgEditVal = *(happyMsgs[1]).(*stakingtypes.MsgEditValidator)
+		newCommissionRate := new(sdk.Dec)
+		*newCommissionRate = sdk.NewDecWithPrec(26, 2)
+		sadMsgEditVal.CommissionRate = newCommissionRate
+
+		return []sdk.Msg{
+			sadMsgCreateVal,
+			sadMsgEditVal,
+		}
+	}
+	sadMsgs := createSadMsgs()
+
+	for _, tc := range []struct {
+		name    string
+		txMsgs  []sdk.Msg
+		wantErr string
+	}{
+		{
+			name:    "happy blank",
+			txMsgs:  []sdk.Msg{},
+			wantErr: "",
+		},
+		{
+			name: "happy msgs",
+			txMsgs: []sdk.Msg{
+				happyMsgs[0],
+				happyMsgs[1],
+			},
+			wantErr: "",
+		},
+		{
+			name: "sad: max commission on create validator",
+			txMsgs: []sdk.Msg{
+				sadMsgs[0],
+				happyMsgs[1],
+			},
+			wantErr: ante.ErrMaxValidatorCommission.Error(),
+		},
+		{
+			name: "sad: max commission on edit validator",
+			txMsgs: []sdk.Msg{
+				happyMsgs[0],
+				sadMsgs[1],
+			},
+			wantErr: ante.ErrMaxValidatorCommission.Error(),
+		},
+	} {
+		s.T().Run(tc.name, func(t *testing.T) {
+			txGasCoins := sdk.NewCoins(
+				sdk.NewCoin("unibi", sdk.NewInt(1_000)),
+				sdk.NewCoin("utoken", sdk.NewInt(500)),
+			)
+
+			encCfg := app.MakeEncodingConfigAndRegister()
+			txBuilder, err := sdkclienttx.Factory{}.
+				WithFees(txGasCoins.String()).
+				WithChainID(s.ctx.ChainID()).
+				WithTxConfig(encCfg.TxConfig).
+				BuildUnsignedTx(tc.txMsgs...)
+			s.NoError(err)
+
+			anteDecorator := ante.AnteDecoratorStakingCommission{}
+			simulate := true
+			s.ctx, err = anteDecorator.AnteHandle(
+				s.ctx, txBuilder.GetTx(), simulate, nextAnteHandler,
+			)
+
+			if tc.wantErr != "" {
+				s.ErrorContains(err, tc.wantErr)
+				return
+			}
+			s.NoError(err)
+		})
+	}
+}

--- a/app/ante/errors.go
+++ b/app/ante/errors.go
@@ -1,0 +1,24 @@
+package ante
+
+import (
+	sdkerrors "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var errorCodeIdx uint32 = 1
+
+func registerError(errMsg string) *sdkerrors.Error {
+	errorCodeIdx += 1
+	return sdkerrors.Register("ante-nibiru", errorCodeIdx, errMsg)
+}
+
+// app/ante "sentinel" errors
+var (
+	ErrOracleAnte             = registerError("oracle ante error")
+	ErrMaxValidatorCommission = registerError("validator commission rate is above max")
+)
+
+func NewErrMaxValidatorCommission(gotCommission sdk.Dec) error {
+	return ErrMaxValidatorCommission.Wrapf(
+		"got (%s), max rate is (%s)", gotCommission, MAX_COMMISSION())
+}

--- a/app/ante/fixed_gas.go
+++ b/app/ante/fixed_gas.go
@@ -3,7 +3,6 @@ package ante
 import (
 	sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/errors"
 
 	oracletypes "github.com/NibiruChain/nibiru/x/oracle/types"
 )
@@ -41,13 +40,13 @@ func (gd EnsureSinglePostPriceMessageDecorator) AnteHandle(
 
 	if hasOracleVoteMsg && hasOraclePreVoteMsg {
 		if len(msgs) > 2 {
-			return ctx, sdkerrors.Wrap(errors.ErrInvalidRequest, "a transaction cannot have more than a single oracle vote and prevote message")
+			return ctx, sdkerrors.Wrap(ErrOracleAnte, "a transaction cannot have more than a single oracle vote and prevote message")
 		}
 
 		ctx = ctx.WithGasMeter(NewFixedGasMeter(OracleMessageGas))
 	} else if hasOraclePreVoteMsg || hasOracleVoteMsg {
 		if len(msgs) > 1 {
-			return ctx, sdkerrors.Wrap(errors.ErrInvalidRequest, "a transaction that includes an oracle vote or prevote message cannot have more than those two messages")
+			return ctx, sdkerrors.Wrap(ErrOracleAnte, "a transaction that includes an oracle vote or prevote message cannot have more than those two messages")
 		}
 
 		ctx = ctx.WithGasMeter(NewFixedGasMeter(OracleMessageGas))

--- a/app/ante/fixed_gas_test.go
+++ b/app/ante/fixed_gas_test.go
@@ -3,9 +3,9 @@ package ante_test
 import (
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/types/errors"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	sdkerrors "cosmossdk.io/errors"
+	sdkioerrors "cosmossdk.io/errors"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -68,7 +68,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 				},
 			},
 			expectedGas: 1042,
-			expectedErr: sdkerrors.Wrap(errors.ErrInvalidRequest, "a transaction that includes an oracle vote or prevote message cannot have more than those two messages"),
+			expectedErr: sdkioerrors.Wrap(ante.ErrOracleAnte, "a transaction that includes an oracle vote or prevote message cannot have more than those two messages"),
 		},
 		{
 			name: "Two messages in a transaction, one of them is an oracle vote message should fail (with MsgAggregateExchangeRatePrevote) permutation 2",
@@ -85,7 +85,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 				},
 			},
 			expectedGas: 1042,
-			expectedErr: sdkerrors.Wrap(errors.ErrInvalidRequest, "a transaction that includes an oracle vote or prevote message cannot have more than those two messages"),
+			expectedErr: sdkioerrors.Wrap(ante.ErrOracleAnte, "a transaction that includes an oracle vote or prevote message cannot have more than those two messages"),
 		},
 		{
 			name: "Two messages in a transaction, one of them is an oracle vote message should fail (with MsgAggregateExchangeRateVote)",
@@ -103,7 +103,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 				},
 			},
 			expectedGas: 1042,
-			expectedErr: sdkerrors.Wrap(errors.ErrInvalidRequest, "a transaction that includes an oracle vote or prevote message cannot have more than those two messages"),
+			expectedErr: sdkioerrors.Wrap(ante.ErrOracleAnte, "a transaction that includes an oracle vote or prevote message cannot have more than those two messages"),
 		},
 		{
 			name: "Two messages in a transaction, one of them is an oracle vote message should fail (with MsgAggregateExchangeRateVote) permutation 2",
@@ -121,7 +121,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 				},
 			},
 			expectedGas: 1042,
-			expectedErr: sdkerrors.Wrap(errors.ErrInvalidRequest, "a transaction that includes an oracle vote or prevote message cannot have more than those two messages"),
+			expectedErr: sdkioerrors.Wrap(ante.ErrOracleAnte, "a transaction that includes an oracle vote or prevote message cannot have more than those two messages"),
 		},
 		{
 			name: "Two messages in a transaction, one is oracle vote, the other oracle pre vote: should work with fixed price",
@@ -180,7 +180,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 				},
 			},
 			expectedGas: 1042,
-			expectedErr: sdkerrors.Wrap(errors.ErrInvalidRequest, "a transaction cannot have more than a single oracle vote and prevote message"),
+			expectedErr: sdkioerrors.Wrap(ante.ErrOracleAnte, "a transaction cannot have more than a single oracle vote and prevote message"),
 		},
 		{
 			name: "Other two messages",
@@ -196,7 +196,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 					Amount:      sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, 200)),
 				},
 			},
-			expectedGas: 62504,
+			expectedGas: 62288,
 			expectedErr: nil,
 		},
 	}
@@ -249,7 +249,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 func (s *AnteTestSuite) ValidateTx(tx signing.Tx, t *testing.T) {
 	memoTx, ok := tx.(sdk.TxWithMemo)
 	if !ok {
-		s.Fail(sdkerrors.Wrap(errors.ErrTxDecode, "invalid transaction type").Error(), "memoTx: %t", memoTx)
+		s.Fail(sdkioerrors.Wrap(sdkerrors.ErrTxDecode, "invalid transaction type").Error(), "memoTx: %t", memoTx)
 	}
 
 	params := s.app.AccountKeeper.GetParams(s.ctx)

--- a/app/ante/testutil_test.go
+++ b/app/ante/testutil_test.go
@@ -19,7 +19,7 @@ import (
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
 	"github.com/NibiruChain/nibiru/app"
-	feeante "github.com/NibiruChain/nibiru/app/ante"
+	nibiruante "github.com/NibiruChain/nibiru/app/ante"
 	"github.com/NibiruChain/nibiru/x/common/testutil/genesis"
 	"github.com/NibiruChain/nibiru/x/common/testutil/testapp"
 )
@@ -38,6 +38,7 @@ type AnteTestSuite struct {
 // SetupTest setups a new test, with new app, context, and anteHandler.
 func (suite *AnteTestSuite) SetupTest() {
 	// Set up base app and ctx
+	testapp.EnsureNibiruPrefix()
 	encodingConfig := genesis.TEST_ENCODING_CONFIG
 	suite.app = testapp.NewNibiruTestApp(app.NewDefaultGenesisState(encodingConfig.Marshaler))
 	chainId := "test-chain-id"
@@ -66,7 +67,8 @@ func (suite *AnteTestSuite) SetupTest() {
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),
 		ante.NewValidateMemoDecorator(suite.app.AccountKeeper),
-		feeante.NewPostPriceFixedPriceDecorator(),
+		nibiruante.NewPostPriceFixedPriceDecorator(),
+		nibiruante.AnteDecoratorStakingCommission{},
 		ante.NewConsumeGasForTxSizeDecorator(suite.app.AccountKeeper),
 		ante.NewDeductFeeDecorator(suite.app.AccountKeeper, suite.app.BankKeeper, suite.app.FeeGrantKeeper, nil), // Replace fee ante from cosmos auth with a custom one.
 


### PR DESCRIPTION
# Purpose

In our validator interviews, we found that a common strategy for "low-commission attacking" validators is to:

1. Set a normal commission rate
2. Then, change the commission rate to be extremely low to undercut the other validators and advertise for delegations
3. And finally, adjust the commission extremely high to rake in profits with the new delegations.

If you impose a reasonable minimum and maximum commission, this problem is almost entirely avoided.

- Related to #1588
