### PR TITLE
fix(app): non-nil snapshot manager is not guarantted in testapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   handler to add a maximum commission rate of 25% for validators.
 * [#1616](https://github.com/NibiruChain/nibiru/pull/1616) - fix(app)!:
   Add custom wasm snapshotter for proper state exports
+* [#1617](https://github.com/NibiruChain/nibiru/pull/1617) - fix(app)!:
+  non-nil snapshot manager is not guarantted in testapp
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1613](https://github.com/NibiruChain/nibiru/pull/1613) - feat(app)!: enforce min commission by changing default and genesis validation
 * [#1615](https://github.com/NibiruChain/nibiru/pull/1613) - feat(ante)!: Ante
   handler to add a maximum commission rate of 25% for validators.
+* [#1616](https://github.com/NibiruChain/nibiru/pull/1616) - fix(app)!:
+  Add custom wasm snapshotter for proper state exports
 
 ### Improvements
 

--- a/app/app.go
+++ b/app/app.go
@@ -206,6 +206,21 @@ func NewNibiruApp(
 	app.SetAnteHandler(anteHandler)
 	app.SetEndBlocker(app.EndBlocker)
 
+	snapshotManager := app.SnapshotManager()
+	if snapshotManager == nil {
+		panic("mistakes were made: snapshot manager is nil")
+	} else {
+		err := snapshotManager.RegisterExtensions(
+			wasmkeeper.NewWasmSnapshotter(
+				app.CommitMultiStore(),
+				&app.WasmKeeper,
+			),
+		)
+		if err != nil {
+			panic("failed to add wasm snapshot extension.")
+		}
+	}
+
 	if loadLatest {
 		if err := app.LoadLatestVersion(); err != nil {
 			tmos.Exit(err.Error())

--- a/app/app.go
+++ b/app/app.go
@@ -209,16 +209,14 @@ func NewNibiruApp(
 	snapshotManager := app.SnapshotManager()
 	if snapshotManager == nil {
 		panic("mistakes were made: snapshot manager is nil")
-	} else {
-		err := snapshotManager.RegisterExtensions(
-			wasmkeeper.NewWasmSnapshotter(
-				app.CommitMultiStore(),
-				&app.WasmKeeper,
-			),
-		)
-		if err != nil {
-			panic("failed to add wasm snapshot extension.")
-		}
+	}
+	if err = snapshotManager.RegisterExtensions(
+		wasmkeeper.NewWasmSnapshotter(
+			app.CommitMultiStore(),
+			&app.WasmKeeper,
+		),
+	); err != nil {
+		panic("failed to add wasm snapshot extension.")
 	}
 
 	if loadLatest {

--- a/app/app.go
+++ b/app/app.go
@@ -206,17 +206,15 @@ func NewNibiruApp(
 	app.SetAnteHandler(anteHandler)
 	app.SetEndBlocker(app.EndBlocker)
 
-	snapshotManager := app.SnapshotManager()
-	if snapshotManager == nil {
-		panic("mistakes were made: snapshot manager is nil")
-	}
-	if err = snapshotManager.RegisterExtensions(
-		wasmkeeper.NewWasmSnapshotter(
-			app.CommitMultiStore(),
-			&app.WasmKeeper,
-		),
-	); err != nil {
-		panic("failed to add wasm snapshot extension.")
+	if snapshotManager := app.SnapshotManager(); snapshotManager != nil {
+		if err = snapshotManager.RegisterExtensions(
+			wasmkeeper.NewWasmSnapshotter(
+				app.CommitMultiStore(),
+				&app.WasmKeeper,
+			),
+		); err != nil {
+			panic("failed to add wasm snapshot extension.")
+		}
 	}
 
 	if loadLatest {


### PR DESCRIPTION
This change affects keeper tests but does not affect the initialization of actual binaries (cmd/.../root.go).

- This more closely resembles the [logic in wasmd](https://github.com/CosmWasm/wasmd/blob/03f3c72a6ce447fafc2da023a1322899327433f8/app/app.go#L769-L779)
- hotfix(app): non-nil snapshot manager is not guaranteed in testapp
