### PR TITLE
fix(tokenfactory)!: Fix bug in MsgBurn on total supply tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1615](https://github.com/NibiruChain/nibiru/pull/1613) - feat(ante)!: Ante handler to add a maximum commission rate of 25% for validators.
 * [#1616](https://github.com/NibiruChain/nibiru/pull/1616) - fix(app)!: Add custom wasm snapshotter for proper state exports
 * [#1617](https://github.com/NibiruChain/nibiru/pull/1617) - fix(app)!: non-nil snapshot manager is not guaranteed in testapp
+* [#1645](https://github.com/NibiruChain/nibiru/pull/1645) - fix(tokenfactory)!: token supply in bank keeper must be correct after MsgBurn.
 
 ### Improvements
 

--- a/x/tokenfactory/keeper/msg_server.go
+++ b/x/tokenfactory/keeper/msg_server.go
@@ -220,12 +220,6 @@ func (k Keeper) burn(
 		return err
 	}
 
-	coins := sdk.NewCoins(coin)
-	err := k.bankKeeper.MintCoins(ctx, types.ModuleName, coins)
-	if err != nil {
-		return err
-	}
-
 	burnFromAddr, err := sdk.AccAddressFromBech32(burnFrom)
 	if err != nil {
 		return err
@@ -236,6 +230,7 @@ func (k Keeper) burn(
 			"failed to burn from %s", burnFromAddr)
 	}
 
+	coins := sdk.NewCoins(coin)
 	if err = k.bankKeeper.SendCoinsFromAccountToModule(
 		ctx, burnFromAddr, types.ModuleName, coins,
 	); err != nil {

--- a/x/tokenfactory/keeper/msg_server_test.go
+++ b/x/tokenfactory/keeper/msg_server_test.go
@@ -379,17 +379,17 @@ func (s *TestSuite) TestMintBurn() {
 				allDenoms := bapp.TokenFactoryKeeper.Store.Denoms.
 					Iterate(ctx, collections.Range[string]{}).Values()
 
-				s.T().Log("Minting changes total supply, but burning does not.")
+				s.T().Log("Total supply should decrease by burned amount.")
 				denom := allDenoms[0]
 				s.Equal(
-					sdk.NewInt(69_420), s.app.BankKeeper.GetSupply(s.ctx, denom.String()).Amount,
+					sdk.NewInt(69_419), s.app.BankKeeper.GetSupply(s.ctx, denom.String()).Amount,
 				)
 
-				s.T().Log("We burned 1 token, so it should be in the module account.")
+				s.T().Log("Module account should be empty.")
 				coin := s.app.BankKeeper.GetBalance(
 					s.ctx, tfModuleAddr, denom.String())
 				s.Equal(
-					sdk.NewInt(1),
+					sdk.NewInt(0),
 					coin.Amount,
 				)
 			},

--- a/x/tokenfactory/types/expected_keepers.go
+++ b/x/tokenfactory/types/expected_keepers.go
@@ -11,6 +11,7 @@ type BankKeeper interface {
 	GetDenomMetaData(ctx sdk.Context, denom string) (banktypes.Metadata, bool)
 	SetDenomMetaData(ctx sdk.Context, denomMetaData banktypes.Metadata)
 
+	GetSupply(ctx sdk.Context, denom string) sdk.Coin
 	HasSupply(ctx sdk.Context, denom string) bool
 	IterateTotalSupply(ctx sdk.Context, cb func(sdk.Coin) bool)
 


### PR DESCRIPTION
- Noticed a bug while querying the supply when writing the NUSD smart contracts. This PR fixes that bug in `MsgBurn`.
- State machine breaking
