### PR TITLE
chore(oracle): curate default oracle whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1638](https://github.com/NibiruChain/nibiru/pull/1638) - test(tokenfactory): integration test core logic with a real smart contract using `nibiru-std`
 * [#1639](https://github.com/NibiruChain/nibiru/pull/1639) - fix(perp): by default, disable new markets until they are toggled on.
 * [#1652](https://github.com/NibiruChain/nibiru/pull/1652) - test: refactors cli.network suites with 'Integration' to use common function
+* [#1659](https://github.com/NibiruChain/nibiru/pull/1659) - refactor(oracle): curate oracle default whitelist
 
 ### Dependencies
 - Bump `github.com/prometheus/client_golang` from 1.16.0 to 1.17.0 ([#1605](https://github.com/NibiruChain/nibiru/pull/1605))

--- a/wasmbinding/exec_oracle_test.go
+++ b/wasmbinding/exec_oracle_test.go
@@ -70,19 +70,19 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 	// Vote Period
 	params, err := s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(uint64(1_000), params.VotePeriod)
+	s.Equal(uint64(1_000), params.VotePeriod)
 
 	err = s.exec.SetOracleParams(cwMsg, s.ctx)
 	s.Require().NoError(err)
 
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(uint64(1234), params.VotePeriod)
+	s.Equal(uint64(1234), params.VotePeriod)
 
 	// Vote Threshold
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(sdk.OneDec().Quo(sdk.NewDec(3)), params.VoteThreshold)
+	s.Equal(sdk.OneDec().Quo(sdk.NewDec(3)), params.VoteThreshold)
 
 	threshold := sdk.MustNewDecFromStr("0.4")
 	cwMsg = &bindings.EditOracleParams{
@@ -94,12 +94,12 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(threshold, params.VoteThreshold)
+	s.Equal(threshold, params.VoteThreshold)
 
 	// Reward Band
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(sdk.NewDecWithPrec(2, 2), params.RewardBand)
+	s.Equal(sdk.NewDecWithPrec(2, 2), params.RewardBand)
 
 	band := sdk.MustNewDecFromStr("0.5")
 	cwMsg = &bindings.EditOracleParams{
@@ -111,12 +111,12 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(band, params.RewardBand)
+	s.Equal(band, params.RewardBand)
 
 	// White List
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(14, len(params.Whitelist))
+	s.Assert().Equal(6, len(params.Whitelist))
 
 	whitelist := []string{"aave:usdc", "sol:usdc"}
 	cwMsg = &bindings.EditOracleParams{
@@ -127,12 +127,12 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(2, len(params.Whitelist))
+	s.Equal(2, len(params.Whitelist))
 
 	// Slash Fraction
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(sdk.NewDecWithPrec(5, 3), params.SlashFraction)
+	s.Equal(sdk.NewDecWithPrec(5, 3), params.SlashFraction)
 
 	slashFraction := sdk.MustNewDecFromStr("0.5")
 	cwMsg = &bindings.EditOracleParams{
@@ -144,12 +144,12 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(slashFraction, params.SlashFraction)
+	s.Equal(slashFraction, params.SlashFraction)
 
 	// Slash Window
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(uint64(3600), params.SlashWindow)
+	s.Equal(uint64(3600), params.SlashWindow)
 
 	slashWindow := sdk.NewInt(2)
 	cwMsg = &bindings.EditOracleParams{
@@ -161,12 +161,12 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(slashWindow.Uint64(), params.SlashWindow)
+	s.Equal(slashWindow.Uint64(), params.SlashWindow)
 
 	// Min valid per window
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(sdk.NewDecWithPrec(69, 2), params.MinValidPerWindow)
+	s.Equal(sdk.NewDecWithPrec(69, 2), params.MinValidPerWindow)
 
 	minValidPerWindow := sdk.MustNewDecFromStr("0.5")
 	cwMsg = &bindings.EditOracleParams{
@@ -178,12 +178,12 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(minValidPerWindow, params.MinValidPerWindow)
+	s.Equal(minValidPerWindow, params.MinValidPerWindow)
 
 	// Twap lookback window
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(time.Minute*15, params.TwapLookbackWindow)
+	s.Equal(time.Minute*15, params.TwapLookbackWindow)
 
 	twapLookbackWindow := sdk.NewInt(int64(time.Second * 30))
 	cwMsg = &bindings.EditOracleParams{
@@ -195,12 +195,12 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(time.Duration(twapLookbackWindow.Int64()), params.TwapLookbackWindow)
+	s.Equal(time.Duration(twapLookbackWindow.Int64()), params.TwapLookbackWindow)
 
 	// Min Voters
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(uint64(4), params.MinVoters)
+	s.Equal(uint64(4), params.MinVoters)
 
 	minVoters := sdk.NewInt(2)
 	cwMsg = &bindings.EditOracleParams{
@@ -212,12 +212,12 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(minVoters.Uint64(), params.MinVoters)
+	s.Equal(minVoters.Uint64(), params.MinVoters)
 
 	// Validator Fee Ratio
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(sdk.NewDecWithPrec(5, 2), params.ValidatorFeeRatio)
+	s.Equal(sdk.NewDecWithPrec(5, 2), params.ValidatorFeeRatio)
 
 	validatorFeeRatio := sdk.MustNewDecFromStr("0.7")
 	cwMsg = &bindings.EditOracleParams{
@@ -229,5 +229,5 @@ func (s *TestSuiteOracleExecutor) TestExecuteOracleParams() {
 
 	params, err = s.nibiru.OracleKeeper.Params.Get(s.ctx)
 	s.Require().NoError(err)
-	s.Require().Equal(validatorFeeRatio, params.ValidatorFeeRatio)
+	s.Equal(validatorFeeRatio, params.ValidatorFeeRatio)
 }

--- a/x/oracle/abci_test.go
+++ b/x/oracle/abci_test.go
@@ -18,7 +18,7 @@ func TestOracleTallyTiming(t *testing.T) {
 	// all the Addrs vote for the block ... not last period block yet, so tally fails
 	for i := range keeper.Addrs[:4] {
 		keeper.MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-			{Pair: asset.Registry.Pair(denoms.BTC, denoms.NUSD), ExchangeRate: sdk.OneDec()},
+			{Pair: asset.Registry.Pair(denoms.BTC, denoms.USD), ExchangeRate: sdk.OneDec()},
 		}, i)
 	}
 
@@ -31,13 +31,13 @@ func TestOracleTallyTiming(t *testing.T) {
 	require.Equal(t, 1, int(input.Ctx.BlockHeight()))
 
 	EndBlocker(input.Ctx, input.OracleKeeper)
-	_, err = input.OracleKeeper.ExchangeRates.Get(input.Ctx, asset.Registry.Pair(denoms.BTC, denoms.NUSD))
+	_, err = input.OracleKeeper.ExchangeRates.Get(input.Ctx, asset.Registry.Pair(denoms.BTC, denoms.USD))
 	require.Error(t, err)
 
 	input.Ctx = input.Ctx.WithBlockHeight(int64(params.VotePeriod - 1))
 
 	EndBlocker(input.Ctx, input.OracleKeeper)
-	_, err = input.OracleKeeper.ExchangeRates.Get(input.Ctx, asset.Registry.Pair(denoms.BTC, denoms.NUSD))
+	_, err = input.OracleKeeper.ExchangeRates.Get(input.Ctx, asset.Registry.Pair(denoms.BTC, denoms.USD))
 	require.NoError(t, err)
 }
 
@@ -45,8 +45,8 @@ func TestOracleTallyTiming(t *testing.T) {
 // Ensure that the updated pair is not deleted and the other pair is deleted after a certain time.
 func TestOraclePriceExpiration(t *testing.T) {
 	input, h := keeper.Setup(t)
-	pair1 := asset.Registry.Pair(denoms.BTC, denoms.NUSD)
-	pair2 := asset.Registry.Pair(denoms.ETH, denoms.NUSD)
+	pair1 := asset.Registry.Pair(denoms.BTC, denoms.USD)
+	pair2 := asset.Registry.Pair(denoms.ETH, denoms.USD)
 
 	// Set prices for both pairs
 	for i := range keeper.Addrs[:4] {

--- a/x/oracle/keeper/msg_server_test.go
+++ b/x/oracle/keeper/msg_server_test.go
@@ -16,7 +16,7 @@ func TestFeederDelegation(t *testing.T) {
 
 	exchangeRates := types.ExchangeRateTuples{
 		{
-			Pair:         asset.Registry.Pair(denoms.BTC, denoms.NUSD),
+			Pair:         asset.Registry.Pair(denoms.BTC, denoms.USD),
 			ExchangeRate: testExchangeRate,
 		},
 	}
@@ -83,43 +83,43 @@ func TestAggregatePrevoteVote(t *testing.T) {
 	salt := "1"
 	exchangeRates := types.ExchangeRateTuples{
 		{
-			Pair:         asset.Registry.Pair(denoms.NIBI, denoms.NUSD),
+			Pair:         asset.Registry.Pair(denoms.ATOM, denoms.USD),
 			ExchangeRate: sdk.MustNewDecFromStr("1000.23"),
 		},
 		{
-			Pair:         asset.Registry.Pair(denoms.ETH, denoms.NUSD),
+			Pair:         asset.Registry.Pair(denoms.ETH, denoms.USD),
 			ExchangeRate: sdk.MustNewDecFromStr("0.29"),
 		},
 
 		{
-			Pair:         asset.Registry.Pair(denoms.BTC, denoms.NUSD),
+			Pair:         asset.Registry.Pair(denoms.BTC, denoms.USD),
 			ExchangeRate: sdk.MustNewDecFromStr("0.27"),
 		},
 	}
 
 	otherExchangeRate := types.ExchangeRateTuples{
 		{
-			Pair:         asset.Registry.Pair(denoms.NIBI, denoms.NUSD),
+			Pair:         asset.Registry.Pair(denoms.ATOM, denoms.USD),
 			ExchangeRate: sdk.MustNewDecFromStr("1000.23"),
 		},
 		{
-			Pair:         asset.Registry.Pair(denoms.ETH, denoms.NUSD),
+			Pair:         asset.Registry.Pair(denoms.ETH, denoms.USD),
 			ExchangeRate: sdk.MustNewDecFromStr("0.29"),
 		},
 
 		{
-			Pair:         asset.Registry.Pair(denoms.ETH, denoms.NUSD),
+			Pair:         asset.Registry.Pair(denoms.ETH, denoms.USD),
 			ExchangeRate: sdk.MustNewDecFromStr("0.27"),
 		},
 	}
 
 	unintendedExchangeRateStr := types.ExchangeRateTuples{
 		{
-			Pair:         asset.Registry.Pair(denoms.NIBI, denoms.NUSD),
+			Pair:         asset.Registry.Pair(denoms.ATOM, denoms.USD),
 			ExchangeRate: sdk.MustNewDecFromStr("1000.23"),
 		},
 		{
-			Pair:         asset.Registry.Pair(denoms.ETH, denoms.NUSD),
+			Pair:         asset.Registry.Pair(denoms.ETH, denoms.USD),
 			ExchangeRate: sdk.MustNewDecFromStr("0.29"),
 		},
 		{

--- a/x/oracle/keeper/reward_test.go
+++ b/x/oracle/keeper/reward_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestKeeperRewardsDistributionMultiVotePeriods(t *testing.T) {
-	// this simulates allocating rewards for the pair nibi:nusd
+	// this simulates allocating rewards for the pair atom:usd
 	// over 5 voting periods. It simulates rewards are correctly
 	// distributed over 5 voting periods to 5 validators.
 	// then we simulate that after the 5 voting periods are
@@ -39,7 +39,7 @@ func TestKeeperRewardsDistributionMultiVotePeriods(t *testing.T) {
 			// then changes the height to current height + vote period for the vote
 			MakeAggregatePrevoteAndVote(t, fixture, msgServer, fixture.Ctx.BlockHeight(), types.ExchangeRateTuples{
 				{
-					Pair:         asset.Registry.Pair(denoms.NIBI, denoms.NUSD),
+					Pair:         asset.Registry.Pair(denoms.ATOM, denoms.USD),
 					ExchangeRate: testExchangeRate,
 				},
 			}, valIndex)

--- a/x/oracle/keeper/slash_test.go
+++ b/x/oracle/keeper/slash_test.go
@@ -92,9 +92,9 @@ func TestInvalidVotesSlashing(t *testing.T) {
 	input, h := Setup(t)
 	params, err := input.OracleKeeper.Params.Get(input.Ctx)
 	require.NoError(t, err)
-	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.NIBI, denoms.NUSD)}
+	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.ATOM, denoms.USD)}
 	input.OracleKeeper.Params.Set(input.Ctx, params)
-	input.OracleKeeper.WhitelistedPairs.Insert(input.Ctx, asset.Registry.Pair(denoms.NIBI, denoms.NUSD))
+	input.OracleKeeper.WhitelistedPairs.Insert(input.Ctx, asset.Registry.Pair(denoms.ATOM, denoms.USD))
 
 	votePeriodsPerWindow := sdk.NewDec(int64(input.OracleKeeper.SlashWindow(input.Ctx))).QuoInt64(int64(input.OracleKeeper.VotePeriod(input.Ctx))).TruncateInt64()
 	slashFraction := input.OracleKeeper.SlashFraction(input.Ctx)
@@ -105,22 +105,22 @@ func TestInvalidVotesSlashing(t *testing.T) {
 
 		// Account 1, govstable
 		MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-			{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate},
+			{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate},
 		}, 0)
 
 		// Account 2, govstable, miss vote
 		MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-			{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate.Add(sdk.NewDec(100000000000000))},
+			{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate.Add(sdk.NewDec(100000000000000))},
 		}, 1)
 
 		// Account 3, govstable
 		MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-			{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate},
+			{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate},
 		}, 2)
 
 		// Account 4, govstable
 		MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-			{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate},
+			{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate},
 		}, 3)
 
 		input.OracleKeeper.UpdateExchangeRates(input.Ctx)
@@ -136,22 +136,22 @@ func TestInvalidVotesSlashing(t *testing.T) {
 	// one more miss vote will inccur ValAddrs[1] slashing
 	// Account 1, govstable
 	MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate},
 	}, 0)
 
 	// Account 2, govstable, miss vote
 	MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate.Add(sdk.NewDec(100000000000000))},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate.Add(sdk.NewDec(100000000000000))},
 	}, 1)
 
 	// Account 3, govstable
 	MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate},
 	}, 2)
 
 	// Account 4, govstable
 	MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate},
 	}, 3)
 
 	input.Ctx = input.Ctx.WithBlockHeight(votePeriodsPerWindow - 1)
@@ -171,7 +171,7 @@ func TestWhitelistSlashing(t *testing.T) {
 	votePeriodsPerSlashWindow := sdk.NewDec(int64(input.OracleKeeper.SlashWindow(input.Ctx))).QuoInt64(int64(input.OracleKeeper.VotePeriod(input.Ctx))).TruncateInt64()
 	minValidVotePeriodsPerWindow := input.OracleKeeper.MinValidPerWindow(input.Ctx)
 
-	pair := asset.Registry.Pair(denoms.NIBI, denoms.NUSD)
+	pair := asset.Registry.Pair(denoms.ATOM, denoms.USD)
 	priceVoteFromVal := func(valIdx int, block int64, erate sdk.Dec) {
 		MakeAggregatePrevoteAndVote(t, input, msgServer, block,
 			types.ExchangeRateTuples{{Pair: pair, ExchangeRate: erate}},
@@ -207,19 +207,19 @@ func TestNotPassedBallotSlashing(t *testing.T) {
 	input, h := Setup(t)
 	params, err := input.OracleKeeper.Params.Get(input.Ctx)
 	require.NoError(t, err)
-	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.NIBI, denoms.NUSD)}
+	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.ATOM, denoms.USD)}
 	input.OracleKeeper.Params.Set(input.Ctx, params)
 
 	// clear tobin tax to reset vote targets
 	for _, p := range input.OracleKeeper.WhitelistedPairs.Iterate(input.Ctx, collections.Range[asset.Pair]{}).Keys() {
 		input.OracleKeeper.WhitelistedPairs.Delete(input.Ctx, p)
 	}
-	input.OracleKeeper.WhitelistedPairs.Insert(input.Ctx, asset.Registry.Pair(denoms.NIBI, denoms.NUSD))
+	input.OracleKeeper.WhitelistedPairs.Insert(input.Ctx, asset.Registry.Pair(denoms.ATOM, denoms.USD))
 
 	input.Ctx = input.Ctx.WithBlockHeight(input.Ctx.BlockHeight() + 1)
 
 	// Account 1, govstable
-	MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate}}, 0)
+	MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate}}, 0)
 
 	input.OracleKeeper.UpdateExchangeRates(input.Ctx)
 	input.OracleKeeper.SlashAndResetMissCounters(input.Ctx)
@@ -235,12 +235,12 @@ func TestAbstainSlashing(t *testing.T) {
 	// reset whitelisted pairs
 	params, err := input.OracleKeeper.Params.Get(input.Ctx)
 	require.NoError(t, err)
-	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.NIBI, denoms.NUSD)}
+	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.ATOM, denoms.USD)}
 	input.OracleKeeper.Params.Set(input.Ctx, params)
 	for _, p := range input.OracleKeeper.WhitelistedPairs.Iterate(input.Ctx, collections.Range[asset.Pair]{}).Keys() {
 		input.OracleKeeper.WhitelistedPairs.Delete(input.Ctx, p)
 	}
-	input.OracleKeeper.WhitelistedPairs.Insert(input.Ctx, asset.Registry.Pair(denoms.NIBI, denoms.NUSD))
+	input.OracleKeeper.WhitelistedPairs.Insert(input.Ctx, asset.Registry.Pair(denoms.ATOM, denoms.USD))
 
 	votePeriodsPerWindow := sdk.NewDec(int64(input.OracleKeeper.SlashWindow(input.Ctx))).QuoInt64(int64(input.OracleKeeper.VotePeriod(input.Ctx))).TruncateInt64()
 	minValidPerWindow := input.OracleKeeper.MinValidPerWindow(input.Ctx)
@@ -248,14 +248,14 @@ func TestAbstainSlashing(t *testing.T) {
 	for i := uint64(0); i <= uint64(sdk.OneDec().Sub(minValidPerWindow).MulInt64(votePeriodsPerWindow).TruncateInt64()); i++ {
 		input.Ctx = input.Ctx.WithBlockHeight(input.Ctx.BlockHeight() + 1)
 
-		// Account 1, NIBI/NUSD
-		MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate}}, 0)
+		// Account 1, ATOM/USD
+		MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate}}, 0)
 
-		// Account 2, NIBI/NUSD, abstain vote
-		MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: sdk.OneDec().Neg()}}, 1)
+		// Account 2, ATOM/USD, abstain vote
+		MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: sdk.OneDec().Neg()}}, 1)
 
-		// Account 3, NIBI/NUSD
-		MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate}}, 2)
+		// Account 3, ATOM/USD
+		MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate}}, 2)
 
 		input.OracleKeeper.UpdateExchangeRates(input.Ctx)
 		input.OracleKeeper.SlashAndResetMissCounters(input.Ctx)

--- a/x/oracle/keeper/update_exchange_rates_test.go
+++ b/x/oracle/keeper/update_exchange_rates_test.go
@@ -23,7 +23,7 @@ import (
 func TestOracleThreshold(t *testing.T) {
 	exchangeRates := types.ExchangeRateTuples{
 		{
-			Pair:         asset.Registry.Pair(denoms.BTC, denoms.NUSD),
+			Pair:         asset.Registry.Pair(denoms.BTC, denoms.USD),
 			ExchangeRate: testExchangeRate,
 		},
 	}
@@ -92,7 +92,7 @@ func TestOracleThreshold(t *testing.T) {
 }
 
 func TestResetExchangeRates(t *testing.T) {
-	pair := asset.Registry.Pair(denoms.BTC, denoms.NUSD)
+	pair := asset.Registry.Pair(denoms.BTC, denoms.USD)
 	fixture, _ := Setup(t)
 
 	emptyVotes := map[asset.Pair]types.ExchangeRateVotes{}
@@ -139,7 +139,7 @@ func TestOracleTally(t *testing.T) {
 	for i, rate := range rates {
 		decExchangeRate := sdk.NewDecWithPrec(int64(rate*math.Pow10(OracleDecPrecision)), int64(OracleDecPrecision))
 		exchangeRateStr, err := types.ExchangeRateTuples{
-			{ExchangeRate: decExchangeRate, Pair: asset.Registry.Pair(denoms.BTC, denoms.NUSD)},
+			{ExchangeRate: decExchangeRate, Pair: asset.Registry.Pair(denoms.BTC, denoms.USD)},
 		}.ToString()
 		require.NoError(t, err)
 
@@ -159,7 +159,7 @@ func TestOracleTally(t *testing.T) {
 		}
 
 		vote := types.NewExchangeRateVote(
-			decExchangeRate, asset.Registry.Pair(denoms.BTC, denoms.NUSD), valAddrs[i], power)
+			decExchangeRate, asset.Registry.Pair(denoms.BTC, denoms.USD), valAddrs[i], power)
 		votes = append(votes, vote)
 
 		// change power of every three validator
@@ -220,35 +220,35 @@ func TestOracleRewardBand(t *testing.T) {
 	params, err := fixture.OracleKeeper.Params.Get(fixture.Ctx)
 	require.NoError(t, err)
 
-	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.NIBI, denoms.NUSD)}
+	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.ATOM, denoms.USD)}
 	fixture.OracleKeeper.Params.Set(fixture.Ctx, params)
 
 	// clear pairs to reset vote targets
 	for _, p := range fixture.OracleKeeper.WhitelistedPairs.Iterate(fixture.Ctx, collections.Range[asset.Pair]{}).Keys() {
 		fixture.OracleKeeper.WhitelistedPairs.Delete(fixture.Ctx, p)
 	}
-	fixture.OracleKeeper.WhitelistedPairs.Insert(fixture.Ctx, asset.Registry.Pair(denoms.NIBI, denoms.NUSD))
+	fixture.OracleKeeper.WhitelistedPairs.Insert(fixture.Ctx, asset.Registry.Pair(denoms.ATOM, denoms.USD))
 
 	rewardSpread := testExchangeRate.Mul(fixture.OracleKeeper.RewardBand(fixture.Ctx).QuoInt64(2))
 
-	// Account 1, nibi:nusd
+	// Account 1, atom:usd
 	MakeAggregatePrevoteAndVote(t, fixture, msgServer, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate.Sub(rewardSpread)},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate.Sub(rewardSpread)},
 	}, 0)
 
-	// Account 2, nibi:nusd
+	// Account 2, atom:usd
 	MakeAggregatePrevoteAndVote(t, fixture, msgServer, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate},
 	}, 1)
 
-	// Account 3, nibi:nusd
+	// Account 3, atom:usd
 	MakeAggregatePrevoteAndVote(t, fixture, msgServer, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate},
 	}, 2)
 
-	// Account 4, nibi:nusd
+	// Account 4, atom:usd
 	MakeAggregatePrevoteAndVote(t, fixture, msgServer, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate.Add(rewardSpread)},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate.Add(rewardSpread)},
 	}, 3)
 
 	fixture.OracleKeeper.UpdateExchangeRates(fixture.Ctx)
@@ -259,24 +259,24 @@ func TestOracleRewardBand(t *testing.T) {
 	assert.Equal(t, uint64(0), fixture.OracleKeeper.MissCounters.GetOr(fixture.Ctx, ValAddrs[3], 0))
 
 	// Account 1 will miss the vote due to raward band condition
-	// Account 1, nibi:nusd
+	// Account 1, atom:usd
 	MakeAggregatePrevoteAndVote(t, fixture, msgServer, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate.Sub(rewardSpread.Add(sdk.OneDec()))},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate.Sub(rewardSpread.Add(sdk.OneDec()))},
 	}, 0)
 
-	// Account 2, nibi:nusd
+	// Account 2, atom:usd
 	MakeAggregatePrevoteAndVote(t, fixture, msgServer, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate},
 	}, 1)
 
-	// Account 3, nibi:nusd
+	// Account 3, atom:usd
 	MakeAggregatePrevoteAndVote(t, fixture, msgServer, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate},
 	}, 2)
 
-	// Account 4, nibi:nusd
+	// Account 4, atom:usd
 	MakeAggregatePrevoteAndVote(t, fixture, msgServer, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate.Add(rewardSpread)},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate.Add(rewardSpread)},
 	}, 3)
 
 	fixture.OracleKeeper.UpdateExchangeRates(fixture.Ctx)
@@ -293,13 +293,13 @@ func TestOracleMultiRewardDistribution(t *testing.T) {
 
 	// SDR and KRW have the same voting power, but KRW has been chosen as referencepair by alphabetical order.
 	// Account 1, SDR, KRW
-	makeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: common.Pairbtc:nusd.String(), ExchangeRate: randomExchangeRate}, {Pair: common.Pairnibi:nusd.String(), ExchangeRate: randomExchangeRate}}, 0)
+	makeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: common.Pairbtc:usd.String(), ExchangeRate: randomExchangeRate}, {Pair: common.Pairatom:usd.String(), ExchangeRate: randomExchangeRate}}, 0)
 
 	// Account 2, SDR
-	makeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: common.Pairbtc:nusd.String(), ExchangeRate: randomExchangeRate}}, 1)
+	makeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: common.Pairbtc:usd.String(), ExchangeRate: randomExchangeRate}}, 1)
 
 	// Account 3, KRW
-	makeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: common.Pairbtc:nusd.String(), ExchangeRate: randomExchangeRate}}, 2)
+	makeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{{Pair: common.Pairbtc:usd.String(), ExchangeRate: randomExchangeRate}}, 2)
 
 	rewardAmt := sdk.NewInt(1e6)
 	err := input.BankKeeper.MintCoins(input.Ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(denoms.Gov, rewardAmt)))
@@ -323,53 +323,53 @@ func TestOracleMultiRewardDistribution(t *testing.T) {
 */
 
 func TestOracleExchangeRate(t *testing.T) {
-	// The following scenario tests four validators providing prices for eth:nusd, nibi:nusd, and btc:nusd.
-	// eth:nusd and nibi:nusd pass, but btc:nusd fails due to not enough validators voting.
+	// The following scenario tests four validators providing prices for eth:usd, atom:usd, and btc:usd.
+	// eth:usd and atom:usd pass, but btc:usd fails due to not enough validators voting.
 	input, h := Setup(t)
 
-	nibiNusdExchangeRate := sdk.NewDec(1000000)
-	ethNusdExchangeRate := sdk.NewDec(1000000)
-	btcNusdExchangeRate := sdk.NewDec(1e6)
+	atomUsdExchangeRate := sdk.NewDec(1000000)
+	ethUsdExchangeRate := sdk.NewDec(1000000)
+	btcusdExchangeRate := sdk.NewDec(1e6)
 
-	// Account 1, eth:nusd, nibi:nusd, btc:nusd
+	// Account 1, eth:usd, atom:usd, btc:usd
 	MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.ETH, denoms.NUSD), ExchangeRate: ethNusdExchangeRate},
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: nibiNusdExchangeRate},
-		{Pair: asset.Registry.Pair(denoms.BTC, denoms.NUSD), ExchangeRate: btcNusdExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ETH, denoms.USD), ExchangeRate: ethUsdExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: atomUsdExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.BTC, denoms.USD), ExchangeRate: btcusdExchangeRate},
 	}, 0)
 
-	// Account 2, eth:nusd, nibi:nusd
+	// Account 2, eth:usd, atom:usd
 	MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.ETH, denoms.NUSD), ExchangeRate: ethNusdExchangeRate},
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: nibiNusdExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ETH, denoms.USD), ExchangeRate: ethUsdExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: atomUsdExchangeRate},
 	}, 1)
 
-	// Account 3, eth:nusd, nibi:nusd, btc:nusd(abstain)
+	// Account 3, eth:usd, atom:usd, btc:usd(abstain)
 	MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.ETH, denoms.NUSD), ExchangeRate: ethNusdExchangeRate},
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: nibiNusdExchangeRate},
-		{Pair: asset.Registry.Pair(denoms.BTC, denoms.NUSD), ExchangeRate: sdk.ZeroDec()},
+		{Pair: asset.Registry.Pair(denoms.ETH, denoms.USD), ExchangeRate: ethUsdExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: atomUsdExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.BTC, denoms.USD), ExchangeRate: sdk.ZeroDec()},
 	}, 2)
 
-	// Account 4, eth:nusd, nibi:nusd, btc:nusd
+	// Account 4, eth:usd, atom:usd, btc:usd
 	MakeAggregatePrevoteAndVote(t, input, h, 0, types.ExchangeRateTuples{
-		{Pair: asset.Registry.Pair(denoms.ETH, denoms.NUSD), ExchangeRate: ethNusdExchangeRate},
-		{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: nibiNusdExchangeRate},
-		{Pair: asset.Registry.Pair(denoms.BTC, denoms.NUSD), ExchangeRate: sdk.ZeroDec()},
+		{Pair: asset.Registry.Pair(denoms.ETH, denoms.USD), ExchangeRate: ethUsdExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: atomUsdExchangeRate},
+		{Pair: asset.Registry.Pair(denoms.BTC, denoms.USD), ExchangeRate: sdk.ZeroDec()},
 	}, 3)
 
-	ethNusdRewards := sdk.NewInt64Coin("ETHREWARD", 1*common.TO_MICRO)
-	nibiNusdRewards := sdk.NewInt64Coin("NIBIREWARD", 1*common.TO_MICRO)
+	ethUsdRewards := sdk.NewInt64Coin("ETHREWARD", 1*common.TO_MICRO)
+	atomUsdRewards := sdk.NewInt64Coin("ATOMREWARD", 1*common.TO_MICRO)
 
-	AllocateRewards(t, input, sdk.NewCoins(ethNusdRewards), 1)
-	AllocateRewards(t, input, sdk.NewCoins(nibiNusdRewards), 1)
+	AllocateRewards(t, input, sdk.NewCoins(ethUsdRewards), 1)
+	AllocateRewards(t, input, sdk.NewCoins(atomUsdRewards), 1)
 
 	input.OracleKeeper.UpdateExchangeRates(input.Ctx)
 
-	// total reward pool for the current vote period is 1* common.TO_MICRO for eth:nusd and 1* common.TO_MICRO for nibi:nusd
+	// total reward pool for the current vote period is 1* common.TO_MICRO for eth:usd and 1* common.TO_MICRO for atom:usd
 	// val 1,2,3,4 all won on 2 pairs
 	// so total votes are 2 * 2 + 2 + 2 = 8
-	expectedRewardAmt := sdk.NewDecCoinsFromCoins(ethNusdRewards, nibiNusdRewards).
+	expectedRewardAmt := sdk.NewDecCoinsFromCoins(ethUsdRewards, atomUsdRewards).
 		QuoDec(sdk.NewDec(8)). // total votes
 		MulDec(sdk.NewDec(2))  // votes won by val1 and val2
 	rewards := input.DistrKeeper.GetValidatorOutstandingRewards(input.Ctx.WithBlockHeight(2), ValAddrs[0])
@@ -388,8 +388,8 @@ func TestOracleRandomPrices(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		for val := 0; val < 4; val++ {
 			MakeAggregatePrevoteAndVote(t, fixture, msgServer, 0, types.ExchangeRateTuples{
-				{Pair: asset.Registry.Pair(denoms.ETH, denoms.NUSD), ExchangeRate: sdk.NewDec(int64(rand.Uint64() % 1e6))},
-				{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: sdk.NewDec(int64(rand.Uint64() % 1e6))},
+				{Pair: asset.Registry.Pair(denoms.ETH, denoms.USD), ExchangeRate: sdk.NewDec(int64(rand.Uint64() % 1e6))},
+				{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: sdk.NewDec(int64(rand.Uint64() % 1e6))},
 			}, val)
 		}
 
@@ -404,15 +404,15 @@ func TestWhitelistedPairs(t *testing.T) {
 	params, err := fixture.OracleKeeper.Params.Get(fixture.Ctx)
 	require.NoError(t, err)
 
-	t.Log("whitelist ONLY nibi:nusd")
+	t.Log("whitelist ONLY atom:usd")
 	for _, p := range fixture.OracleKeeper.WhitelistedPairs.Iterate(fixture.Ctx, collections.Range[asset.Pair]{}).Keys() {
 		fixture.OracleKeeper.WhitelistedPairs.Delete(fixture.Ctx, p)
 	}
-	fixture.OracleKeeper.WhitelistedPairs.Insert(fixture.Ctx, asset.Registry.Pair(denoms.NIBI, denoms.NUSD))
+	fixture.OracleKeeper.WhitelistedPairs.Insert(fixture.Ctx, asset.Registry.Pair(denoms.ATOM, denoms.USD))
 
-	t.Log("vote and prevote from all vals on nibi:nusd")
+	t.Log("vote and prevote from all vals on atom:usd")
 	priceVoteFromVal := func(valIdx int, block int64) {
-		MakeAggregatePrevoteAndVote(t, fixture, msgServer, block, types.ExchangeRateTuples{{Pair: asset.Registry.Pair(denoms.NIBI, denoms.NUSD), ExchangeRate: testExchangeRate}}, valIdx)
+		MakeAggregatePrevoteAndVote(t, fixture, msgServer, block, types.ExchangeRateTuples{{Pair: asset.Registry.Pair(denoms.ATOM, denoms.USD), ExchangeRate: testExchangeRate}}, valIdx)
 	}
 	block := int64(0)
 	priceVoteFromVal(0, block)
@@ -420,8 +420,8 @@ func TestWhitelistedPairs(t *testing.T) {
 	priceVoteFromVal(2, block)
 	priceVoteFromVal(3, block)
 
-	t.Log("whitelist btc:nusd for next vote period")
-	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.NIBI, denoms.NUSD), asset.Registry.Pair(denoms.BTC, denoms.NUSD)}
+	t.Log("whitelist btc:usd for next vote period")
+	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.ATOM, denoms.USD), asset.Registry.Pair(denoms.BTC, denoms.USD)}
 	fixture.OracleKeeper.Params.Set(fixture.Ctx, params)
 	fixture.OracleKeeper.UpdateExchangeRates(fixture.Ctx)
 
@@ -431,22 +431,22 @@ func TestWhitelistedPairs(t *testing.T) {
 	assert.Equal(t, uint64(0), fixture.OracleKeeper.MissCounters.GetOr(fixture.Ctx, ValAddrs[2], 0))
 	assert.Equal(t, uint64(0), fixture.OracleKeeper.MissCounters.GetOr(fixture.Ctx, ValAddrs[3], 0))
 
-	t.Log("whitelisted pairs are {nibi:nusd, btc:nusd}")
+	t.Log("whitelisted pairs are {atom:usd, btc:usd}")
 	assert.Equal(t,
 		[]asset.Pair{
-			asset.Registry.Pair(denoms.BTC, denoms.NUSD),
-			asset.Registry.Pair(denoms.NIBI, denoms.NUSD),
+			asset.Registry.Pair(denoms.ATOM, denoms.USD),
+			asset.Registry.Pair(denoms.BTC, denoms.USD),
 		},
 		fixture.OracleKeeper.GetWhitelistedPairs(fixture.Ctx))
 
-	t.Log("vote from vals 0-3 on nibi:nusd (but not btc:nusd)")
+	t.Log("vote from vals 0-3 on atom:usd (but not btc:usd)")
 	priceVoteFromVal(0, block)
 	priceVoteFromVal(1, block)
 	priceVoteFromVal(2, block)
 	priceVoteFromVal(3, block)
 
-	t.Log("delete btc:nusd for next vote period")
-	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.NIBI, denoms.NUSD)}
+	t.Log("delete btc:usd for next vote period")
+	params.Whitelist = []asset.Pair{asset.Registry.Pair(denoms.ATOM, denoms.USD)}
 	fixture.OracleKeeper.Params.Set(fixture.Ctx, params)
 	perfs := fixture.OracleKeeper.UpdateExchangeRates(fixture.Ctx)
 
@@ -463,13 +463,13 @@ func TestWhitelistedPairs(t *testing.T) {
 	assert.EqualValues(t, 2, perf.AbstainCount)
 	assert.EqualValues(t, 0, perf.MissCount)
 
-	t.Log("btc:nusd must be deleted")
-	assert.Equal(t, []asset.Pair{asset.Registry.Pair(denoms.NIBI, denoms.NUSD)},
+	t.Log("btc:usd must be deleted")
+	assert.Equal(t, []asset.Pair{asset.Registry.Pair(denoms.ATOM, denoms.USD)},
 		fixture.OracleKeeper.GetWhitelistedPairs(fixture.Ctx))
 	require.False(t, fixture.OracleKeeper.WhitelistedPairs.Has(
-		fixture.Ctx, asset.Registry.Pair(denoms.BTC, denoms.NUSD)))
+		fixture.Ctx, asset.Registry.Pair(denoms.BTC, denoms.USD)))
 
-	t.Log("vote from vals 0-3 on nibi:nusd")
+	t.Log("vote from vals 0-3 on atom:usd")
 	priceVoteFromVal(0, block)
 	priceVoteFromVal(1, block)
 	priceVoteFromVal(2, block)

--- a/x/oracle/types/params.go
+++ b/x/oracle/types/params.go
@@ -40,21 +40,7 @@ var (
 	DefaultVoteThreshold = sdk.OneDec().Quo(sdk.NewDec(3)) // 33.33%
 	DefaultRewardBand    = sdk.NewDecWithPrec(2, 2)        // 2% (-1, 1)
 	DefaultWhitelist     = []asset.Pair{
-		// paired against NUSD
-		asset.Registry.Pair(denoms.NIBI, denoms.NUSD),
-		asset.Registry.Pair(denoms.BTC, denoms.NUSD),
-		asset.Registry.Pair(denoms.ETH, denoms.NUSD),
-		asset.Registry.Pair(denoms.ATOM, denoms.NUSD),
-		asset.Registry.Pair(denoms.BNB, denoms.NUSD),
-		asset.Registry.Pair(denoms.USDC, denoms.NUSD),
-		asset.Registry.Pair(denoms.USDT, denoms.NUSD),
-		// asset.Registry.Pair(denoms.OSMO, denoms.NUSD),
-		// asset.Registry.Pair(denoms.AVAX, denoms.NUSD),
-		// asset.Registry.Pair(denoms.SOL, denoms.NUSD),
-		// asset.Registry.Pair(denoms.ADA, denoms.NUSD),
-
 		// paired against the US fiat dollar
-		asset.Registry.Pair(denoms.NIBI, denoms.USD),
 		asset.Registry.Pair(denoms.BTC, denoms.USD),
 		asset.Registry.Pair(denoms.ETH, denoms.USD),
 		asset.Registry.Pair(denoms.ATOM, denoms.USD),


### PR DESCRIPTION
# Description

Curates the default genesis whitelist of oracle pairs for mainnet.

Since we won't have NUSD at genesis time, we don't need the oracle prices paired against NUSD.
Since we don't have NIBI prices on external exchanges at genesis time, we can remove it and add it later.

# Purpose

Smooth mainnet launch