### PR TITLE
fix(inflation): lock default inflation params with tokenomics curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1606](https://github.com/NibiruChain/nibiru/pull/1606) - fix(perp): emit `MarketUpdatedEvent` in the absence of index price
 * [#1649](https://github.com/NibiruChain/nibiru/pull/1649) - fix(ledger): fix ledger for newer macos versions
 * [#1655](https://github.com/NibiruChain/nibiru/pull/1655) - fix(inflation): inflate NIBI correctly to strategic treasury account
+* [#1661](https://github.com/NibiruChain/nibiru/pull/1661) - fix(inflation): update default params to follow tokenomics curve
 
 ## [v0.21.10]
 

--- a/x/inflation/keeper/inflation.go
+++ b/x/inflation/keeper/inflation.go
@@ -111,7 +111,7 @@ func (k Keeper) GetCirculatingSupply(ctx sdk.Context, mintDenom string) sdkmath.
 	return k.bankKeeper.GetSupply(ctx, mintDenom).Amount
 }
 
-// GetInflationRate returns the inflation rate for the current period.
+// GetInflationRate returns the annualized inflation rate for the current period.
 func (k Keeper) GetInflationRate(ctx sdk.Context, mintDenom string) sdk.Dec {
 	epochMintProvision := k.GetEpochMintProvision(ctx)
 	if epochMintProvision.IsZero() {

--- a/x/inflation/keeper/inflation_test.go
+++ b/x/inflation/keeper/inflation_test.go
@@ -37,12 +37,12 @@ func TestMintAndAllocateInflation(t *testing.T) {
 		{
 			name:                             "pass",
 			coinsToMint:                      sdk.NewCoin(denoms.NIBI, sdk.NewInt(1_000_000)),
-			expectedStakingAmt:               sdk.NewCoin(denoms.NIBI, sdk.NewInt(278_000)),
-			expectedStrategicAmt:             sdk.NewCoin(denoms.NIBI, sdk.NewInt(100_000)),
-			expectedCommunityAmt:             sdk.NewCoin(denoms.NIBI, sdk.NewInt(622_000)),
-			expectedStakingRewardsBalance:    sdk.NewCoin(denoms.NIBI, sdk.NewInt(278_000)),
-			expectedStrategicReservesBalance: sdk.NewCoin(denoms.NIBI, sdk.NewInt(100_000)),
-			expectedCommunityPoolBalance:     sdk.NewDecCoins(sdk.NewDecCoin(denoms.NIBI, sdk.NewInt(622_000))),
+			expectedStakingAmt:               sdk.NewCoin(denoms.NIBI, sdk.NewInt(277_572)),
+			expectedStrategicAmt:             sdk.NewCoin(denoms.NIBI, sdk.NewInt(370_837)),
+			expectedCommunityAmt:             sdk.NewCoin(denoms.NIBI, sdk.NewInt(351_591)),
+			expectedStakingRewardsBalance:    sdk.NewCoin(denoms.NIBI, sdk.NewInt(277_572)),
+			expectedStrategicReservesBalance: sdk.NewCoin(denoms.NIBI, sdk.NewInt(370_837)),
+			expectedCommunityPoolBalance:     sdk.NewDecCoins(sdk.NewDecCoin(denoms.NIBI, sdk.NewInt(351_591))),
 			rootAccount:                      "nibi1qyqf35fkhn73hjr70442fctpq8prpqr9ysj9sn",
 		},
 		{
@@ -59,12 +59,12 @@ func TestMintAndAllocateInflation(t *testing.T) {
 		{
 			name:                             "pass - no root account",
 			coinsToMint:                      sdk.NewCoin(denoms.NIBI, sdk.NewInt(1_000_000)),
-			expectedStakingAmt:               sdk.NewCoin(denoms.NIBI, sdk.NewInt(278_000)),
-			expectedStrategicAmt:             sdk.NewCoin(denoms.NIBI, sdk.NewInt(100_000)),
-			expectedCommunityAmt:             sdk.NewCoin(denoms.NIBI, sdk.NewInt(622_000)),
-			expectedStakingRewardsBalance:    sdk.NewCoin(denoms.NIBI, sdk.NewInt(278_000)),
-			expectedStrategicReservesBalance: sdk.NewCoin(denoms.NIBI, sdk.NewInt(100_000)),
-			expectedCommunityPoolBalance:     sdk.NewDecCoins(sdk.NewDecCoin(denoms.NIBI, sdk.NewInt(622_000))),
+			expectedStakingAmt:               sdk.NewCoin(denoms.NIBI, sdk.NewInt(277_572)),
+			expectedStrategicAmt:             sdk.NewCoin(denoms.NIBI, sdk.NewInt(370_837)),
+			expectedCommunityAmt:             sdk.NewCoin(denoms.NIBI, sdk.NewInt(351_591)),
+			expectedStakingRewardsBalance:    sdk.NewCoin(denoms.NIBI, sdk.NewInt(277_572)),
+			expectedStrategicReservesBalance: sdk.NewCoin(denoms.NIBI, sdk.NewInt(370_837)),
+			expectedCommunityPoolBalance:     sdk.NewDecCoins(sdk.NewDecCoin(denoms.NIBI, sdk.NewInt(351_591))),
 			rootAccount:                      "",
 		},
 	}
@@ -82,9 +82,9 @@ func TestMintAndAllocateInflation(t *testing.T) {
 
 			staking, strategic, community, err := nibiruApp.InflationKeeper.MintAndAllocateInflation(ctx, tc.coinsToMint, types.DefaultParams())
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedStakingAmt, staking)
-			assert.Equal(t, tc.expectedStrategicAmt, strategic)
-			assert.Equal(t, tc.expectedCommunityAmt, community)
+			assert.EqualValues(t, tc.expectedStakingAmt, staking)
+			assert.EqualValues(t, tc.expectedStrategicAmt, strategic)
+			assert.EqualValues(t, tc.expectedCommunityAmt, community)
 
 			// Get balances
 			var balanceStrategicReserve sdk.Coin
@@ -110,9 +110,9 @@ func TestMintAndAllocateInflation(t *testing.T) {
 			balanceCommunityPool := nibiruApp.DistrKeeper.GetFeePoolCommunityCoins(ctx)
 
 			require.NoError(t, err, tc.name)
-			assert.Equal(t, tc.expectedStakingRewardsBalance, balanceStakingRewards)
-			assert.Equal(t, tc.expectedStrategicReservesBalance, balanceStrategicReserve)
-			assert.Equal(t, tc.expectedCommunityPoolBalance, balanceCommunityPool)
+			assert.EqualValues(t, tc.expectedStakingRewardsBalance, balanceStakingRewards)
+			assert.EqualValues(t, tc.expectedStrategicReservesBalance, balanceStrategicReserve)
+			assert.EqualValues(t, tc.expectedCommunityPoolBalance, balanceCommunityPool)
 		})
 	}
 }

--- a/x/inflation/keeper/inflation_test.go
+++ b/x/inflation/keeper/inflation_test.go
@@ -141,13 +141,13 @@ func TestGetCirculatingSupplyAndInflationRate(t *testing.T) {
 			"high supply",
 			sdk.TokensFromConsensusPower(800_000_000, sdk.DefaultPowerReduction),
 			func(nibiruApp *app.NibiruApp, ctx sdk.Context) {},
-			sdk.MustNewDecFromStr("50.674438476562500000"),
+			sdk.MustNewDecFromStr("50.711975096875000000"),
 		},
 		{
 			"low supply",
 			sdk.TokensFromConsensusPower(400_000_000, sdk.DefaultPowerReduction),
 			func(nibiruApp *app.NibiruApp, ctx sdk.Context) {},
-			sdk.MustNewDecFromStr("101.348876953125000000"),
+			sdk.MustNewDecFromStr("101.423950193750000000"),
 		},
 	}
 	for _, tc := range testCases {
@@ -165,10 +165,10 @@ func TestGetCirculatingSupplyAndInflationRate(t *testing.T) {
 			require.NoError(t, err)
 
 			circulatingSupply := nibiruApp.InflationKeeper.GetCirculatingSupply(ctx, denoms.NIBI)
-			require.EqualValues(t, tc.supply, circulatingSupply)
+			assert.EqualValues(t, tc.supply, circulatingSupply)
 
 			inflationRate := nibiruApp.InflationKeeper.GetInflationRate(ctx, denoms.NIBI)
-			require.Equal(t, tc.expInflationRate, inflationRate)
+			assert.EqualValues(t, tc.expInflationRate, inflationRate)
 		})
 	}
 }

--- a/x/inflation/types/inflation_calculation_test.go
+++ b/x/inflation/types/inflation_calculation_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCalculateEpochMintProvision(t *testing.T) {
@@ -17,42 +17,42 @@ func TestCalculateEpochMintProvision(t *testing.T) {
 		{
 			"pass - initial period",
 			0,
-			sdk.MustNewDecFromStr("1110672624143.835616438356000000"),
+			sdk.MustNewDecFromStr("1111495344589.041095890410000000"),
 		},
 		{
 			"pass - period 1",
 			1,
-			sdk.MustNewDecFromStr("555878103595.890410958904000000"),
+			sdk.MustNewDecFromStr("556289865136.986301369863000000"),
 		},
 		{
 			"pass - period 2",
 			2,
-			sdk.MustNewDecFromStr("278480843321.917808219178000000"),
+			sdk.MustNewDecFromStr("278687125410.958904109589000000"),
 		},
 		{
 			"pass - period 3",
 			3,
-			sdk.MustNewDecFromStr("139782213184.931506849315000000"),
+			sdk.MustNewDecFromStr("139885755547.945205479452000000"),
 		},
 		{
 			"pass - period 4",
 			4,
-			sdk.MustNewDecFromStr("70432898116.438356164383000000"),
+			sdk.MustNewDecFromStr("70485070616.438356164383000000"),
 		},
 		{
 			"pass - period 5",
 			5,
-			sdk.MustNewDecFromStr("35758240582.191780821917000000"),
+			sdk.MustNewDecFromStr("35784728150.684931506849000000"),
 		},
 		{
 			"pass - period 6",
 			6,
-			sdk.MustNewDecFromStr("18420911815.068493150684000000"),
+			sdk.MustNewDecFromStr("18434556917.808219178082000000"),
 		},
 		{
 			"pass - period 7",
 			7,
-			sdk.MustNewDecFromStr("9752247431.506849315068000000"),
+			sdk.MustNewDecFromStr("9759471301.369863013698000000"),
 		},
 	}
 	for _, tc := range testCases {
@@ -62,7 +62,7 @@ func TestCalculateEpochMintProvision(t *testing.T) {
 				tc.period,
 			)
 
-			require.Equal(t, tc.expEpochProvision, epochMintProvisions)
+			assert.EqualValues(t, tc.expEpochProvision, epochMintProvisions)
 		})
 	}
 }
@@ -72,5 +72,5 @@ func TestCalculateEpochMintProvision_ZeroEpochs(t *testing.T) {
 	params.EpochsPerPeriod = 0
 
 	epochMintProvisions := CalculateEpochMintProvision(params, 1)
-	require.Equal(t, epochMintProvisions, sdk.ZeroDec())
+	assert.EqualValues(t, epochMintProvisions, sdk.ZeroDec())
 }

--- a/x/inflation/types/params.go
+++ b/x/inflation/types/params.go
@@ -18,9 +18,9 @@ var (
 var (
 	DefaultInflation              = true
 	DefaultExponentialCalculation = ExponentialCalculation{
-		A: sdk.NewDec(int64(405_000_000)),
+		A: sdk.NewDec(int64(405_300_000)),
 		R: sdk.NewDecWithPrec(50, 2), // 50%
-		C: sdk.NewDecWithPrec(395_507_8125, 4),
+		C: sdk.NewDecWithPrec(395_800_775, 3),
 	}
 	DefaultInflationDistribution = InflationDistribution{
 		StakingRewards:    sdk.NewDecWithPrec(27_8, 3),  // 27.8%

--- a/x/inflation/types/params.go
+++ b/x/inflation/types/params.go
@@ -23,9 +23,9 @@ var (
 		C: sdk.NewDecWithPrec(395_800_775, 3),
 	}
 	DefaultInflationDistribution = InflationDistribution{
-		StakingRewards:    sdk.NewDecWithPrec(27_8, 3),  // 27.8%
-		CommunityPool:     sdk.NewDecWithPrec(62_20, 4), // 62.20%
-		StrategicReserves: sdk.NewDecWithPrec(10, 2),    // 10%
+		CommunityPool:     sdk.NewDecWithPrec(35_159141, 6), // 35.159141%
+		StakingRewards:    sdk.NewDecWithPrec(27_757217, 6), // 27.757217%
+		StrategicReserves: sdk.NewDecWithPrec(37_083642, 6), // 37.083642%
 	}
 	DefaultEpochsPerPeriod = uint64(365)
 )

--- a/x/inflation/types/params.go
+++ b/x/inflation/types/params.go
@@ -23,9 +23,9 @@ var (
 		C: sdk.NewDecWithPrec(395_800_775, 3),
 	}
 	DefaultInflationDistribution = InflationDistribution{
-		CommunityPool:     sdk.NewDecWithPrec(35_159141, 6), // 35.159141%
-		StakingRewards:    sdk.NewDecWithPrec(27_757217, 6), // 27.757217%
-		StrategicReserves: sdk.NewDecWithPrec(37_083642, 6), // 37.083642%
+		CommunityPool:     sdk.NewDecWithPrec(35_159141, 8), // 35.159141%
+		StakingRewards:    sdk.NewDecWithPrec(27_757217, 8), // 27.757217%
+		StrategicReserves: sdk.NewDecWithPrec(37_083642, 8), // 37.083642%
 	}
 	DefaultEpochsPerPeriod = uint64(365)
 )
@@ -120,7 +120,7 @@ func validateInflationDistribution(i interface{}) error {
 
 	totalProportions := v.StakingRewards.Add(v.StrategicReserves).Add(v.CommunityPool)
 	if !totalProportions.Equal(sdk.OneDec()) {
-		return errors.New("total distributions ratio should be 1")
+		return fmt.Errorf("total distributions ratio should be 1, but it is currently %s", totalProportions.String())
 	}
 
 	return nil


### PR DESCRIPTION
# Description

- Adjusts the default x/inflation params to follow the tokenomics curve
See math at https://docs.google.com/spreadsheets/d/1eL0E_GcIJajXdDSl3jUwKK7mKycvmJltXFJxD1sout4/edit#gid=0

# Purpose

Follows the inflation curve
