### PR TITLE
docs(CHANGELOG.md): Correct the change log, providing clarity on what's released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### State Machine Breaking 
 
 #### For next mainnet version:
+
 * [#1682](https://github.com/NibiruChain/nibiru/pull/1682) - feat!: add upgrade handler for v1.1.0
 * [#1688](https://github.com/NibiruChain/nibiru/pull/1688) - fix(inflation)!: make default inflation allocation follow tokenomics
 
 #### Dapp modules: perp, spot, etc.
+
 * [#1573](https://github.com/NibiruChain/nibiru/pull/1573) - feat(perp): Close markets and compute settlement price
 * [#1632](https://github.com/NibiruChain/nibiru/pull/1632) - feat(perp): Add settle position transaction
 * [#1656](https://github.com/NibiruChain/nibiru/pull/1656) - feat(perp): Make the collateral denom a stateful collections.Item
@@ -60,12 +62,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Non-breaking/Compatible Improvements
 
 * [#1679](https://github.com/NibiruChain/nibiru/pull/1679) - test(perp): add more tests for perp module msg server
+* [#1690](https://github.com/NibiruChain/nibiru/pull/1690) - docs(CHANGELOG.md): Correct the change log, providing clarity on what's released.
 
 ### Dependencies
+
 - Bump `github.com/spf13/cast` from 1.5.1 to 1.6.0 ([#1689](https://github.com/NibiruChain/nibiru/pull/1689))
 - Bump `github.com/grpc-ecosystem/grpc-gateway/v2` from 2.18.0 to 2.18.1 ([#1675](https://github.com/NibiruChain/nibiru/pull/1675))
 - Bump `cosmossdk.io/math` from 1.1.2 to 1.2.0 ([#1676](https://github.com/NibiruChain/nibiru/pull/1676))
-- Bump `github.com/spf13/cast` from 1.5.1 to 1.6.0 ([#1689](https://github.com/NibiruChain/nibiru/pull/1689))
 
 ## [v1.1.0] - 2023-11-20
 
@@ -125,6 +128,7 @@ v0.47.5.
 * [#1659](https://github.com/NibiruChain/nibiru/pull/1659) - refactor(oracle): curate oracle default whitelist
 
 ### Dependencies
+
 - Bump `github.com/prometheus/client_golang` from 1.16.0 to 1.17.0 ([#1605](https://github.com/NibiruChain/nibiru/pull/1605))
 - Bump `bufbuild/buf-setup-action` from 1.26.1 to 1.28.1 ([#1624](https://github.com/NibiruChain/nibiru/pull/1624), [#1641](https://github.com/NibiruChain/nibiru/pull/1641), [#1654](https://github.com/NibiruChain/nibiru/pull/1654), [#1671](https://github.com/NibiruChain/nibiru/pull/1671), [#1673](https://github.com/NibiruChain/nibiru/pull/1673))
 - Bump `stefanzweifel/git-auto-commit-action` from 4 to 5 ([#1625](https://github.com/NibiruChain/nibiru/pull/1625))


### PR DESCRIPTION
docs(CHANGELOG.md): Correct the change log, providing clarity on what's released.

Our CHANGELOG.md file has gotten a bit messy. This PR fixes that.

Changes as far back as v0.19.2 now have a clear separation between
non-breaking and breaking. The format is also updated to more accurately
follow the conventions outlined on https://keepachangelog.com/en/1.1.0/.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


<!-- end of auto-generated comment: release notes by coderabbit.ai -->