### PR TITLE
ci: replace `master` with `main`

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Publish Docker Image
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - v*
 
@@ -43,7 +43,7 @@ jobs:
       
       - name: Build and push latest chaosnet image
         uses: docker/build-push-action@v5
-        if: startsWith(github.ref, 'refs/heads/master')
+        if: startsWith(github.ref, 'refs/heads/main')
         with:
           file: contrib/docker/chaosnet.Dockerfile
           context: .

--- a/.github/workflows/e2e-wasm.yml
+++ b/.github/workflows/e2e-wasm.yml
@@ -8,7 +8,7 @@ on:
 # Allow concurrent runs on main/release branches but isolates other branches 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
-  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) }}
+  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
 
 jobs:
   get-release:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,9 +1,9 @@
 name: Linter
 
-# Run on every master merge and on PRs.
+# Run on every main merge and on PRs.
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
     paths: ["**.go", "**.proto", "go.mod", "go.sum"]
   pull_request:
     paths: ["**.go", "**.proto", "go.mod", "go.sum"]
@@ -11,7 +11,7 @@ on:
 # Allow concurrent runs on main/release branches but isolates other branches
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
-  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) }}
+  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
 
 permissions:
   contents: read

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ on:
 # Allow concurrent runs on main/release branches but isolates other branches
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
-  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) }}
+  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
 
 jobs:
   integration-tests:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -8,7 +8,7 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: seferov/pr-lint-action@master
+      - uses: seferov/pr-lint-action@main
         with:
           # taken from https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c
           title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)'

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -8,9 +8,11 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: seferov/pr-lint-action@main
+      - uses: seferov/pr-lint-action@v1.2.0
         with:
           # taken from https://gist.github.com/marcojahn/482410b728c31b221b70ea6d2c433f0c
           title-regex: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)'
-          title-regex-flags: "g" # optional
-          error-message: "Please follow conventional commit style: https://www.conventionalcommits.org/en/v1.0.0/" # optional
+          # title-regex-flags (Optional)
+          title-regex-flags: "g" 
+          # error-message (Optional)
+          error-message: "Please follow conventional commit style: https://www.conventionalcommits.org/en/v1.0.0/" 

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -9,7 +9,7 @@ on:
 # Allow concurrent runs on main/release branches but isolates other branches 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
-  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) }}
+  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
 
 permissions:
   contents: read

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,7 @@ on:
 # Allow concurrent runs on main/release branches but isolates other branches
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
-  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) }}
+  cancel-in-progress: ${{ ! (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
 
 jobs:
   unit-tests:


### PR DESCRIPTION
# Description

Substitute references from `master` branch to `main` branch.

# Purpose

![image](https://github.com/NibiruChain/nibiru/assets/5478483/5fe2dd74-7494-446b-b50e-d25cda5e8e8f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to reference the new default branch name "main" instead of "master."

- **Documentation**
  - Updated all workflow files to reflect the industry-wide shift in naming conventions for the default branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->