### PR TITLE
ci: test chaosnet script in CI after build

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,10 +49,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Go
+      - name: "Set up Go"
         uses: actions/setup-go@v5
         with:
           go-version: 1.21
 
-      - name: Build the nibid binary
+      - name: "Build the nibid binary"
         run: make build
+
+      - name: "Run scripts/chaosnet.sh (Used in Docker image)"
+        run:  bash contrib/scripts/chaosnet.sh &

--- a/CHAOSNET.md
+++ b/CHAOSNET.md
@@ -1,4 +1,12 @@
-# How to use
+# CHAOSNET
+
+- [How to use "chaosnet"](#how-to-use-chaosnet)
+- [How to force pull images from the registry](#how-to-force-pull-images-from-the-registry)
+- [Endpoints](#endpoints)
+- [FAQ](#faq)
+  - [`make chaosnet` says that "Additional property name is not allowed"](#make-chaosnet-says-that-additional-property-name-is-not-allowed)
+
+## How to use "chaosnet" 
 
 Before running
 

--- a/contrib/scripts/chaosnet.sh
+++ b/contrib/scripts/chaosnet.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+#
+# This script is used in tandem with `contrib/docker/chaosnet.Dockerfile` to
+# run nodes for Nibiru Chain networks inside docker containers. 
+# - See CHAOSNET.md for usage instructions.
 set -e
 
 # Set localnet settings

--- a/x/perp/v2/integration/action/position.go
+++ b/x/perp/v2/integration/action/position.go
@@ -273,6 +273,8 @@ func (i insertPosition) Do(app *app.NibiruApp, ctx sdk.Context) (sdk.Context, er
 	return ctx, nil, true
 }
 
+// InsertPosition: Adds a position into state without a corresponding market
+// order.
 func InsertPosition(modifiers ...positionModifier) action.Action {
 	position := types.Position{
 		Pair:                            asset.Registry.Pair(denoms.BTC, denoms.USDC),


### PR DESCRIPTION
# Purpose

Will help us maintain the script and dockerfile 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated step names in CI pipeline for clarity.
  
- **New Features**
  - Integrated a new step in the CI process to run the "chaosnet.sh" script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->