### PR TITLE
refactor(inflation): make inflation disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#1688](https://github.com/NibiruChain/nibiru/pull/1688) - fix(inflation)!: make default inflation allocation follow tokenomics
 * [#1682](https://github.com/NibiruChain/nibiru/pull/1682) - feat!: add upgrade handler for v1.1.0
 * [#1706](https://github.com/NibiruChain/nibiru/pull/1706) - fix: `v1.1.0` upgrade handler
+* [#1712](https://github.com/NibiruChain/nibiru/pull/1712) - refactor(inflation): turn inflation off by default
 
 #### Dapp modules: perp, spot, etc
 
@@ -79,7 +80,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Bump `golang` from 1.19 to 1.21 ([#1698](https://github.com/NibiruChain/nibiru/pull/1698))
 * [#1678](https://github.com/NibiruChain/nibiru/pull/1678) - chore(deps): collections to v0.4.0 for math.Int value encoder
 * Bump `rocksdb` from 8.1.1 to 8.8.1
-
 
 ## [v1.1.0] - 2023-11-20
 

--- a/x/inflation/keeper/hooks_test.go
+++ b/x/inflation/keeper/hooks_test.go
@@ -16,6 +16,10 @@ import (
 func TestEpochIdentifierAfterEpochEnd(t *testing.T) {
 	nibiruApp, ctx := testapp.NewNibiruTestAppAndContext()
 
+	params := nibiruApp.InflationKeeper.GetParams(ctx)
+	params.InflationEnabled = true
+	nibiruApp.InflationKeeper.SetParams(ctx, params)
+
 	feePoolOld := nibiruApp.DistrKeeper.GetFeePool(ctx)
 	nibiruApp.EpochsKeeper.AfterEpochEnd(ctx, epochstypes.DayEpochID, 1)
 	feePoolNew := nibiruApp.DistrKeeper.GetFeePool(ctx)

--- a/x/inflation/keeper/inflation_test.go
+++ b/x/inflation/keeper/inflation_test.go
@@ -149,13 +149,21 @@ func TestGetCirculatingSupplyAndInflationRate(t *testing.T) {
 		{
 			"high supply",
 			sdk.TokensFromConsensusPower(800_000_000, sdk.DefaultPowerReduction),
-			func(nibiruApp *app.NibiruApp, ctx sdk.Context) {},
+			func(nibiruApp *app.NibiruApp, ctx sdk.Context) {
+				params := nibiruApp.InflationKeeper.GetParams(ctx)
+				params.InflationEnabled = true
+				nibiruApp.InflationKeeper.SetParams(ctx, params)
+			},
 			sdk.MustNewDecFromStr("27.095518287362700000"),
 		},
 		{
 			"low supply",
 			sdk.TokensFromConsensusPower(400_000_000, sdk.DefaultPowerReduction),
-			func(nibiruApp *app.NibiruApp, ctx sdk.Context) {},
+			func(nibiruApp *app.NibiruApp, ctx sdk.Context) {
+				params := nibiruApp.InflationKeeper.GetParams(ctx)
+				params.InflationEnabled = true
+				nibiruApp.InflationKeeper.SetParams(ctx, params)
+			},
 			sdk.MustNewDecFromStr("54.191036574725400000"),
 		},
 	}

--- a/x/inflation/types/inflation_calculation_test.go
+++ b/x/inflation/types/inflation_calculation_test.go
@@ -24,6 +24,7 @@ var ExpectedTotalInflation = sdk.NewDec(810_600_000_000_000)
 
 func TestCalculateEpochMintProvision(t *testing.T) {
 	params := DefaultParams()
+	params.InflationEnabled = true
 
 	epochId := uint64(0)
 	totalInflation := sdk.ZeroDec()

--- a/x/inflation/types/params.go
+++ b/x/inflation/types/params.go
@@ -18,7 +18,7 @@ var (
 )
 
 var (
-	DefaultInflation         = true
+	DefaultInflation         = false
 	DefaultPolynomialFactors = []sdk.Dec{
 		sdk.MustNewDecFromStr("-0.00014903"),
 		sdk.MustNewDecFromStr("0.07527647"),


### PR DESCRIPTION
# Description

Disables inflation by default

# Purpose

If inflation is enabled, then it will begin as soon as we upgrade the chain. It's preferable to separate out inflation into two discrete steps:
- upgrade the chain with the inflation module
- pass a gov proposal to turn on inflation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to reflect recent modifications.

- **Tests**
  - Enhanced test cases to include setting inflation parameters before execution.
  - Added logic to test scenarios for high and low supply conditions in inflation calculations.
  - Adjusted tests to account for the new default state of inflation being disabled.

- **Refactor**
  - Changed the default inflation parameter to improve system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->