### PR TITLE
ci: remove temp directory caching which causes stale libs

### DIFF
--- a/contrib/docker/chaosnet.Dockerfile
+++ b/contrib/docker/chaosnet.Dockerfile
@@ -8,7 +8,6 @@ COPY . .
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,target=/go/pkg \
-  --mount=type=cache,target=/nibiru/temp \
   make build
 
 FROM alpine:latest


### PR DESCRIPTION
# Description

Remotes the `/nibiru/temp` cache directory. 

# Purpose

Caching the `temp` directory causes the wrong version of the library to used, which is especially bad when we do multi-platform builds. For example, [this run](https://github.com/NibiruChain/nibiru/actions/runs/7251871181/job/19755132894) was broken because an incompatible libwasmvm was cached.