### PR TITLE
ci: remove ld_classic flag

### DIFF
--- a/contrib/make/build.mk
+++ b/contrib/make/build.mk
@@ -71,7 +71,7 @@ BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 CGO_CFLAGS  := -I$(TEMPDIR)/include
 CGO_LDFLAGS := -L$(TEMPDIR)/lib
 ifeq ($(OS_NAME),darwin)
-	CGO_LDFLAGS += -Wl,-ld_classic -lrocksdb -lstdc++ -lz -lbz2
+	CGO_LDFLAGS += -lrocksdb -lstdc++ -lz -lbz2
 else
 	CGO_LDFLAGS += -static -lm -lbz2
 endif


### PR DESCRIPTION
# Purpose / Abstract

The ld_classic flag is not necessary on Darwin (Mac) machines and causes build errors. 

```
ld: library not found for -ld_classic
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Modified build settings for macOS to enhance compatibility and performance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->