### PR TITLE
ci: remove sim test from PRs

### DIFF
--- a/.github/workflows/simulation-tests.yml
+++ b/.github/workflows/simulation-tests.yml
@@ -8,10 +8,6 @@ on:
   schedule:
     # once per day
     - cron: "0 0 * * *"
-  pull_request:
-    branches:
-      # every pull request to default branch
-      - main
 
 jobs:
   test-sim-nondeterminism:


### PR DESCRIPTION
# Purpose / Abstract

Simulation tests take a long time on PRs, so we'll just run them on `main` branch push and on a once daily cron job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated simulation tests to run on a daily schedule instead of on every pull request to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->