### PR TITLE
fix(inflation-docs): 1 Document inflation, 2 delete unused code, 3 fix CI

### DIFF
--- a/.github/workflows/e2e-wasm.yml
+++ b/.github/workflows/e2e-wasm.yml
@@ -39,6 +39,7 @@ jobs:
           rm nibid*.gz
           mv nibid* nibid || true
           mv nibid /usr/local/bin/
+          echo "nibid version: $(nibid version)"
 
       - name: "Install just"
         # casey/just: https://just.systems/man/en/chapter_6.html

--- a/.github/workflows/e2e-wasm.yml
+++ b/.github/workflows/e2e-wasm.yml
@@ -15,40 +15,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Download release
-        id: latest_release
-        uses: pozetroninc/github-action-get-latest-release@v0.7.0
-        with:
-          repository: ${{ github.repository }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: download release
-        uses: robinraju/release-downloader@v1.9
+      - name: "Set up Go"
+        uses: actions/setup-go@v5
         with:
-          # uses latest (including drafts)
-          # tag: ${{ steps.latest_release.outputs.release }}
-          # uses latest (excluding drafts) as tagged by GitHub
-          latest: true
-          fileName: "*linux_amd64.tar.gz"
-
-      - name: unpack release
-        run: |
-          tar -xzf *linux_amd64.tar.gz
-          rm nibid*.gz
-          mv nibid* nibid || true
-          mv nibid /usr/local/bin/
-          echo "nibid version: $(nibid version)"
+          go-version: 1.21
 
       - name: "Install just"
         # casey/just: https://just.systems/man/en/chapter_6.html
         # taiki-e/install-action: https://github.com/taiki-e/install-action
         uses: taiki-e/install-action@just
 
-      - name: "launch localnet"
+      - name: "Build the nibid binary + Run localnet"
         run: |
-          just localnet --no-build
+          just install
+          just localnet
 
       - name: run e2e tests
         run: |

--- a/.github/workflows/e2e-wasm.yml
+++ b/.github/workflows/e2e-wasm.yml
@@ -5,7 +5,7 @@ on:
   # On normal PRs or when workflow goreleaser finishes, as it gets the last release tag.
   pull_request:
 
-# Allow concurrent runs on main/release branches but isolates other branches 
+# Allow concurrent runs on main/release branches but isolates other branches
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}
   cancel-in-progress: ${{ ! (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
@@ -28,7 +28,7 @@ jobs:
         uses: robinraju/release-downloader@v1.9
         with:
           # uses latest (including drafts)
-          # tag: ${{ steps.latest_release.outputs.release }} 
+          # tag: ${{ steps.latest_release.outputs.release }}
           # uses latest (excluding drafts) as tagged by GitHub
           latest: true
           fileName: "*linux_amd64.tar.gz"
@@ -39,9 +39,14 @@ jobs:
           rm nibid*.gz
           mv nibid* nibid || true
 
-      - name: launch localnet
+      - name: "Install just"
+        # casey/just: https://just.systems/man/en/chapter_6.html
+        # taiki-e/install-action: https://github.com/taiki-e/install-action
+        uses: taiki-e/install-action@just
+
+      - name: "launch localnet"
         run: |
-          sh ./contrib/scripts/e2e/localnet.sh
+          just localnet --no-build
 
       - name: run e2e tests
         run: |

--- a/.github/workflows/e2e-wasm.yml
+++ b/.github/workflows/e2e-wasm.yml
@@ -1,5 +1,5 @@
 ---
-name: CosmWasm e2e contract tests
+name: CosmWasm e2e tests
 
 on:
   # On normal PRs or when workflow goreleaser finishes, as it gets the last release tag.
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ ! (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
 
 jobs:
-  get-release:
+  e2e-wasm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-wasm.yml
+++ b/.github/workflows/e2e-wasm.yml
@@ -15,21 +15,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: "Set up Go"
-        uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          fetch-depth: 0
+      - name: Download release
+        id: latest_release
+        uses: pozetroninc/github-action-get-latest-release@v0.7.0
+        with:
+          repository: ${{ github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: download release
+        uses: robinraju/release-downloader@v1.9
+        with:
+          # uses latest (including drafts)
+          # tag: ${{ steps.latest_release.outputs.release }}
+          # uses latest (excluding drafts) as tagged by GitHub
+          latest: true
+          fileName: "*linux_amd64.tar.gz"
+
+      - name: unpack release
+        run: |
+          tar -xzf *linux_amd64.tar.gz
+          rm nibid*.gz
+          mv nibid* nibid || true
+          mv nibid /usr/local/bin/
+          echo "nibid version: $(nibid version)"
 
       - name: "Install just"
         # casey/just: https://just.systems/man/en/chapter_6.html
         # taiki-e/install-action: https://github.com/taiki-e/install-action
         uses: taiki-e/install-action@just
 
-      - name: "Build the nibid binary + Run localnet"
+      - name: "launch localnet"
         run: |
-          just install
-          just localnet
+          just localnet --no-build
 
       - name: run e2e tests
         run: |

--- a/.github/workflows/e2e-wasm.yml
+++ b/.github/workflows/e2e-wasm.yml
@@ -48,7 +48,8 @@ jobs:
 
       - name: "launch localnet"
         run: |
-          just localnet --no-build
+          just localnet --no-build &
+          sleep 6
 
       - name: run e2e tests
         run: |

--- a/.github/workflows/e2e-wasm.yml
+++ b/.github/workflows/e2e-wasm.yml
@@ -38,6 +38,7 @@ jobs:
           tar -xzf *linux_amd64.tar.gz
           rm nibid*.gz
           mv nibid* nibid || true
+          mv nibid /usr/local/bin/
 
       - name: "Install just"
         # casey/just: https://just.systems/man/en/chapter_6.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,10 +98,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1735](https://github.com/NibiruChain/nibiru/pull/1735) - test(sim): fix simulation tests
 - [#1736](https://github.com/NibiruChain/nibiru/pull/1736) - test(sim): add sim genesis state for all cusom modules
 - [#1754](https://github.com/NibiruChain/nibiru/pull/1754) - refactor(decode-base64): clean code improvements and fn docs
-
-* [#1769](https://github.com/NibiruChain/nibiru/pull/1769) - feat: cherrypick GetBuildWasmMsg() to main branch
-
+- [#1769](https://github.com/NibiruChain/nibiru/pull/1769) - feat: cherrypick GetBuildWasmMsg() to main branch
 - [#1778](https://github.com/NibiruChain/nibiru/pull/1778) - chore: bump librocksdb to v8.9.1
+- [#1799](https://github.com/NibiruChain/nibiru/pull/1799) refactor,docs(inflation): Document everything + delete unused code
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1754](https://github.com/NibiruChain/nibiru/pull/1754) - refactor(decode-base64): clean code improvements and fn docs
 - [#1769](https://github.com/NibiruChain/nibiru/pull/1769) - feat: cherrypick GetBuildWasmMsg() to main branch
 - [#1778](https://github.com/NibiruChain/nibiru/pull/1778) - chore: bump librocksdb to v8.9.1
-- [#1799](https://github.com/NibiruChain/nibiru/pull/1799) refactor,docs(inflation): Document everything + delete unused code
+- [#1799](https://github.com/NibiruChain/nibiru/pull/1799) refactor,docs(inflation): Document everything + delete unused code. Make perp and spot optional features in localnet.sh
 
 ### Dependencies
 

--- a/contrib/make/localnet.mk
+++ b/contrib/make/localnet.mk
@@ -5,5 +5,4 @@
 # Simple localnet script for testing
 .PHONY: localnet
 localnet:
-	./contrib/scripts/localnet.sh
-
+	./contrib/scripts/localnet.sh $(FLAGS)

--- a/contrib/scripts/chaosnet.sh
+++ b/contrib/scripts/chaosnet.sh
@@ -44,36 +44,7 @@ add_genesis_param() {
   mv $HOME/.nibid/config/tmp_genesis.json $HOME/.nibid/config/genesis.json
 }
 
-add_genesis_perp_markets_with_coingecko_prices() {
-  local temp_json_fname="tmp_market_prices.json"
-  curl -X 'GET' \
-    'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin%2Cethereum&vs_currencies=usd' \
-    -H 'accept: application/json' \
-    >$temp_json_fname
-
-  local M=1000000
-
-  local num_users=300000
-  local faucet_nusd_amt=100
-  local reserve_amt=$(($num_users * $faucet_nusd_amt * $M))
-
-  price_btc=$(cat $temp_json_fname | jq -r '.bitcoin.usd')
-  price_btc=${price_btc%.*}
-  if [ -z "$price_btc" ]; then
-    return 1
-  fi
-
-  nibid genesis add-genesis-perp-market --pair=ubtc:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_btc --oracle-pair=ubtc:uusd
-
-  price_eth=$(cat $temp_json_fname | jq -r '.ethereum.usd')
-  price_eth=${price_eth%.*}
-  if [ -z "$price_eth" ]; then
-    return 1
-  fi
-
-  nibid genesis add-genesis-perp-market --pair=ueth:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_eth --oracle-pair=ueth:uusd
-}
-
+source "./feat-perp.sh"
 add_genesis_perp_markets_with_coingecko_prices
 
 # recover mnemonic

--- a/contrib/scripts/chaosnet.sh
+++ b/contrib/scripts/chaosnet.sh
@@ -44,7 +44,8 @@ add_genesis_param() {
   mv $HOME/.nibid/config/tmp_genesis.json $HOME/.nibid/config/genesis.json
 }
 
-source "./feat-perp.sh"
+curr_dir="$(dirname "$0")"
+source "$curr_dir/feat-perp.sh"
 add_genesis_perp_markets_with_coingecko_prices
 
 # recover mnemonic

--- a/contrib/scripts/chaosnet.sh
+++ b/contrib/scripts/chaosnet.sh
@@ -46,7 +46,7 @@ add_genesis_param() {
 
 curr_dir="$(dirname "$0")"
 source "$curr_dir/feat-perp.sh"
-add_genesis_perp_markets_with_coingecko_prices
+add_genesis_perp_markets_offline
 
 # recover mnemonic
 echo "$MNEMONIC" | nibid keys add validator --recover

--- a/contrib/scripts/e2e/deploy-wasm.sh
+++ b/contrib/scripts/e2e/deploy-wasm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-BINARY="./nibid"
+BINARY="nibid"
 DENOM="unibi"
 CHAIN_ID="nibiru-localnet-0"
 TXFLAG="--gas-prices 0.1$DENOM --gas auto --gas-adjustment 1.3 -y -b async --chain-id $CHAIN_ID"

--- a/contrib/scripts/feat-perp.sh
+++ b/contrib/scripts/feat-perp.sh
@@ -37,8 +37,7 @@ add_genesis_perp_markets_with_coingecko_prices() {
     fi
   }
 
-  nibid genesis add-genesis-perp-market --pair=ubtc:unusd --sqrt-depth="$reserve_amt" --price-multiplier="$price_btc" --oracle-pair="ubtc:uusd"
-  check_fail nibid genesis add-genesis-perp-market
+  check_fail nibid genesis add-genesis-perp-market --pair="ubtc:unusd" --sqrt-depth="$reserve_amt" --price-multiplier="$price_btc" --oracle-pair="ubtc:uusd"
 
   price_eth=$(cat tmp_market_prices.json | jq -r '.ethereum.usd')
   price_eth=${price_eth%.*}
@@ -46,8 +45,7 @@ add_genesis_perp_markets_with_coingecko_prices() {
     return 1
   fi
 
-  nibid genesis add-genesis-perp-market --pair=ueth:unusd --sqrt-depth=$reserve_amt --price-multiplier="$price_eth" --oracle-pair="ueth:uusd"
-  check_fail nibid genesis add-genesis-perp-market
+  check_fail nibid genesis add-genesis-perp-market --pair="ueth:unusd" --sqrt-depth=$reserve_amt --price-multiplier="$price_eth" --oracle-pair="ueth:uusd"
 
   echo 'tmp_market_prices: '
   cat $temp_json_fname | jq .
@@ -55,10 +53,10 @@ add_genesis_perp_markets_with_coingecko_prices() {
 }
 
 add_genesis_perp_markets_offline() {
-  local reserve_amt=$(add_genesis_reserve_amt)
+  local reserve_amt
+  reserve_amt=$(add_genesis_reserve_amt)
   price_btc="20000"
   price_eth="2000"
-  nibid genesis add-genesis-perp-market --pair=ubtc:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_btc
-  nibid genesis add-genesis-perp-market --pair=ueth:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_eth
+  nibid genesis add-genesis-perp-market --pair="ubtc:unusd" --sqrt-depth="$reserve_amt" --price-multiplier="$price_btc" --oracle-pair="ubtc:uusd"
+  nibid genesis add-genesis-perp-market --pair="ueth:unusd" --sqrt-depth="$reserve_amt" --price-multiplier="$price_eth" --oracle-pair="ueth:uusd"
 }
-

--- a/contrib/scripts/feat-perp.sh
+++ b/contrib/scripts/feat-perp.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+# add_genesis_reserve_amt: Used to configure initial reserve values of genesis
+# perp markets.
+add_genesis_reserve_amt() {
+  local M=1000000
+  local num_users=300000
+  local faucet_nusd_amt=100
+  local reserve_amt=$(($num_users * $faucet_nusd_amt * $M))
+  echo "$reserve_amt"
+}
+
+# add_genesis_perp_markets_with_coingecko_prices: Queries Coingecko to set the
+# initial values to for x/perp markets in the genesis.
+add_genesis_perp_markets_with_coingecko_prices() {
+  local temp_json_fname="tmp_market_prices.json"
+  curl -X 'GET' \
+    'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin%2Cethereum&vs_currencies=usd' \
+    -H 'accept: application/json' \
+    >$temp_json_fname
+
+  local reserve_amt=$(add_genesis_reserve_amt)
+
+  price_btc=$(cat tmp_market_prices.json | jq -r '.bitcoin.usd')
+  price_btc=${price_btc%.*}
+  if [ -z "$price_btc" ]; then
+    return 1
+  fi
+
+  check_fail() {
+    if [ $? -eq 0 ]; then
+      echo_success "Command \"$*\" executed successfully."
+    else
+      echo_error "Command \"$*\" failed."
+      exit 1
+    fi
+  }
+
+  nibid genesis add-genesis-perp-market --pair=ubtc:unusd --sqrt-depth="$reserve_amt" --price-multiplier="$price_btc" --oracle-pair="ubtc:uusd"
+  check_fail nibid genesis add-genesis-perp-market
+
+  price_eth=$(cat tmp_market_prices.json | jq -r '.ethereum.usd')
+  price_eth=${price_eth%.*}
+  if [ -z "$price_eth" ]; then
+    return 1
+  fi
+
+  nibid genesis add-genesis-perp-market --pair=ueth:unusd --sqrt-depth=$reserve_amt --price-multiplier="$price_eth" --oracle-pair="ueth:uusd"
+  check_fail nibid genesis add-genesis-perp-market
+
+  echo 'tmp_market_prices: '
+  cat $temp_json_fname | jq .
+  rm -f $temp_json_fname
+}
+
+add_genesis_perp_markets_offline() {
+  local reserve_amt=$(add_genesis_reserve_amt)
+  price_btc="20000"
+  price_eth="2000"
+  nibid genesis add-genesis-perp-market --pair=ubtc:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_btc
+  nibid genesis add-genesis-perp-market --pair=ueth:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_eth
+}
+

--- a/contrib/scripts/feat-perp.sh
+++ b/contrib/scripts/feat-perp.sh
@@ -30,9 +30,9 @@ add_genesis_perp_markets_with_coingecko_prices() {
 
   check_fail() {
     if [ $? -eq 0 ]; then
-      echo_success "Command \"$*\" executed successfully."
+      echo "Command \"$*\" executed successfully."
     else
-      echo_error "Command \"$*\" failed."
+      echo "Command \"$*\" failed."
       exit 1
     fi
   }

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -218,6 +218,8 @@ fi
 add_genesis_param '.app_state.sudo.sudoers.root = "'"$val_address"'"'
 
 # hack for localnet since we don't have a pricefeeder yet
+price_btc="50000"
+price_eth="2000"
 add_genesis_param '.app_state.oracle.exchange_rates[0].pair = "ubtc:uuusd"'
 add_genesis_param '.app_state.oracle.exchange_rates[0].exchange_rate = "'"$price_btc"'"'
 add_genesis_param '.app_state.oracle.exchange_rates[1].pair = "ueth:uuusd"'

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -156,17 +156,16 @@ $BINARY config output json
 $BINARY config # Prints config.
 
 # Enable API Server
-config_app_toml="$CHAIN_DIR/config/app.toml"
 echo_info "config/app.toml: Enabling API server"
-sed -i "$SEDOPTION" '/\[api\]/,+3 s/enable = false/enable = true/' "$config_app_toml"
+sed -i $SEDOPTION '/\[api\]/,+3 s/enable = false/enable = true/' $CHAIN_DIR/config/app.toml
 
 # Enable Swagger Docs
 echo_info "config/app.toml: Enabling Swagger Docs"
-sed -i "$SEDOPTION" 's/swagger = false/swagger = true/' "$config_app_toml"
+sed -i $SEDOPTION 's/swagger = false/swagger = true/' $CHAIN_DIR/config/app.toml
 
 # Enable CORS for localnet
 echo_info "config/app.toml: Enabling CORS"
-sed -i "$SEDOPTION" 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/' "$config_app_toml"
+sed -i $SEDOPTION 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/' $CHAIN_DIR/config/app.toml
 
 echo_info "Adding genesis accounts..."
 

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -197,7 +197,8 @@ add_genesis_param() {
 echo_info "Configuring genesis params"
 
 if $FLAG_PERP; then
-  source "./feat-perp.sh"
+  local curr_dir="$(dirname "$0")"
+  source "$curr_dir/feat-perp.sh"
 
   if add_genesis_perp_markets_with_coingecko_prices; then
     echo_success "set perp markets with coingecko prices"

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -1,5 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 set -e
+
+# Set localnet settings
+BINARY="nibid"
+CHAIN_ID="nibiru-localnet-0"
+MNEMONIC="guard cream sadness conduct invite crumble clock pudding hole grit liar hotel maid produce squeeze return argue turtle know drive eight casino maze host"
+GENESIS_COINS="10000000000000unibi,10000000000000unusd,10000000000000uusdt,10000000000000uusdc"
+CHAIN_DIR="$HOME/.nibid"
+
+echo "CHAIN_DIR: $CHAIN_DIR"
+echo "CHAIN_ID: $CHAIN_ID"
+
+# ------------------------------------------------------------
+# Set up colored text logging
+# ------------------------------------------------------------
 
 # Console log text colour
 console_log_text_color() {
@@ -34,11 +48,21 @@ echo_success() {
   echo "${reset}"
 }
 
-# Flag parsing: --flag-name (BASH_VAR_NAME)
-#
-# --no-build ($FLAG_NO_BUILD): toggles whether to build from source. The default
-#   behavior of the script is to run make install.
+# ------------------------------------------------------------
+# Flag parsing
+# ------------------------------------------------------------
+
+echo_info "Parsing flags for the script..."
+
+# $FLAG_NO_BUILD: toggles whether to build from source. The default
+#   behavior of the script is to run make install if the flag --no-build is not present.
 FLAG_NO_BUILD=false
+
+# $FLAG_PERP: Feature flag for x/perp. Enabled with `--features perp`.
+FLAG_PERP=false
+
+# $FLAG_SPOT: Feature flag for x/spot. Enabled with `--features spot`.
+FLAG_SPOT=false
 
 build_from_source() {
   echo_info "Building from source..."
@@ -50,13 +74,34 @@ build_from_source() {
   fi
 }
 
-echo_info "Parsing flags for the script..."
+# Initialize an associative array for feature flags with default values
+declare -A features=( ["perp"]=0 ["spot"]=0 )
 
-# Iterate over all arguments to the script
-for arg in "$@"; do
-  if [ "$arg" == "--no-build" ]; then
-    FLAG_NO_BUILD=true
-  fi
+# enable_feature_flag: Enables feature flags variables if present
+enable_feature_flag() {
+  case $1 in
+    perp) FLAG_PERP=true ;;
+    spot) FLAG_SPOT=true ;;
+    *) echo_error "Unknown feature: $1" ;;
+  esac
+}
+
+# Iterate over flags, handling the cases: "--no-build" and "--features"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --no-build)
+      FLAG_NO_BUILD=true
+      shift
+      ;;
+    --features)
+      shift # Remove '--features' from arguments
+      while [[ $# -gt 0 && $1 != --* ]]; do
+        enable_feature_flag "$1"
+        shift # Remove the feature name from arguments
+      done
+      ;;
+    *) shift ;; # Unknown arg
+  esac
 done
 
 # Check if FLAG_NO_BUILD was set to true
@@ -64,16 +109,10 @@ if ! $FLAG_NO_BUILD; then
   build_from_source
 fi
 
-# Set localnet settings
-BINARY="nibid"
-CHAIN_ID="nibiru-localnet-0"
-RPC_PORT="26657"
-GRPC_PORT="9090"
-MNEMONIC="guard cream sadness conduct invite crumble clock pudding hole grit liar hotel maid produce squeeze return argue turtle know drive eight casino maze host"
-GENESIS_COINS="10000000000000unibi,10000000000000unusd,10000000000000uusdt,10000000000000uusdc"
-CHAIN_DIR="$HOME/.nibid"
-echo "CHAIN_DIR: $CHAIN_DIR"
-echo "CHAIN_ID: $CHAIN_ID"
+echo_info "Features flags:"
+echo "FLAG_NO_BUILD: $FLAG_NO_BUILD"
+echo "FLAG_PERP: $FLAG_PERP"
+echo "FLAG_SPOT: $FLAG_SPOT"
 
 SEDOPTION=""
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -92,10 +131,10 @@ fi
 
 # Remove previous data
 echo_info "Removing previous chain data from $CHAIN_DIR..."
-rm -rf $CHAIN_DIR
+rm -rf "$CHAIN_DIR"
 
 # Add directory for chain, exit if error
-if ! mkdir -p $CHAIN_DIR 2>/dev/null; then
+if ! mkdir -p "$CHAIN_DIR" 2>/dev/null; then
   echo_error "Failed to create chain folder. Aborting..."
   exit 1
 fi
@@ -117,16 +156,17 @@ $BINARY config output json
 $BINARY config # Prints config.
 
 # Enable API Server
+config_app_toml="$CHAIN_DIR/config/app.toml"
 echo_info "config/app.toml: Enabling API server"
-sed -i $SEDOPTION '/\[api\]/,+3 s/enable = false/enable = true/' $CHAIN_DIR/config/app.toml
+sed -i "$SEDOPTION" '/\[api\]/,+3 s/enable = false/enable = true/' "$config_app_toml"
 
 # Enable Swagger Docs
 echo_info "config/app.toml: Enabling Swagger Docs"
-sed -i $SEDOPTION 's/swagger = false/swagger = true/' $CHAIN_DIR/config/app.toml
+sed -i "$SEDOPTION" 's/swagger = false/swagger = true/' "$config_app_toml"
 
 # Enable CORS for localnet
 echo_info "config/app.toml: Enabling CORS"
-sed -i $SEDOPTION 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/' $CHAIN_DIR/config/app.toml
+sed -i "$SEDOPTION" 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/' "$config_app_toml"
 
 echo_info "Adding genesis accounts..."
 
@@ -155,73 +195,24 @@ add_genesis_param() {
   mv $CHAIN_DIR/config/tmp_genesis.json $CHAIN_DIR/config/genesis.json
 }
 
-add_genesis_reserve_amt() {
-  local M=1000000
-  local num_users=300000
-  local faucet_nusd_amt=100
-  local reserve_amt=$(($num_users * $faucet_nusd_amt * $M))
-  echo "$reserve_amt"
-}
-
-add_genesis_perp_markets_with_coingecko_prices() {
-  local temp_json_fname="tmp_market_prices.json"
-  curl -X 'GET' \
-    'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin%2Cethereum&vs_currencies=usd' \
-    -H 'accept: application/json' \
-    >$temp_json_fname
-
-  local reserve_amt=$(add_genesis_reserve_amt)
-
-  price_btc=$(cat tmp_market_prices.json | jq -r '.bitcoin.usd')
-  price_btc=${price_btc%.*}
-  if [ -z "$price_btc" ]; then
-    return 1
-  fi
-
-  check_fail() {
-    if [ $? -eq 0 ]; then
-      echo_success "Command \"$*\" executed successfully."
-    else
-      echo_error "Command \"$*\" failed."
-      exit 1
-    fi
-  }
-
-  nibid genesis add-genesis-perp-market --pair=ubtc:unusd --sqrt-depth="$reserve_amt" --price-multiplier="$price_btc" --oracle-pair="ubtc:uusd"
-  check_fail nibid genesis add-genesis-perp-market
-
-  price_eth=$(cat tmp_market_prices.json | jq -r '.ethereum.usd')
-  price_eth=${price_eth%.*}
-  if [ -z "$price_eth" ]; then
-    return 1
-  fi
-
-  nibid genesis add-genesis-perp-market --pair=ueth:unusd --sqrt-depth=$reserve_amt --price-multiplier="$price_eth" --oracle-pair="ueth:uusd"
-  check_fail nibid genesis add-genesis-perp-market
-
-  echo 'tmp_market_prices: '
-  cat $temp_json_fname | jq .
-  rm -f $temp_json_fname
-}
-
-add_genesis_perp_markets_offline() {
-  local reserve_amt=$(add_genesis_reserve_amt)
-  price_btc="20000"
-  price_eth="2000"
-  nibid genesis add-genesis-perp-market --pair=ubtc:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_btc
-  nibid genesis add-genesis-perp-market --pair=ueth:unusd --sqrt-depth=$reserve_amt --price-multiplier=$price_eth
-}
-
 echo_info "Configuring genesis params"
 
-if add_genesis_perp_markets_with_coingecko_prices; then
-  echo_success "set perp markets with coingecko prices"
-elif add_genesis_perp_markets_offline; then
-  echo_success "set perp markets with offline defaults"
-else
-  echo_error "failed to set genesis perp markets"
-  exit 1
+if $FLAG_PERP; then
+  source "./feat-perp.sh"
+
+  if add_genesis_perp_markets_with_coingecko_prices; then
+    echo_success "set perp markets with coingecko prices"
+  elif add_genesis_perp_markets_offline; then
+    echo_success "set perp markets with offline defaults"
+  else
+    echo_error "failed to set genesis perp markets"
+    exit 1
+  fi
 fi
+
+# if $FLAG_SPOT; then
+#   # Perform any actions specific to the x/spot feature
+# fi
 
 # set validator as sudoer
 add_genesis_param '.app_state.sudo.sudoers.root = "'"$val_address"'"'

--- a/justfile
+++ b/justfile
@@ -39,9 +39,9 @@ lint:
 
   golangci-lint run --allow-parallel-runners --fix
 
-# Runs a Nibiru local network
-localnet:
-  make localnet
+# Runs a Nibiru local network. Ex: "just localnet --features perp spot" 
+localnet *PASS_FLAGS:
+  make localnet FLAGS="{{PASS_FLAGS}}"
 
 # Test: "localnet.sh" script
 test-localnet:

--- a/x/devgas/v1/keeper/keeper.go
+++ b/x/devgas/v1/keeper/keeper.go
@@ -26,6 +26,12 @@ type Keeper struct {
 	wasmKeeper    wasmkeeper.Keeper
 	accountKeeper devgastypes.AccountKeeper
 
+	// feeCollectorName is the name of of x/auth module's fee collector module
+	// account, "fee_collector", which collects transaction fees for distribution
+	// to all stakers.
+	//
+	// See the `[AllocateTokens]` function from x/distribution to learn more.
+	// [AllocateTokens]: https://github.com/cosmos/cosmos-sdk/blob/v0.50.3/x/distribution/keeper/allocation.go
 	feeCollectorName string
 
 	// DevGasStore: IndexedMap

--- a/x/epochs/keeper/hooks_test.go
+++ b/x/epochs/keeper/hooks_test.go
@@ -36,7 +36,6 @@ func TestAfterEpochEnd(t *testing.T) {
 	nibiruApp.EpochsKeeper.SetHooks(hooks)
 	hooks.On("AfterEpochEnd", ctx, identifier, epochNumber)
 	nibiruApp.EpochsKeeper.AfterEpochEnd(ctx, identifier, epochNumber)
-
 	hooks.AssertExpectations(t)
 }
 

--- a/x/epochs/types/hooks.go
+++ b/x/epochs/types/hooks.go
@@ -4,8 +4,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// EpochHooks defines a set of lifecycle hooks to occur in the ABCI BeginBlock
+// hooks based on temporal epochs.
 type EpochHooks interface {
-	// AfterEpochEnd the first block whose timestamp is after the duration is counted as the end of the epoch
+	// AfterEpochEnd the first block whose timestamp is after the duration is
+	// counted as the end of the epoch
 	AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber uint64)
 	// BeforeEpochStart new epoch is next block of epoch end block
 	BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber uint64)
@@ -13,21 +16,29 @@ type EpochHooks interface {
 
 var _ EpochHooks = MultiEpochHooks{}
 
-// MultiEpochHooks combine multiple gamm hooks, all hook functions are run in array sequence.
+// MultiEpochHooks combines multiple [EpochHooks]. All hook functions are
+// executed sequentially in the order of the slice.
 type MultiEpochHooks []EpochHooks
 
 func NewMultiEpochHooks(hooks ...EpochHooks) MultiEpochHooks {
 	return hooks
 }
 
-// AfterEpochEnd is called when epoch is going to be ended, epochNumber is the number of epoch that is ending.
+// AfterEpochEnd runs logic at the end of an epoch.
+//
+//   - epochIdentifier: The unique identifier of specific epoch. Ex: "30 min", "1 min".
+//   - epochNumber: Counter for the specific epoch type identified.
 func (h MultiEpochHooks) AfterEpochEnd(ctx sdk.Context, epochIdentifier string, epochNumber uint64) {
 	for i := range h {
 		h[i].AfterEpochEnd(ctx, epochIdentifier, epochNumber)
 	}
 }
 
-// BeforeEpochStart is called when epoch is going to be started, epochNumber is the number of epoch that is starting.
+// BeforeEpochStart runs logic in the ABCI BeginBlocker right before an epoch
+// starts.
+//
+//   - epochIdentifier: The unique identifier of specific epoch. Ex: "30 min", "1 min".
+//   - epochNumber: Counter for the specific epoch type identified.
 func (h MultiEpochHooks) BeforeEpochStart(ctx sdk.Context, epochIdentifier string, epochNumber uint64) {
 	for i := range h {
 		h[i].BeforeEpochStart(ctx, epochIdentifier, epochNumber)

--- a/x/inflation/doc.go
+++ b/x/inflation/doc.go
@@ -1,0 +1,11 @@
+/*
+Package inflation implements the token inflation for the staking and utility
+token of the network as described by the "Community" portion of the Nibiru Chain
+tokenomics. The inflation curve is implemented as a polynomial that corresponds
+to a normalized exponential decay until the network reaches its maximum supply.
+
+References:
+  - https://github.com/NibiruChain/tokenomics
+  - https://nibiru.fi/docs/learn/tokenomics.html
+*/
+package inflation

--- a/x/inflation/keeper/grpc_query.go
+++ b/x/inflation/keeper/grpc_query.go
@@ -14,8 +14,8 @@ type querier struct {
 	Keeper
 }
 
-// NewQuerier returns an implementation of the oracle QueryServer interface
-// for the provided Keeper.
+// NewQuerier returns an implementation of the [types.QueryServer] interface
+// for the provided [Keeper].
 func NewQuerier(keeper Keeper) types.QueryServer {
 	return &querier{Keeper: keeper}
 }

--- a/x/inflation/keeper/hooks_test.go
+++ b/x/inflation/keeper/hooks_test.go
@@ -236,7 +236,7 @@ func TestManual(t *testing.T) {
 	require.Equal(t, sdk.ZeroInt(), GetBalanceStaking(ctx, nibiruApp))
 
 	for i := 0; i < 42069; i++ {
-		inflationKeeper.AfterEpochEnd(ctx, epochstypes.DayEpochID, epochNumber)
+		inflationKeeper.Hooks().AfterEpochEnd(ctx, epochstypes.DayEpochID, epochNumber)
 		epochNumber++
 	}
 	require.Equal(t, sdk.ZeroInt(), GetBalanceStaking(ctx, nibiruApp))
@@ -258,7 +258,7 @@ func TestManual(t *testing.T) {
 
 	// Period 0 - inflate 3M NIBI over 30 epochs or 100k uNIBI per epoch
 	for i := 0; i < 30; i++ {
-		inflationKeeper.AfterEpochEnd(ctx, epochstypes.DayEpochID, epochNumber)
+		inflationKeeper.Hooks().AfterEpochEnd(ctx, epochstypes.DayEpochID, epochNumber)
 		require.Equal(t, sdk.NewInt(100_000).Mul(sdk.NewInt(int64(i+1))), GetBalanceStaking(ctx, nibiruApp))
 		epochNumber++
 	}
@@ -270,7 +270,7 @@ func TestManual(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 42069; i++ {
-		inflationKeeper.AfterEpochEnd(ctx, epochstypes.DayEpochID, epochNumber)
+		inflationKeeper.Hooks().AfterEpochEnd(ctx, epochstypes.DayEpochID, epochNumber)
 		epochNumber++
 	}
 	require.Equal(t, sdk.NewInt(3_000_000), GetBalanceStaking(ctx, nibiruApp))
@@ -282,7 +282,7 @@ func TestManual(t *testing.T) {
 
 	// Period 1 - inflate 6M NIBI over 30 epochs or 200k uNIBI per epoch
 	for i := 0; i < 30; i++ {
-		inflationKeeper.AfterEpochEnd(ctx, epochstypes.DayEpochID, epochNumber)
+		inflationKeeper.Hooks().AfterEpochEnd(ctx, epochstypes.DayEpochID, epochNumber)
 		require.Equal(t, sdk.NewInt(3_000_000).Add(sdk.NewInt(200_000).Mul(sdk.NewInt(int64(i+1)))), GetBalanceStaking(ctx, nibiruApp))
 		epochNumber++
 	}

--- a/x/inflation/keeper/keeper.go
+++ b/x/inflation/keeper/keeper.go
@@ -18,6 +18,9 @@ import (
 type Keeper struct {
 	cdc      codec.BinaryCodec
 	storeKey storetypes.StoreKey
+	// paramSpace: unused but present for backward compatibility. Removing this
+	// breaks the state machine and requires an upgrade.
+	paramSpace paramstypes.Subspace
 
 	accountKeeper types.AccountKeeper
 	bankKeeper    types.BankKeeper
@@ -69,6 +72,7 @@ func NewKeeper(
 	return Keeper{
 		storeKey:         storeKey,
 		cdc:              cdc,
+		paramSpace:       paramspace,
 		accountKeeper:    accountKeeper,
 		bankKeeper:       bankKeeper,
 		distrKeeper:      distributionKeeper,

--- a/x/inflation/keeper/msg_server.go
+++ b/x/inflation/keeper/msg_server.go
@@ -33,6 +33,8 @@ func (ms msgServer) EditInflationParams(
 	return resp, err
 }
 
+// ToggleInflation: gRPC tx msg for enabling or disabling token inflation.
+// [SUDO] Only callable by sudoers.
 func (ms msgServer) ToggleInflation(
 	goCtx context.Context, msg *types.MsgToggleInflation,
 ) (resp *types.MsgToggleInflationResponse, err error) {

--- a/x/inflation/keeper/sudo.go
+++ b/x/inflation/keeper/sudo.go
@@ -8,21 +8,22 @@ import (
 	inflationtypes "github.com/NibiruChain/nibiru/x/inflation/types"
 )
 
-// Sudo extends the Keeper with sudo functions. See sudo.go.
+// Sudo extends the Keeper with sudo functions. See [x/sudo].
 //
-// These Sudo functions should:
+// These sudo functions should:
 // 1. Not be called in other methods in the module.
 // 2. Only be callable by the x/sudo root or sudo contracts.
 //
-// The intention behind "Keeper.Sudo()" is to make it more obvious to the
+// The intention behind "[Keeper.Sudo]" is to make it more obvious to the
 // developer that an unsafe function is being used when it's called.
+// [x/sudo]: https://pkg.go.dev/github.com/NibiruChain/nibiru@v1.1.0/x/sudo/keeper
 func (k Keeper) Sudo() sudoExtension { return sudoExtension{k} }
 
 type sudoExtension struct{ Keeper }
 
-// ------------------------------------------------------------------
-// Admin.EditInflationParams
-
+// EditInflationParams performs a partial struct update, or struct merge, on the
+// module parameters, given a subset of the params, `newParams`. Only the new
+// params are overwritten.
 func (k sudoExtension) EditInflationParams(
 	ctx sdk.Context, newParams inflationtypes.MsgEditInflationParams,
 	sender sdk.AccAddress,
@@ -44,6 +45,7 @@ func (k sudoExtension) EditInflationParams(
 	return paramsAfter.Validate()
 }
 
+// ToggleInflation disables (pauses) or enables (unpauses) inflation.
 func (k sudoExtension) ToggleInflation(
 	ctx sdk.Context, enabled bool, sender sdk.AccAddress,
 ) (err error) {
@@ -65,9 +67,10 @@ func (k sudoExtension) ToggleInflation(
 	return
 }
 
-// MergeInflationParams: Takes the given Inflation params and merges them into the
-// existing partial params, keeping any existing values that are not set in the
-// partial.
+// MergeInflationParams: Performs a partial struct update using [partial] and
+// merges its params into the existing [inflationParams], keeping any existing
+// values that are not set in the partial. For use with
+// [Keeper.EditInflationParams].
 func MergeInflationParams(
 	partial inflationtypes.MsgEditInflationParams,
 	inflationParams inflationtypes.Params,

--- a/x/inflation/types/inflation_calculation_test.go
+++ b/x/inflation/types/inflation_calculation_test.go
@@ -20,6 +20,13 @@ var ExpectedYearlyInflation = []sdk.Dec{
 	sdk.NewDec(40_412_283_000_000),
 }
 
+// ExpectedTotalInflation is the total amount of NIBI tokens (in unibi) that
+// should be minted via inflation for the network to reach its target supply.
+// The value 810.6 million is equivalent to:
+// = (Community allocation of total supply) - (Community supply at start)
+// = (60% of the total supply) - (Community supply at start)
+// = (60% of 1.5 billion) - (Community supply at start)
+// = 810.6 million NIBI
 var ExpectedTotalInflation = sdk.NewDec(810_600_000_000_000)
 
 func TestCalculateEpochMintProvision(t *testing.T) {
@@ -30,7 +37,7 @@ func TestCalculateEpochMintProvision(t *testing.T) {
 	totalInflation := sdk.ZeroDec()
 
 	// Only the first 8 years have inflation with default params but we run
-	// for 10 years expecting 0 inflation
+	// for 10 years expecting 0 inflation in the last 2 years.
 	for year := uint64(0); year < 10; year++ {
 		yearlyInflation := sdk.ZeroDec()
 		for month := uint64(0); month < 12; month++ {


### PR DESCRIPTION
## Purpose / Abstract

Originally, I opened this to add some doc comments and delete unused code. When I opened the PR, I noticed that the localnet.sh was not running on the branch and was also broken on `main`. I've gone ahead and fixed that.

In addition, both `just localnet` and `make localnet` now use feature flags to enable modules like x/perp and x/spot, which will make tests a lot less finicky. 

- Fixed scripts/chaosnet.sh
- Fixed scripts/localnet.sh
- Documented x/inflation more thoroughly in each file.
- Slight no-op refactor in x/inflation to delete unused code

## Summary

- **New Features**
	- Added functions to configure initial reserve values for genesis perpetual markets and query market prices.
- **Enhancements**
	- Enhanced localnet script with bash, flag parsing for build options, and feature flags for `perp` and `spot`.
	- Improved clarity and organization in scripts and documentation, particularly in the inflation module.
- **Refactor**
	- Code related to inflation refactored for better clarity and efficiency, including removal of unused code.
- **Documentation**
	- Added and refined comments across various modules for better understanding of functionalities and parameters.
- **Chores**
	- Updated workflow settings and configurations for e2e testing.
