### PR TITLE
fix(docker-chaosnet): release snapshot docker build failed CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,9 +4,9 @@ name: Linter
 on:
   push:
     branches: ["main"]
-    paths: ["**.go", "**.proto", "go.mod", "go.sum"]
+    paths: ["**.go", "**.proto", "go.mod", "go.sum", "**go.mod", "**go.sum"]
   pull_request:
-    paths: ["**.go", "**.proto", "go.mod", "go.sum"]
+    paths: ["**.go", "**.proto", "go.mod", "go.sum", "**go.mod", "**go.sum"]
 
 # Allow concurrent runs on main/release branches but isolates other branches
 concurrency:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 0 * * *" # Runs automatically every day
   pull_request:
     # paths makes the action run only when the given paths are changed
-    paths: ["**.go", "**.proto", "go.mod", "go.sum"]
+    paths: ["**.go", "**.proto", "go.mod", "go.sum", "**go.mod", "**go.sum"]
 
 # Allow concurrent runs on main/release branches but isolates other branches
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 on:
   pull_request:
-    paths: ["**.go", "**.proto", "go.mod", "go.sum", "**go.mod", "**go.sum"]
+    paths: ["**.go", "**.proto", "go.mod", "go.sum", "**go.mod", "**go.sum", "contrib/docker/*"]
 
 # Allow concurrent runs on main/release branches but isolates other branches
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 on:
   pull_request:
-    paths: ["**.go", "**.proto", "go.mod", "go.sum"]
+    paths: ["**.go", "**.proto", "go.mod", "go.sum", "**go.mod", "**go.sum"]
 
 # Allow concurrent runs on main/release branches but isolates other branches
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1837](https://github.com/NibiruChain/nibiru/pull/1837) - feat(eth): protos, eth types, and evm module types
 - [#1838](https://github.com/NibiruChain/nibiru/pull/1838) - feat(eth): Go-ethereum, crypto, encoding, and unit tests for evm/types
 - [#1841](https://github.com/NibiruChain/nibiru/pull/1841) - feat(eth): Collections encoders for bytes, Ethereum addresses, and Ethereum hashes 
+- [#1847](https://github.com/NibiruChain/nibiru/pull/1847) - fix(docker-chaosnet): release snapshot docker build failed CI.
 
 #### Dapp modules: perp, spot, etc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM golang:1.21 AS builder
 
 WORKDIR /nibiru
 
-COPY go.sum go.mod ./
+# copy go.mod, go.sum to WORKDIR
+COPY go.sum go.mod ./  
+# copy geth to WORKDIR/geth
+COPY geth ./geth       
 RUN go mod download
 COPY . .
 

--- a/contrib/docker/chaosnet.Dockerfile
+++ b/contrib/docker/chaosnet.Dockerfile
@@ -2,9 +2,10 @@ FROM golang:1.21 AS builder
 
 WORKDIR /nibiru
 
-COPY go.sum go.mod ./
+COPY go.sum go.mod ./  # copy go.mod, go.sum to WORKDIR
+COPY geth ./geth       # copy geth to WORKDIR/geth
 RUN go mod download
-COPY . .
+COPY . .               # copy the rest of the project to WORKDIR
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,target=/go/pkg \

--- a/contrib/docker/chaosnet.Dockerfile
+++ b/contrib/docker/chaosnet.Dockerfile
@@ -2,10 +2,13 @@ FROM golang:1.21 AS builder
 
 WORKDIR /nibiru
 
-COPY go.sum go.mod ./  # copy go.mod, go.sum to WORKDIR
-COPY geth ./geth       # copy geth to WORKDIR/geth
+# copy go.mod, go.sum to WORKDIR
+COPY go.sum go.mod ./  
+# copy geth to WORKDIR/geth
+COPY geth ./geth       
 RUN go mod download
-COPY . .               # copy the rest of the project to WORKDIR
+# copy the rest of the project to WORKDIR
+COPY . .               
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,target=/go/pkg \


### PR DESCRIPTION
# Purpose / Abstract

The GitHub action that builds using `chaosnet.Dockerfile` failed even though the pull request passed all of its checks. 

This PR is meant to include necessary changes for the docker build.

## Local Testing

- [x] For `Dockerfile`: 
```bash
docker build -t nibi-test .
```

- [x] For `contrib/docker/chaosnet.Dockerfile`: 
```bash
docker build -t nibi-test-2 -f contrib/docker/chaosnet.Dockerfile .
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced GitHub Actions workflows to include `go.mod` and `go.sum` files in linting, integration tests, and unit tests triggers.

- **Bug Fixes**
  - Addressed a CI build issue in the `docker-chaosnet` module as documented in the CHANGELOG.

- **Documentation**
  - Updated CHANGELOG with recent fixes.

- **New Features**
  - Modified Dockerfiles to better manage dependencies and project files within the containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->