### PR TITLE
refactor(oracle): add oracle slashing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1799](https://github.com/NibiruChain/nibiru/pull/1799) - refactor,docs(inflation): Document everything + delete unused code. Make perp and spot optional features in localnet.sh
 - [#1810](https://github.com/NibiruChain/nibiru/pull/1810) - chore(ci): use ubuntu-latest-m for goreleaser
 - [#1818](https://github.com/NibiruChain/nibiru/pull/1818) - feat: add pebbledb support
+- [#1859](https://github.com/NibiruChain/nibiru/pull/1859) - refactor(oracle): add oracle slashing events
 
 ### Dependencies
 

--- a/app/keepers.go
+++ b/app/keepers.go
@@ -363,7 +363,7 @@ func (app *NibiruApp) InitKeepers(
 	)
 
 	app.OracleKeeper = oraclekeeper.NewKeeper(appCodec, keys[oracletypes.StoreKey],
-		app.AccountKeeper, app.BankKeeper, app.DistrKeeper, app.stakingKeeper,
+		app.AccountKeeper, app.BankKeeper, app.DistrKeeper, app.stakingKeeper, app.slashingKeeper,
 		app.SudoKeeper,
 		distrtypes.ModuleName,
 	)

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -23,11 +23,12 @@ type Keeper struct {
 	cdc      codec.BinaryCodec
 	storeKey storetypes.StoreKey
 
-	AccountKeeper types.AccountKeeper
-	bankKeeper    types.BankKeeper
-	distrKeeper   types.DistributionKeeper
-	StakingKeeper types.StakingKeeper
-	SudoKeeper    types.SudoKeeper
+	AccountKeeper  types.AccountKeeper
+	bankKeeper     types.BankKeeper
+	distrKeeper    types.DistributionKeeper
+	StakingKeeper  types.StakingKeeper
+	slashingKeeper types.SlashingKeeper
+	SudoKeeper     types.SudoKeeper
 
 	distrModuleName string
 
@@ -57,6 +58,7 @@ func NewKeeper(
 	bankKeeper types.BankKeeper,
 	distrKeeper types.DistributionKeeper,
 	stakingKeeper types.StakingKeeper,
+	slashingKeeper types.SlashingKeeper,
 	sudoKeeper types.SudoKeeper,
 
 	distrName string,
@@ -73,6 +75,7 @@ func NewKeeper(
 		bankKeeper:        bankKeeper,
 		distrKeeper:       distrKeeper,
 		StakingKeeper:     stakingKeeper,
+		slashingKeeper:    slashingKeeper,
 		SudoKeeper:        sudoKeeper,
 		distrModuleName:   distrName,
 		Params:            collections.NewItem(storeKey, 11, collections.ProtoValueEncoder[types.Params](cdc)),

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -28,7 +28,7 @@ type Keeper struct {
 	distrKeeper    types.DistributionKeeper
 	StakingKeeper  types.StakingKeeper
 	slashingKeeper types.SlashingKeeper
-	SudoKeeper     types.SudoKeeper
+	sudoKeeper     types.SudoKeeper
 
 	distrModuleName string
 
@@ -76,7 +76,7 @@ func NewKeeper(
 		distrKeeper:       distrKeeper,
 		StakingKeeper:     stakingKeeper,
 		slashingKeeper:    slashingKeeper,
-		SudoKeeper:        sudoKeeper,
+		sudoKeeper:        sudoKeeper,
 		distrModuleName:   distrName,
 		Params:            collections.NewItem(storeKey, 11, collections.ProtoValueEncoder[types.Params](cdc)),
 		ExchangeRates:     collections.NewMap(storeKey, 1, asset.PairKeyEncoder, collections.ProtoValueEncoder[types.DatedPrice](cdc)),

--- a/x/oracle/keeper/slash.go
+++ b/x/oracle/keeper/slash.go
@@ -39,12 +39,11 @@ func (k Keeper) SlashAndResetMissCounters(ctx sdk.Context) {
 					continue
 				}
 
-				k.StakingKeeper.Slash(
-					ctx, consAddr,
-					distributionHeight, validator.GetConsensusPower(powerReduction), slashFraction,
+				k.slashingKeeper.Slash(
+					ctx, consAddr, slashFraction, validator.GetConsensusPower(powerReduction), distributionHeight,
 				)
-				k.Logger(ctx).Info("slash", "validator", consAddr.String(), "fraction", slashFraction.String())
-				k.StakingKeeper.Jail(ctx, consAddr)
+				k.Logger(ctx).Info("oracle slash", "validator", consAddr.String(), "fraction", slashFraction.String())
+				k.slashingKeeper.Jail(ctx, consAddr)
 			}
 		}
 

--- a/x/oracle/keeper/sudo.go
+++ b/x/oracle/keeper/sudo.go
@@ -30,7 +30,7 @@ func (k sudoExtension) EditOracleParams(
 	ctx sdk.Context, newParams oracletypes.MsgEditOracleParams,
 	sender sdk.AccAddress,
 ) (paramsAfter oracletypes.Params, err error) {
-	if err := k.SudoKeeper.CheckPermissions(sender, ctx); err != nil {
+	if err := k.sudoKeeper.CheckPermissions(sender, ctx); err != nil {
 		return paramsAfter, err
 	}
 

--- a/x/oracle/keeper/test_utils.go
+++ b/x/oracle/keeper/test_utils.go
@@ -39,6 +39,8 @@ import (
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/params"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -139,8 +141,11 @@ func CreateTestFixture(t *testing.T) TestFixture {
 	tKeyParams := sdk.NewTransientStoreKey(paramstypes.TStoreKey)
 	keyOracle := sdk.NewKVStoreKey(types.StoreKey)
 	keyStaking := sdk.NewKVStoreKey(stakingtypes.StoreKey)
+	keySlashing := sdk.NewKVStoreKey(slashingtypes.StoreKey)
 	keyDistr := sdk.NewKVStoreKey(distrtypes.StoreKey)
 	keySudo := sdk.NewKVStoreKey(sudotypes.StoreKey)
+
+	govModuleAddr := authtypes.NewModuleAddress(govtypes.ModuleName).String()
 
 	db := dbm.NewMemDB()
 	ms := store.NewCommitMultiStore(db)
@@ -201,10 +206,11 @@ func CreateTestFixture(t *testing.T) TestFixture {
 		bankKeeper,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
-
 	stakingParams := stakingtypes.DefaultParams()
 	stakingParams.BondDenom = denoms.NIBI
 	stakingKeeper.SetParams(ctx, stakingParams)
+
+	slashingKeeper := slashingkeeper.NewKeeper(appCodec, legacyAmino, keySlashing, stakingKeeper, govModuleAddr)
 
 	distrKeeper := distrkeeper.NewKeeper(
 		appCodec,
@@ -253,6 +259,7 @@ func CreateTestFixture(t *testing.T) TestFixture {
 		bankKeeper,
 		distrKeeper,
 		stakingKeeper,
+		slashingKeeper,
 		sudoKeeper,
 		distrtypes.ModuleName,
 	)

--- a/x/oracle/types/expected_keeper.go
+++ b/x/oracle/types/expected_keeper.go
@@ -18,6 +18,11 @@ type StakingKeeper interface {
 	PowerReduction(ctx sdk.Context) (res sdkmath.Int)
 }
 
+type SlashingKeeper interface {
+	Slash(ctx sdk.Context, consAddr sdk.ConsAddress, fraction sdk.Dec, power int64, height int64)
+	Jail(sdk.Context, sdk.ConsAddress)
+}
+
 // DistributionKeeper is expected keeper for distribution module
 type DistributionKeeper interface {
 	AllocateTokensToValidator(ctx sdk.Context, val stakingtypes.ValidatorI, tokens sdk.DecCoins)


### PR DESCRIPTION
# Purpose / Abstract

- Add x/oracle slashing events to block_results. SlashingKeeper wraps StakingKeeper and delegates `Slash` and `Jail` to it, but adds extra events to the block output.
