### PR TITLE
feat(evm): module and keeper start

### DIFF
--- a/app/keepers.go
+++ b/app/keepers.go
@@ -111,6 +111,9 @@ import (
 	"github.com/NibiruChain/nibiru/x/epochs"
 	epochskeeper "github.com/NibiruChain/nibiru/x/epochs/keeper"
 	epochstypes "github.com/NibiruChain/nibiru/x/epochs/types"
+	"github.com/NibiruChain/nibiru/x/evm"
+	"github.com/NibiruChain/nibiru/x/evm/evmmodule"
+	evmkeeper "github.com/NibiruChain/nibiru/x/evm/keeper"
 	"github.com/NibiruChain/nibiru/x/genmsg"
 	"github.com/NibiruChain/nibiru/x/inflation"
 	inflationkeeper "github.com/NibiruChain/nibiru/x/inflation/keeper"
@@ -182,6 +185,7 @@ type AppKeepers struct {
 	SudoKeeper         keeper.Keeper
 	DevGasKeeper       devgaskeeper.Keeper
 	TokenFactoryKeeper tokenfactorykeeper.Keeper
+	EvmKeeper          evmkeeper.Keeper
 
 	// WASM keepers
 	WasmKeeper       wasmkeeper.Keeper
@@ -224,6 +228,8 @@ func initStoreKeys() (
 		wasmtypes.StoreKey,
 		devgastypes.StoreKey,
 		tokenfactorytypes.StoreKey,
+
+		evm.StoreKey,
 	)
 	tkeys = sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
 	memKeys = sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
@@ -382,6 +388,13 @@ func (app *NibiruApp) InitKeepers(
 			app.InflationKeeper.Hooks(),
 			app.OracleKeeper.Hooks(),
 		),
+	)
+
+	app.EvmKeeper = evmkeeper.NewKeeper(
+		appCodec,
+		keys[evm.StoreKey],
+		tkeys[evm.TransientKey],
+		authtypes.NewModuleAddress(govtypes.ModuleName),
 	)
 
 	// ---------------------------------- IBC keepers
@@ -622,6 +635,8 @@ func (app *NibiruApp) initAppModules(
 		ibcfee.NewAppModule(app.ibcFeeKeeper),
 		ica.NewAppModule(&app.icaControllerKeeper, &app.icaHostKeeper),
 
+		evmmodule.NewAppModule(&app.EvmKeeper, app.AccountKeeper),
+
 		// wasm
 		wasm.NewAppModule(
 			appCodec, &app.WasmKeeper, app.stakingKeeper, app.AccountKeeper,
@@ -692,12 +707,15 @@ func orderedModuleNames() []string {
 		icatypes.ModuleName,
 
 		// --------------------------------------------------------------------
+		evm.ModuleName,
+
+		// --------------------------------------------------------------------
 		// CosmWasm
 		wasmtypes.ModuleName,
 		devgastypes.ModuleName,
 		tokenfactorytypes.ModuleName,
 
-		// Should be before genmsg
+		// Everything else should be before genmsg
 		genmsg.ModuleName,
 	}
 }
@@ -794,6 +812,7 @@ func ModuleBasicManager() module.BasicManager {
 		ibctm.AppModuleBasic{},
 		ica.AppModuleBasic{},
 		// native x/
+		evmmodule.AppModuleBasic{},
 		oracle.AppModuleBasic{},
 		epochs.AppModuleBasic{},
 		inflation.AppModuleBasic{},
@@ -819,6 +838,7 @@ func ModuleAccPerms() map[string][]string {
 		ibcfeetypes.ModuleName:         {},
 		icatypes.ModuleName:            {},
 
+		evm.ModuleName:                   {authtypes.Minter, authtypes.Burner},
 		epochstypes.ModuleName:           {},
 		sudotypes.ModuleName:             {},
 		common.TreasuryPoolModuleAccount: {},

--- a/eth/chain_id.go
+++ b/eth/chain_id.go
@@ -33,8 +33,9 @@ func IsValidChainID(chainID string) bool {
 	return nibiruEvmChainId.MatchString(chainID)
 }
 
-// ParseChainID parses a string chain identifier's epoch to an Ethereum-compatible
-// chain-id in *big.Int format. The function returns an error if the chain-id has an invalid format
+// ParseChainID parses a string chain identifier's epoch to an
+// Ethereum-compatible chain-id in *big.Int format. The function returns an error
+// if the chain-id has an invalid format
 func ParseChainID(chainID string) (*big.Int, error) {
 	chainID = strings.TrimSpace(chainID)
 	if len(chainID) > 48 {

--- a/x/common/error.go
+++ b/x/common/error.go
@@ -187,3 +187,11 @@ func CombineErrorsFromStrings(strs ...string) (err error) {
 func ErrNilMsg() error {
 	return grpcstatus.Errorf(grpccodes.InvalidArgument, "nil msg")
 }
+
+// ErrNotImplemented: Represents an function error value.
+func ErrNotImplemented() error { return fmt.Errorf("fn not implemented yet") }
+
+// ErrNotImplementedGprc: Represents an unimplemented gRPC method.
+func ErrNotImplementedGprc() error {
+	return grpcstatus.Error(grpccodes.Unimplemented, ErrNotImplemented().Error())
+}

--- a/x/evm/cli/cli.go
+++ b/x/evm/cli/cli.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/NibiruChain/nibiru/x/evm"
+	"github.com/NibiruChain/nibiru/x/sudo/types"
+
+	"github.com/cosmos/cosmos-sdk/client"
+
+	"github.com/spf13/cobra"
+)
+
+// GetTxCmd returns a cli command for this module's transactions
+func GetTxCmd() *cobra.Command {
+	txCmd := &cobra.Command{
+		Use:                        evm.ModuleName,
+		Short:                      fmt.Sprintf("x/%s transaction subcommands", evm.ModuleName),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmds := []*cobra.Command{}
+	for _, cmd := range cmds {
+		txCmd.AddCommand(cmd)
+	}
+
+	return txCmd
+}
+
+// GetQueryCmd returns a cli command for this module's queries
+func GetQueryCmd() *cobra.Command {
+	moduleQueryCmd := &cobra.Command{
+		Use: evm.ModuleName,
+		Short: fmt.Sprintf(
+			"Query commands for the x/%s module", types.ModuleName),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	// Add subcommands
+	cmds := []*cobra.Command{}
+	for _, cmd := range cmds {
+		moduleQueryCmd.AddCommand(cmd)
+	}
+
+	return moduleQueryCmd
+}

--- a/x/evm/codec.go
+++ b/x/evm/codec.go
@@ -22,11 +22,6 @@ var (
 	AminoCdc = codec.NewAminoCodec(amino)
 )
 
-const (
-	// Amino names
-	updateParamsName = "evm/MsgUpdateParams"
-)
-
 // NOTE: This is required for the GetSignBytes function
 func init() {
 	RegisterLegacyAminoCodec(amino)

--- a/x/evm/const.go
+++ b/x/evm/const.go
@@ -60,3 +60,17 @@ func PrefixAccStateEthAddr(address common.Address) []byte {
 func StateKey(address common.Address, key []byte) []byte {
 	return append(PrefixAccStateEthAddr(address), key...)
 }
+
+const (
+	// Amino names
+	updateParamsName = "evm/MsgUpdateParams"
+)
+
+type CallType int
+
+const (
+	// CallTypeRPC call type is used on requests to eth_estimateGas rpc API endpoint
+	CallTypeRPC CallType = iota + 1
+	// CallTypeSmart call type is used in case of smart contract methods calls
+	CallTypeSmart
+)

--- a/x/evm/deps.go
+++ b/x/evm/deps.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023-2024 Nibi, Inc.
+package evm
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// AccountKeeper defines the expected account keeper interface
+type AccountKeeper interface {
+	NewAccountWithAddress(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
+	GetModuleAddress(moduleName string) sdk.AccAddress
+	GetAllAccounts(ctx sdk.Context) (accounts []authtypes.AccountI)
+	IterateAccounts(ctx sdk.Context, cb func(account authtypes.AccountI) bool)
+	GetSequence(sdk.Context, sdk.AccAddress) (uint64, error)
+	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
+	SetAccount(ctx sdk.Context, account authtypes.AccountI)
+	RemoveAccount(ctx sdk.Context, account authtypes.AccountI)
+	GetParams(ctx sdk.Context) (params authtypes.Params)
+}
+
+// BankKeeper defines the expected interface needed to retrieve account balances.
+type BankKeeper interface {
+	authtypes.BankKeeper
+	GetBalance(ctx sdk.Context, addr sdk.AccAddress, denom string) sdk.Coin
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
+	BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
+}
+
+// StakingKeeper returns the historical headers kept in store.
+type StakingKeeper interface {
+	GetHistoricalInfo(ctx sdk.Context, height int64) (stakingtypes.HistoricalInfo, bool)
+	GetValidatorByConsAddr(ctx sdk.Context, consAddr sdk.ConsAddress) (validator stakingtypes.Validator, found bool)
+}

--- a/x/evm/evmmodule/genesis.go
+++ b/x/evm/evmmodule/genesis.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2023-2024 Nibi, Inc.
+package evmmodule
+
+import (
+	abci "github.com/cometbft/cometbft/abci/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/NibiruChain/nibiru/x/evm"
+	"github.com/NibiruChain/nibiru/x/evm/keeper"
+)
+
+// InitGenesis initializes genesis state based on exported genesis
+func InitGenesis(
+	ctx sdk.Context,
+	k *keeper.Keeper,
+	accountKeeper evm.AccountKeeper,
+	data evm.GenesisState,
+) []abci.ValidatorUpdate {
+	// TODO: impl InitGenesis
+	return []abci.ValidatorUpdate{}
+}
+
+// ExportGenesis exports genesis state of the EVM module
+func ExportGenesis(ctx sdk.Context, k *keeper.Keeper, ak evm.AccountKeeper) *evm.GenesisState {
+	// TODO: impl ExportGenesis
+	return &evm.GenesisState{
+		Accounts: []evm.GenesisAccount{},
+		Params:   evm.Params{},
+	}
+}

--- a/x/evm/evmmodule/module.go
+++ b/x/evm/evmmodule/module.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2023-2024 Nibi, Inc.
+package evmmodule
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gorilla/mux"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
+	"github.com/NibiruChain/nibiru/x/evm"
+	"github.com/NibiruChain/nibiru/x/evm/cli"
+	"github.com/NibiruChain/nibiru/x/evm/keeper"
+)
+
+// consensusVersion: EVM module consensus version for upgrades.
+const consensusVersion = 1
+
+var (
+	_ module.AppModule           = AppModule{}
+	_ module.AppModuleBasic      = AppModuleBasic{}
+	_ module.EndBlockAppModule   = AppModule{}
+	_ module.BeginBlockAppModule = AppModule{}
+)
+
+// AppModuleBasic defines the basic application module used by the evm module.
+type AppModuleBasic struct{}
+
+// Name returns the evm module's name.
+func (AppModuleBasic) Name() string {
+	return evm.ModuleName
+}
+
+// RegisterLegacyAminoCodec registers the module's types with the given codec.
+func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	evm.RegisterLegacyAminoCodec(cdc)
+}
+
+// ConsensusVersion returns the consensus state-breaking version for the module.
+func (AppModuleBasic) ConsensusVersion() uint64 {
+	return consensusVersion
+}
+
+// DefaultGenesis returns default genesis state as raw bytes for the evm
+// module.
+func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	return cdc.MustMarshalJSON(evm.DefaultGenesisState())
+}
+
+// ValidateGenesis is the validation check of the Genesis
+func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, _ client.TxEncodingConfig, bz json.RawMessage) error {
+	var genesisState evm.GenesisState
+	if err := cdc.UnmarshalJSON(bz, &genesisState); err != nil {
+		return fmt.Errorf("failed to unmarshal %s genesis state: %w", evm.ModuleName, err)
+	}
+
+	return genesisState.Validate()
+}
+
+// RegisterRESTRoutes performs a no-op as the EVM module doesn't expose REST
+// endpoints
+func (AppModuleBasic) RegisterRESTRoutes(_ client.Context, _ *mux.Router) {
+}
+
+func (b AppModuleBasic) RegisterGRPCGatewayRoutes(c client.Context, serveMux *runtime.ServeMux) {
+	if err := evm.RegisterQueryHandlerClient(context.Background(), serveMux, evm.NewQueryClient(c)); err != nil {
+		panic(err)
+	}
+}
+
+// GetTxCmd returns the root tx command for the evm module.
+func (AppModuleBasic) GetTxCmd() *cobra.Command {
+	return cli.GetTxCmd()
+}
+
+// GetQueryCmd returns no root query command for the evm module.
+func (AppModuleBasic) GetQueryCmd() *cobra.Command {
+	return cli.GetQueryCmd()
+}
+
+// RegisterInterfaces registers interfaces and implementations of the evm module.
+func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
+	evm.RegisterInterfaces(registry)
+}
+
+// ____________________________________________________________________________
+
+// AppModule implements an application module for the evm module.
+type AppModule struct {
+	AppModuleBasic
+	keeper *keeper.Keeper
+	ak     evm.AccountKeeper
+}
+
+// NewAppModule creates a new AppModule object
+func NewAppModule(k *keeper.Keeper, ak evm.AccountKeeper) AppModule {
+	return AppModule{
+		AppModuleBasic: AppModuleBasic{},
+		keeper:         k,
+		ak:             ak,
+	}
+}
+
+// Name returns the evm module's name.
+func (AppModule) Name() string {
+	return evm.ModuleName
+}
+
+// RegisterInvariants interface for registering invariants. Performs a no-op
+// as the evm module doesn't expose invariants.
+func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {
+}
+
+// RegisterServices registers a GRPC query service to respond to the
+// module-specific GRPC queries.
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	evm.RegisterMsgServer(cfg.MsgServer(), am.keeper)
+	evm.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+}
+
+// BeginBlock returns the begin block for the evm module.
+func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
+	am.keeper.BeginBlock(ctx, req)
+}
+
+// EndBlock returns the end blocker for the evm module. It returns no validator
+// updates.
+func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.ValidatorUpdate {
+	return am.keeper.EndBlock(ctx, req)
+}
+
+// InitGenesis performs genesis initialization for the evm module. It returns
+// no validator updates.
+func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.RawMessage) []abci.ValidatorUpdate {
+	var genesisState evm.GenesisState
+	cdc.MustUnmarshalJSON(data, &genesisState)
+	InitGenesis(ctx, am.keeper, am.ak, genesisState)
+	return []abci.ValidatorUpdate{}
+}
+
+// ExportGenesis returns the exported genesis state as raw bytes for the evm
+// module.
+func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
+	gs := ExportGenesis(ctx, am.keeper, am.ak)
+	return cdc.MustMarshalJSON(gs)
+}
+
+// RegisterStoreDecoder registers a decoder for evm module's types
+func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {
+}
+
+// GenerateGenesisState creates a randomized GenState of the evm module.
+func (AppModule) GenerateGenesisState(_ *module.SimulationState) {
+}
+
+// WeightedOperations returns the all the evm module operations with their respective weights.
+func (am AppModule) WeightedOperations(_ module.SimulationState) []simtypes.WeightedOperation {
+	return nil
+}

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2023-2024 Nibi, Inc.
+package keeper
+
+import (
+	"context"
+
+	sdkmath "cosmossdk.io/math"
+
+	"github.com/NibiruChain/nibiru/x/common"
+	"github.com/NibiruChain/nibiru/x/evm"
+)
+
+// Compile-time interface assertion
+var _ evm.QueryServer = Keeper{}
+
+// Account: Implements the gRPC query for "/eth.evm.v1.Query/Account".
+// Account retrieves the account details for a given Ethereum hex address.
+//
+// Parameters:
+//   - goCtx: The context.Context object representing the request context.
+//   - req: The QueryAccountRequest object containing the Ethereum address.
+//
+// Returns:
+//   - A pointer to the QueryAccountResponse object containing the account details.
+//   - An error if the account retrieval process encounters any issues.
+func (k Keeper) Account(
+	goCtx context.Context, req *evm.QueryAccountRequest,
+) (*evm.QueryAccountResponse, error) {
+	// TODO: feat(evm): impl query Account
+	return &evm.QueryAccountResponse{
+		Balance:  "",
+		CodeHash: "",
+		Nonce:    0,
+	}, common.ErrNotImplementedGprc()
+}
+
+// CosmosAccount: Implements the gRPC query for "/eth.evm.v1.Query/CosmosAccount".
+// CosmosAccount retrieves the Cosmos account details for a given Ethereum address.
+//
+// Parameters:
+//   - goCtx: The context.Context object representing the request context.
+//   - req: The QueryCosmosAccountRequest object containing the Ethereum address.
+//
+// Returns:
+//   - A pointer to the QueryCosmosAccountResponse object containing the Cosmos account details.
+//   - An error if the account retrieval process encounters any issues.
+func (k Keeper) CosmosAccount(
+	goCtx context.Context, req *evm.QueryCosmosAccountRequest,
+) (*evm.QueryCosmosAccountResponse, error) {
+	// TODO: feat(evm): impl query CosmosAccount
+	return &evm.QueryCosmosAccountResponse{
+		CosmosAddress: "",
+		Sequence:      0,
+		AccountNumber: 0,
+	}, common.ErrNotImplementedGprc()
+}
+
+// ValidatorAccount: Implements the gRPC query for "/eth.evm.v1.Query/ValidatorAccount".
+// ValidatorAccount retrieves the account details for a given validator consensus address.
+//
+// Parameters:
+//   - goCtx: The context.Context object representing the request context.
+//   - req: The QueryValidatorAccountRequest object containing the validator consensus address.
+//
+// Returns:
+//   - A pointer to the QueryValidatorAccountResponse object containing the account details.
+//   - An error if the account retrieval process encounters any issues.
+func (k Keeper) ValidatorAccount(
+	goCtx context.Context, req *evm.QueryValidatorAccountRequest,
+) (*evm.QueryValidatorAccountResponse, error) {
+	// TODO: feat(evm): impl query ValidatorAccount
+	return &evm.QueryValidatorAccountResponse{
+		AccountAddress: "",
+		Sequence:       0,
+		AccountNumber:  0,
+	}, common.ErrNotImplementedGprc()
+}
+
+// Balance: Implements the gRPC query for "/eth.evm.v1.Query/Balance".
+// Balance retrieves the balance of an Ethereum address in "Ether", which
+// actually refers to NIBI tokens on Nibiru EVM.
+//
+// Parameters:
+//   - goCtx: The context.Context object representing the request context.
+//   - req: The QueryBalanceRequest object containing the Ethereum address.
+//
+// Returns:
+//   - A pointer to the QueryBalanceResponse object containing the balance.
+//   - An error if the balance retrieval process encounters any issues.
+func (k Keeper) Balance(goCtx context.Context, req *evm.QueryBalanceRequest) (*evm.QueryBalanceResponse, error) {
+	// TODO: feat(evm): impl query Balance
+	return &evm.QueryBalanceResponse{
+		Balance: "",
+	}, common.ErrNotImplementedGprc()
+}
+
+// BaseFee implements the Query/BaseFee gRPC method
+func (k Keeper) BaseFee(
+	goCtx context.Context, _ *evm.QueryBaseFeeRequest,
+) (*evm.QueryBaseFeeResponse, error) {
+	// TODO: feat(evm): impl query BaseFee
+	return &evm.QueryBaseFeeResponse{
+		BaseFee: &sdkmath.Int{},
+	}, common.ErrNotImplementedGprc()
+}
+
+// Storage: Implements the gRPC query for "/eth.evm.v1.Query/Storage".
+// Storage retrieves the storage value for a given Ethereum address and key.
+//
+// Parameters:
+//   - goCtx: The context.Context object representing the request context.
+//   - req: The QueryStorageRequest object containing the Ethereum address and key.
+//
+// Returns:
+//   - A pointer to the QueryStorageResponse object containing the storage value.
+//   - An error if the storage retrieval process encounters any issues.
+func (k Keeper) Storage(goCtx context.Context, req *evm.QueryStorageRequest) (*evm.QueryStorageResponse, error) {
+	// TODO: feat(evm): impl query Storage
+	return &evm.QueryStorageResponse{
+		Value: "",
+	}, common.ErrNotImplementedGprc()
+}
+
+// Code: Implements the gRPC query for "/eth.evm.v1.Query/Code".
+// Code retrieves the smart contract bytecode associated with a given Ethereum
+// address.
+//
+// Parameters:
+//   - goCtx: The context.Context object representing the request context.
+//   - req: The QueryCodeRequest object containing the Ethereum address.
+//
+// Returns:
+//   - A pointer to the QueryCodeResponse object containing the code.
+//   - An error if the code retrieval process encounters any issues.
+func (k Keeper) Code(goCtx context.Context, req *evm.QueryCodeRequest) (*evm.QueryCodeResponse, error) {
+	// TODO: feat(evm): impl query Code
+	return &evm.QueryCodeResponse{
+		Code: []byte{},
+	}, common.ErrNotImplementedGprc()
+}
+
+// Params: Implements the gRPC query for "/eth.evm.v1.Query/Params".
+// Params retrieves the EVM module parameters.
+//
+// Parameters:
+//   - goCtx: The context.Context object representing the request context.
+//   - req: The QueryParamsRequest object (unused).
+//
+// Returns:
+//   - A pointer to the QueryParamsResponse object containing the EVM module parameters.
+//   - An error if the parameter retrieval process encounters any issues.
+func (k Keeper) Params(goCtx context.Context, _ *evm.QueryParamsRequest) (*evm.QueryParamsResponse, error) {
+	// TODO: feat(evm): impl query Params
+	return &evm.QueryParamsResponse{
+		Params: evm.Params{},
+	}, common.ErrNotImplementedGprc()
+}
+
+// EthCall: Implements the gRPC query for "/eth.evm.v1.Query/EthCall".
+// EthCall performs a smart contract call using the eth_call JSON-RPC method.
+//
+// Parameters:
+//   - goCtx: The context.Context object representing the request context.
+//   - req: The EthCallRequest object containing the call parameters.
+//
+// Returns:
+//   - A pointer to the MsgEthereumTxResponse object containing the result of the eth_call.
+//   - An error if the eth_call process encounters any issues.
+func (k Keeper) EthCall(
+	goCtx context.Context, req *evm.EthCallRequest,
+) (*evm.MsgEthereumTxResponse, error) {
+	// TODO: feat(evm): impl query EthCall
+	return &evm.MsgEthereumTxResponse{
+		Hash:    "",
+		Logs:    []*evm.Log{},
+		Ret:     []byte{},
+		VmError: "",
+		GasUsed: 0,
+	}, common.ErrNotImplementedGprc()
+}
+
+// EstimateGas: Implements the gRPC query for "/eth.evm.v1.Query/EstimateGas".
+// EstimateGas implements eth_estimateGas rpc api.
+func (k Keeper) EstimateGas(
+	goCtx context.Context, req *evm.EthCallRequest,
+) (*evm.EstimateGasResponse, error) {
+	// TODO: feat(evm): impl query EstimateGas
+	return k.EstimateGasForEvmCallType(goCtx, req, evm.CallTypeRPC)
+}
+
+// EstimateGas estimates the gas cost of a transaction. This can be called with
+// the "eth_estimateGas" JSON-RPC method or an smart contract query.
+//
+// When [EstimateGas] is called from the JSON-RPC client, we need to reset the
+// gas meter before simulating the transaction (tx) to have an accurate gas estimate
+// txs using EVM extensions.
+//
+// Parameters:
+//   - goCtx: The context.Context object representing the request context.
+//   - req: The EthCallRequest object containing the transaction parameters.
+//
+// Returns:
+//   - A pointer to the EstimateGasResponse object containing the estimated gas cost.
+//   - An error if the gas estimation process encounters any issues.
+func (k Keeper) EstimateGasForEvmCallType(
+	goCtx context.Context, req *evm.EthCallRequest, fromType evm.CallType,
+) (*evm.EstimateGasResponse, error) {
+	// TODO: feat(evm): impl query EstimateGasForEvmCallType
+	return &evm.EstimateGasResponse{
+		Gas: 0,
+	}, common.ErrNotImplementedGprc()
+}
+
+// TraceTx configures a new tracer according to the provided configuration, and
+// executes the given message in the provided environment. The return value will
+// be tracer dependent.
+func (k Keeper) TraceTx(
+	goCtx context.Context, req *evm.QueryTraceTxRequest,
+) (*evm.QueryTraceTxResponse, error) {
+	// TODO: feat(evm): impl query TraceTx
+	return &evm.QueryTraceTxResponse{
+		Data: []byte{},
+	}, common.ErrNotImplementedGprc()
+}
+
+// TraceBlock: Implements the gRPC query for "/eth.evm.v1.Query/TraceBlock".
+// Configures a Nibiru EVM tracer that is used to "trace" and analyze
+// the execution of transactions within a given block. Block information is read
+// from the context (goCtx). [TraceBlock] is responsible iterates over each Eth
+// transacion message and calls [TraceEthTxMsg] on it.
+func (k Keeper) TraceBlock(
+	goCtx context.Context, req *evm.QueryTraceBlockRequest,
+) (*evm.QueryTraceBlockResponse, error) {
+	// TODO: feat(evm): impl query TraceBlock
+	return &evm.QueryTraceBlockResponse{
+		Data: []byte{},
+	}, common.ErrNotImplementedGprc()
+}

--- a/x/evm/keeper/hooks.go
+++ b/x/evm/keeper/hooks.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2023-2024 Nibi, Inc.
+package keeper
+
+import (
+	abci "github.com/cometbft/cometbft/abci/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// BeginBlock sets the sdk Context and EIP155 chain id to the Keeper.
+func (k *Keeper) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
+	// TODO: feat(evm): impl BeginBlock
+}
+
+// EndBlock also retrieves the bloom filter value from the transient store and commits it to the
+// KVStore. The EVM end block logic doesn't update the validator set, thus it returns
+// an empty slice.
+func (k *Keeper) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	// TODO: feat(evm): impl EndBlock
+	return []abci.ValidatorUpdate{}
+}

--- a/x/evm/keeper/keeper.go
+++ b/x/evm/keeper/keeper.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023-2024 Nibi, Inc.
+package keeper
+
+import (
+	// "github.com/NibiruChain/nibiru/x/evm"
+	"github.com/cosmos/cosmos-sdk/codec"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type Keeper struct {
+	cdc codec.BinaryCodec
+	// storeKey: For persistent storage of EVM state.
+	storeKey storetypes.StoreKey
+	// transientKey: Store key that resets every block during Commit
+	transientKey storetypes.StoreKey
+
+	// the address capable of executing a MsgUpdateParams message. Typically, this should be the x/gov module account.
+	authority sdk.AccAddress
+}
+
+func NewKeeper(
+	cdc codec.BinaryCodec,
+	storeKey, transientKey storetypes.StoreKey,
+	authority sdk.AccAddress,
+) Keeper {
+	if err := sdk.VerifyAddressFormat(authority); err != nil {
+		panic(err)
+	}
+	return Keeper{
+		cdc:          cdc,
+		storeKey:     storeKey,
+		transientKey: transientKey,
+		authority:    authority,
+	}
+}

--- a/x/evm/keeper/keeper_test.go
+++ b/x/evm/keeper/keeper_test.go
@@ -1,0 +1,99 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/NibiruChain/nibiru/x/common"
+	"github.com/NibiruChain/nibiru/x/common/testutil/testapp"
+)
+
+type KeeperSuite struct {
+	suite.Suite
+}
+
+// TestKeeperSuite: Runs all of the tests in the suite.
+func TestKeeperSuite(t *testing.T) {
+	s := new(KeeperSuite)
+	suite.Run(t, s)
+}
+
+func (s *KeeperSuite) TestMsgServer() {
+	chain, ctx := testapp.NewNibiruTestAppAndContext()
+	goCtx := sdk.WrapSDKContext(ctx)
+	k := chain.EvmKeeper
+	for _, testCase := range []func() error{
+		func() error {
+			_, err := k.EthereumTx(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.UpdateParams(goCtx, nil)
+			return err
+		},
+	} {
+		err := testCase()
+		s.Require().ErrorContains(err, common.ErrNotImplemented().Error())
+	}
+}
+
+func (s *KeeperSuite) TestQuerier() {
+	chain, ctx := testapp.NewNibiruTestAppAndContext()
+	goCtx := sdk.WrapSDKContext(ctx)
+	k := chain.EvmKeeper
+	for _, testCase := range []func() error{
+		func() error {
+			_, err := k.Account(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.CosmosAccount(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.ValidatorAccount(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.Balance(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.BaseFee(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.Storage(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.Code(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.Params(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.EthCall(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.EstimateGas(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.TraceTx(goCtx, nil)
+			return err
+		},
+		func() error {
+			_, err := k.TraceBlock(goCtx, nil)
+			return err
+		},
+	} {
+		err := testCase()
+		s.Require().ErrorContains(err, common.ErrNotImplemented().Error())
+	}
+}

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023-2024 Nibi, Inc.
+package keeper
+
+import (
+	"context"
+
+	"github.com/NibiruChain/nibiru/x/common"
+	"github.com/NibiruChain/nibiru/x/evm"
+)
+
+var _ evm.MsgServer = &Keeper{}
+
+func (k *Keeper) EthereumTx(
+	goCtx context.Context, msg *evm.MsgEthereumTx,
+) (resp *evm.MsgEthereumTxResponse, err error) {
+	// TODO: feat(evm): EthereumTx impl
+	return resp, common.ErrNotImplemented()
+}
+
+func (k *Keeper) UpdateParams(
+	goCtx context.Context, msg *evm.MsgUpdateParams,
+) (resp *evm.MsgUpdateParamsResponse, err error) {
+	// TODO: feat(evm): UpdateParams impl
+	return resp, common.ErrNotImplemented()
+}


### PR DESCRIPTION
- Part of #1836
- This PR wires the EVM Module into the `BaseApp`, using placeholder functions to satisfy the `AppModule` interface methods. 
