### PR TITLE
feat(wasm)!: increase contract size limit to 3MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1766](https://github.com/NibiruChain/nibiru/pull/1766) - refactor(app-wasmext)!: remove wasmbinding `CosmosMsg::Custom` bindings.
 - [#1776](https://github.com/NibiruChain/nibiru/pull/1776) - feat(inflation): make inflation params a collection and add commands to update them
 - [#1872](https://github.com/NibiruChain/nibiru/pull/1872) - chore(math): use cosmossdk.io/math to replace sdk types
-
 - [#1874](https://github.com/NibiruChain/nibiru/pull/1874) - chore(proto): remove the proto stringer as per Cosmos SDK migration guidelines
+- [#1906](https://github.com/NibiruChain/nibiru/pull/1906) - feat(wasm): increase contract size limit to 3MB
 
 #### Nibiru EVM
 

--- a/app/app.go
+++ b/app/app.go
@@ -131,7 +131,7 @@ const DefaultMaxTxGasWanted uint64 = 0
 //   - allow for larger wasm files
 func overrideWasmVariables() {
 	// Override Wasm size limitation from WASMD.
-	wasmtypes.MaxWasmSize = 3 * 1024 * 1024
+	wasmtypes.MaxWasmSize = 3 * 1024 * 1024 // 3MB
 	wasmtypes.MaxProposalWasmSize = wasmtypes.MaxWasmSize
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -127,6 +127,14 @@ func GetWasmOpts(nibiru NibiruApp, appOpts servertypes.AppOptions) []wasmkeeper.
 
 const DefaultMaxTxGasWanted uint64 = 0
 
+// overrideWasmVariables overrides the wasm variables to:
+//   - allow for larger wasm files
+func overrideWasmVariables() {
+	// Override Wasm size limitation from WASMD.
+	wasmtypes.MaxWasmSize = 3 * 1024 * 1024
+	wasmtypes.MaxProposalWasmSize = wasmtypes.MaxWasmSize
+}
+
 // NewNibiruApp returns a reference to an initialized NibiruApp.
 func NewNibiruApp(
 	logger log.Logger,
@@ -137,6 +145,7 @@ func NewNibiruApp(
 	appOpts servertypes.AppOptions,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *NibiruApp {
+	overrideWasmVariables()
 	appCodec := encodingConfig.Codec
 	legacyAmino := encodingConfig.Amino
 	interfaceRegistry := encodingConfig.InterfaceRegistry


### PR DESCRIPTION
# Purpose / Abstract

- Closes #1905 

<!-- 
Why is this PR important? 
What does this PR do?
-->

Increases the contract size limit to 3MB (up from 800KB). I originally tried to set the config via compile time flag (`-X github.com/CosmWasm/wasmd/x/wasm/types.MaxWasmSize=3145728`) but got an error `github.com/CosmWasm/wasmd/x/wasm/types.MaxWasmSize: cannot set with -X: not a var of type string (type:int)`. Seems like it's not possible to set an int variable with a compile time flag.

I took inspiration from [Osmosis](https://github.com/osmosis-labs/osmosis/blob/c13b40f597352483b5d12287e5a65b643db06c94/app/app.go#L192)' `overrideWasmVariables()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the contract size limit to 3MB in the Nibiru EVM, allowing for larger contracts.
- **Enhancements**
  - Adjusted wasm size limitations to support larger wasm files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->