### PR TITLE
chore: make default db backend PebbleDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1872](https://github.com/NibiruChain/nibiru/pull/1872) - chore(math): use cosmossdk.io/math to replace sdk types
 - [#1874](https://github.com/NibiruChain/nibiru/pull/1874) - chore(proto): remove the proto stringer as per Cosmos SDK migration guidelines
 - [#1906](https://github.com/NibiruChain/nibiru/pull/1906) - feat(wasm): increase contract size limit to 3MB
+- [#1908](https://github.com/NibiruChain/nibiru/pull/1908) - chore: make pebbledb the default db backend
 
 #### Nibiru EVM
 

--- a/cmd/nibid/cmd/init.go
+++ b/cmd/nibid/cmd/init.go
@@ -53,7 +53,7 @@ func customTendermintConfig() *tmcfg.Config {
 	cfg.Consensus.TimeoutPrecommitDelta = ms(500)
 	cfg.Consensus.TimeoutCommit = ms(1_000)
 
-	cfg.DBBackend = string(db.RocksDBBackend)
+	cfg.DBBackend = string(db.PebbleDBBackend)
 	return cfg
 }
 


### PR DESCRIPTION
# Purpose / Abstract

- Closes #1818 

<!-- 
Why is this PR important? 
What does this PR do?
-->

Makes `PebbleDB` the default DB Backend. It doesn't affect existing nodes. It only sets `db_backend = "pebbledb"` in `config.toml` when `nibid init` is called. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the default database backend to `pebbledb` for improved performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->