### PR TITLE
refactor(localnet): preserve local keyring on make localnet

### DIFF
--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -146,6 +146,7 @@ $BINARY config keyring-backend test
 $BINARY config chain-id $CHAIN_ID
 $BINARY config broadcast-mode sync
 $BINARY config output json
+$BINARY config node "http://localhost:26657"
 $BINARY config # Prints config.
 
 # Enable API Server

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -122,7 +122,7 @@ fi
 # Remove previous data, preserving keyring and config files
 echo_info "Removing previous chain data from $CHAIN_DIR..."
 $BINARY tendermint unsafe-reset-all
-rm "$CHAIN_DIR/config/genesis.json"
+rm -f "$CHAIN_DIR/config/genesis.json"
 rm -rf "$CHAIN_DIR/config/gentx/"
 
 # Add directory for chain, exit if error

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -54,9 +54,9 @@ echo_success() {
 
 echo_info "Parsing flags for the script..."
 
-# $FLAG_NO_BUILD: toggles whether to build from source. The default
-#   behavior of the script is to run make install if the flag --no-build is not present.
-FLAG_NO_BUILD=false
+# $FLAG_SKIP_BUILD: toggles whether to build from source. The default
+#   behavior of the script is to run make install if the flag --no-build is omitted.
+FLAG_SKIP_BUILD=false
 
 
 build_from_source() {
@@ -81,7 +81,7 @@ enable_feature_flag() {
 while [[ $# -gt 0 ]]; do
   case $1 in
   --no-build)
-    FLAG_NO_BUILD=true
+    FLAG_SKIP_BUILD=true
     shift
     ;;
   --features)
@@ -96,13 +96,13 @@ while [[ $# -gt 0 ]]; do
 done
 
 
-# Check if FLAG_NO_BUILD was set to true
-if ! $FLAG_NO_BUILD; then
+# Check if FLAG_SKIP_BUILD was set to true
+if ! $FLAG_SKIP_BUILD; then
   build_from_source
 fi
 
 echo_info "Features flags:"
-echo "FLAG_NO_BUILD: $FLAG_NO_BUILD"
+echo "FLAG_SKIP_BUILD: $FLAG_SKIP_BUILD"
 
 SEDOPTION=""
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
# Purpose / Abstract

A really annoying thing about the `make localnet` script is that it destroys the local keyring on every invocation. It makes interacting with other networks (e.g. mainnet, testnet, and devnet) really annoying.

This PR fixes the localnet.sh script to preserve the local keyring and only delete the local data files, so that localnet starts fresh from block 1.

<!-- 
Why is this PR important? 
What does this PR do?
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated script flag `FLAG_NO_BUILD` to `FLAG_SKIP_BUILD` for better clarity.
  - Improved flag logic and data removal steps in the `localnet.sh` script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->