### PR TITLE
refactor(db): use pebbledb as the default db in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1971](https://github.com/NibiruChain/nibiru/pull/1971) - feat(evm): typed events for contract creation, contract execution and transfer
 - [#1973](https://github.com/NibiruChain/nibiru/pull/1973) - chore(appconst): Add chain IDs ending in "3" to the "knownEthChainIDMap". This makes it possible to use devnet 3 and testnet 3.
 - [#1977](https://github.com/NibiruChain/nibiru/pull/1977) - fix(localnet): rolled back change of evm validator address with cosmos derivation path
+- [#1979](https://github.com/NibiruChain/nibiru/pull/1979) -refactor(db): use pebbledb as the default db in integration tests
 
 #### Dapp modules: perp, spot, oracle, etc
 

--- a/app/appconst/appconst.go
+++ b/app/appconst/appconst.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/big"
 	"runtime"
+
+	db "github.com/cometbft/cometbft-db"
 )
 
 const (
@@ -12,6 +14,10 @@ const (
 	BondDenom  = "unibi"
 	// AccountAddressPrefix: Bech32 prefix for Nibiru accounts.
 	AccountAddressPrefix = "nibi"
+)
+
+var (
+	DefaultDBBackend db.BackendType = db.PebbleDBBackend
 )
 
 // Runtime version vars

--- a/app/appconst/appconst.go
+++ b/app/appconst/appconst.go
@@ -17,7 +17,8 @@ const (
 )
 
 var (
-	DefaultDBBackend db.BackendType = db.PebbleDBBackend
+	DefaultDBBackend     db.BackendType = db.PebbleDBBackend
+	HavePebbleDBBuildTag bool
 )
 
 // Runtime version vars

--- a/app/appconst/consensus_config.go
+++ b/app/appconst/consensus_config.go
@@ -1,0 +1,29 @@
+package appconst
+
+import (
+	tmcfg "github.com/cometbft/cometbft/config"
+	"time"
+)
+
+// NewDefaultTendermintConfig returns a consensus "Config" (CometBFT) with new
+// default values for the "consensus" and "db_backend" fields to be enforced upon
+// node initialization. See the "nibiru/cmd/nibid/cmd/InitCmd" function for more
+// information.
+func NewDefaultTendermintConfig() *tmcfg.Config {
+	cfg := tmcfg.DefaultConfig()
+
+	// Overwrite consensus config
+	ms := func(n time.Duration) time.Duration {
+		return n * time.Millisecond
+	}
+	cfg.Consensus.TimeoutPropose = ms(3_000)
+	cfg.Consensus.TimeoutProposeDelta = ms(500)
+	cfg.Consensus.TimeoutPrevote = ms(1_000)
+	cfg.Consensus.TimeoutPrevoteDelta = ms(500)
+	cfg.Consensus.TimeoutPrecommit = ms(1_000)
+	cfg.Consensus.TimeoutPrecommitDelta = ms(500)
+	cfg.Consensus.TimeoutCommit = ms(1_000)
+
+	cfg.DBBackend = string(DefaultDBBackend)
+	return cfg
+}

--- a/app/appconst/consensus_config.go
+++ b/app/appconst/consensus_config.go
@@ -1,8 +1,9 @@
 package appconst
 
 import (
-	tmcfg "github.com/cometbft/cometbft/config"
 	"time"
+
+	tmcfg "github.com/cometbft/cometbft/config"
 )
 
 // NewDefaultTendermintConfig returns a consensus "Config" (CometBFT) with new

--- a/app/appconst/pebbledb.go
+++ b/app/appconst/pebbledb.go
@@ -1,0 +1,8 @@
+//go:build pebbledb
+// +build pebbledb
+
+package appconst
+
+func init() {
+	HavePebbleDBBuildTag = true
+}

--- a/cmd/ethclient/const.go
+++ b/cmd/ethclient/const.go
@@ -1,3 +1,0 @@
-package ethclient
-
-const Bech32Prefix = "nibi"

--- a/cmd/nibid/cmd/init.go
+++ b/cmd/nibid/cmd/init.go
@@ -7,8 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/NibiruChain/nibiru/app/appconst"
 	tmcfg "github.com/cometbft/cometbft/config"
+
+	"github.com/NibiruChain/nibiru/app/appconst"
 
 	tmcli "github.com/cometbft/cometbft/libs/cli"
 	tmrand "github.com/cometbft/cometbft/libs/rand"

--- a/cmd/nibid/cmd/init.go
+++ b/cmd/nibid/cmd/init.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
-	db "github.com/cometbft/cometbft-db"
+	"github.com/NibiruChain/nibiru/app/appconst"
 	tmcfg "github.com/cometbft/cometbft/config"
 
 	tmcli "github.com/cometbft/cometbft/libs/cli"
@@ -37,25 +36,6 @@ const (
 	// FlagDefaultBondDenom defines the default denom to use in the genesis file.
 	FlagDefaultBondDenom = "default-denom"
 )
-
-func customTendermintConfig() *tmcfg.Config {
-	cfg := tmcfg.DefaultConfig()
-
-	// Overwrite consensus config
-	ms := func(n time.Duration) time.Duration {
-		return n * time.Millisecond
-	}
-	cfg.Consensus.TimeoutPropose = ms(3_000)
-	cfg.Consensus.TimeoutProposeDelta = ms(500)
-	cfg.Consensus.TimeoutPrevote = ms(1_000)
-	cfg.Consensus.TimeoutPrevoteDelta = ms(500)
-	cfg.Consensus.TimeoutPrecommit = ms(1_000)
-	cfg.Consensus.TimeoutPrecommitDelta = ms(500)
-	cfg.Consensus.TimeoutCommit = ms(1_000)
-
-	cfg.DBBackend = string(db.PebbleDBBackend)
-	return cfg
-}
 
 /*
 InitCmd is a stand-in replacement for genutilcli.InitCmd that overwrites the
@@ -176,7 +156,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 
 			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "", appState)
 
-			customCfg := customTendermintConfig()
+			customCfg := appconst.NewDefaultTendermintConfig()
 			config.Consensus = customCfg.Consensus
 			config.DBBackend = customCfg.DBBackend
 			tmcfg.WriteConfigFile(filepath.Join(config.RootDir, "config", "config.toml"), config)

--- a/cmd/nibid/cmd/root.go
+++ b/cmd/nibid/cmd/root.go
@@ -76,7 +76,7 @@ func NewRootCmd() (*cobra.Command, app.EncodingConfig) {
 			}
 
 			customAppTemplate, customAppConfig := srvconfig.AppConfig("unibi")
-			tmCfg := customTendermintConfig()
+			tmCfg := appconst.NewDefaultTendermintConfig()
 
 			return sdkserver.InterceptConfigsPreRunHandler(
 				cmd,

--- a/contrib/make/test.mk
+++ b/contrib/make/test.mk
@@ -9,6 +9,7 @@ test-unit:
 .PHONY: test-coverage-unit
 test-coverage-unit:
 	go test ./... -short \
+		-tags=pebbledb \
 		-coverprofile=coverage.txt \
 		-covermode=atomic \
 		-race
@@ -18,10 +19,10 @@ test-coverage-unit:
 .PHONY: test-coverage-integration
 test-coverage-integration:
 	go test ./... \
+		-tags=pebbledb \
 		-coverprofile=coverage.txt \
 		-covermode=atomic \
-		-race \
-		-v
+		-race
 
 # Require Python3
 .PHONY: test-create-test-cases

--- a/eth/eip712/eip712_test.go
+++ b/eth/eip712/eip712_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
+	"github.com/NibiruChain/nibiru/app/appconst"
 	"github.com/NibiruChain/nibiru/eth/eip712"
 	"github.com/NibiruChain/nibiru/x/common/testutil"
 	"github.com/NibiruChain/nibiru/x/evm"
@@ -27,7 +28,6 @@ import (
 	"github.com/NibiruChain/nibiru/eth/crypto/ethsecp256k1"
 
 	"github.com/NibiruChain/nibiru/app"
-	"github.com/NibiruChain/nibiru/cmd/ethclient"
 
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
@@ -82,7 +82,7 @@ func (suite *EIP712TestSuite) SetupTest() {
 	suite.clientCtx = client.Context{}.WithTxConfig(suite.config.TxConfig)
 	suite.denom = evm.DefaultEVMDenom
 
-	sdk.GetConfig().SetBech32PrefixForAccount(ethclient.Bech32Prefix, "")
+	sdk.GetConfig().SetBech32PrefixForAccount(appconst.AccountAddressPrefix, "")
 	eip712.SetEncodingConfig(suite.config)
 }
 
@@ -369,7 +369,7 @@ func (suite *EIP712TestSuite) TestEIP712() {
 					AccountNumber: params.accountNumber,
 					Sequence:      params.sequence,
 					PubKey:        pubKey,
-					Address:       sdk.MustBech32ifyAddressBytes(ethclient.Bech32Prefix, pubKey.Bytes()),
+					Address:       sdk.MustBech32ifyAddressBytes(appconst.AccountAddressPrefix, pubKey.Bytes()),
 				}
 
 				bz, err := suite.clientCtx.TxConfig.SignModeHandler().GetSignBytes(

--- a/x/common/testutil/testnetwork/network.go
+++ b/x/common/testutil/testnetwork/network.go
@@ -191,8 +191,10 @@ func New(logger Logger, baseDir string, cfg Config) (network *Network, err error
 		tmCfg := ctx.Config
 
 		tmCfg.Consensus.TimeoutCommit = cfg.TimeoutCommit
-		defaultTmCfg := appconst.NewDefaultTendermintConfig()
-		tmCfg.DBBackend = defaultTmCfg.DBBackend
+		if appconst.HavePebbleDBBuildTag {
+			defaultTmCfg := appconst.NewDefaultTendermintConfig()
+			tmCfg.DBBackend = defaultTmCfg.DBBackend
+		}
 
 		// Only allow the first validator to expose an RPC, API and gRPC
 		// server/client due to Tendermint in-process constraints.

--- a/x/common/testutil/testnetwork/util.go
+++ b/x/common/testutil/testnetwork/util.go
@@ -69,11 +69,11 @@ func startInProcess(cfg Config, val *Validator) error {
 		logger.With("module", val.Moniker),
 	)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to construct Node: %w", err)
 	}
 
 	if err := tmNode.Start(); err != nil {
-		return err
+		return fmt.Errorf("failed Node.Start(): %w", err)
 	}
 
 	val.tmNode = tmNode


### PR DESCRIPTION
Uses the DB backend from production in our test suites 

- **refactor: remove unused vars. improve error clarity for testnetwork/New**
- **refactor: use pebbledb as the test db**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new default database backend, PebbleDB, for improved testing reliability.
	- Added a function to generate default configurations for the CometBFT consensus mechanism.

- **Improvements**
	- Enhanced error handling across various components, providing clearer context in error messages.
	- Streamlined the initialization process for Tendermint configuration, promoting consistency and maintainability.

- **Bug Fixes**
	- Updated account address prefix usage in tests for alignment with new conventions. 

- **Documentation**
	- Updated CHANGELOG.md to reflect recent changes and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->