### PR TITLE
fix(evm): remove isCheckTx() short circuit on `AnteDecVerifyEthAcc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1973](https://github.com/NibiruChain/nibiru/pull/1973) - chore(appconst): Add chain IDs ending in "3" to the "knownEthChainIDMap". This makes it possible to use devnet 3 and testnet 3.
 - [#1976](https://github.com/NibiruChain/nibiru/pull/1976) - refactor(evm): unique chain ids for all networks
 - [#1977](https://github.com/NibiruChain/nibiru/pull/1977) - fix(localnet): rolled back change of evm validator address with cosmos derivation path
+- [#1981](https://github.com/NibiruChain/nibiru/pull/1981) - fix(evm): remove isCheckTx() short circuit on `AnteDecVerifyEthAcc`
 
 #### Dapp modules: perp, spot, oracle, etc
 

--- a/app/evmante/evmante_verify_eth_acc.go
+++ b/app/evmante/evmante_verify_eth_acc.go
@@ -39,10 +39,6 @@ func (anteDec AnteDecVerifyEthAcc) AnteHandle(
 	simulate bool,
 	next sdk.AnteHandler,
 ) (newCtx sdk.Context, err error) {
-	if !ctx.IsCheckTx() {
-		return next(ctx, tx, simulate)
-	}
-
 	for i, msg := range tx.GetMsgs() {
 		msgEthTx, ok := msg.(*evm.MsgEthereumTx)
 		if !ok {


### PR DESCRIPTION
# Why is this change needed?

The `AnteDecVerifyEthAcc` AnteHandler does a very important job of upserting an EVM Account into the AccountKeeper if the EVM Account does not already exist.

Later on in `AnteDecEthIncrementSenderSequence`, the account nonce is checked and the tx is aborted if the account is not found in the AccountKeeper.

When `AnteDecVerifyEthAcc` runs on CheckTx, the the account is created and so the tx is added to the mempool successfully. Later, when the block is mined and the tx runs in DeliverTx mode, the `AnteDecVerifyEthAcc` doesn't run, but `AnteDecEthIncrementSenderSequence` will run and abort the tx.

Fundamentally, there's no reason to skip the `AnteDecVerifyEthAcc` on DeliverTx because it's a no-op when the EVM Account already exists, but does the very important job of filling in the EVM Accounts on the AccountKeeper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the Ethereum Virtual Machine (EVM) integration by improving the transaction verification process, ensuring that critical checks are not bypassed, thus increasing security and correctness.
	- Modified the handling of messages in transaction processing to occur in all contexts, allowing for broader transaction validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->