### PR TITLE
refactor(evm): clean up EVM module address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,8 +98,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1982](https://github.com/NibiruChain/nibiru/pull/1982) - feat(evm): add GlobalMinGasPrices
 - [#1983](https://github.com/NibiruChain/nibiru/pull/1983) - chore(evm): remove ExtensionOptionsWeb3Tx and ExtensionOptionDynamicFeeTx
 - [#1984](https://github.com/NibiruChain/nibiru/pull/1984) - refactor(evm): embeds
-- [#1985](https://github.com/NibiruChain/nibiru/pull/1985) - feat(evm)!: Use atto denomination for the wei units in the EVM so that NIBI is "ether" to clients. Only micronibi (unibi) amounts can be transferred. All clients follow the constraint equation, 1 ether == 1 NIBI == 10^6 unibi == 10^18 wei. 
+- [#1985](https://github.com/NibiruChain/nibiru/pull/1985) - feat(evm)!: Use atto denomination for the wei units in the EVM so that NIBI is "ether" to clients. Only micronibi (unibi) amounts can be transferred. All clients follow the constraint equation, 1 ether == 1 NIBI == 10^6 unibi == 10^18 wei.
 - [#1986](https://github.com/NibiruChain/nibiru/pull/1986) - feat(evm): Combine both account queries into "/eth.evm.v1.Query/EthAccount", accepting both nibi-prefixed Bech32 addresses and Ethereum-type hexadecimal addresses as input.
+- [#1989](https://github.com/NibiruChain/nibiru/pull/1989) - refactor(evm): simplify evm module address
 
 #### Dapp modules: perp, spot, oracle, etc
 

--- a/x/evm/const.go
+++ b/x/evm/const.go
@@ -76,20 +76,11 @@ const (
 	CallTypeSmart
 )
 
-// ModuleAddressEVM: Module account address as a `gethcommon.Address`.
-func ModuleAddressEVM() gethcommon.Address {
-	if evmModuleAddr == zeroAddr {
-		evmModuleAddr = gethcommon.BytesToAddress(
-			authtypes.NewModuleAddress(ModuleName).Bytes(),
-		)
-	}
-	return evmModuleAddr
-}
+var EVM_MODULE_ADDRESS gethcommon.Address
 
-var (
-	zeroAddr      gethcommon.Address
-	evmModuleAddr gethcommon.Address
-)
+func init() {
+	EVM_MODULE_ADDRESS = gethcommon.BytesToAddress(authtypes.NewModuleAddress(ModuleName))
+}
 
 // NativeToWei converts a "unibi" amount to "wei" units for the EVM.
 //

--- a/x/evm/evm_test.go
+++ b/x/evm/evm_test.go
@@ -117,7 +117,7 @@ func (s *TestSuite) TestFunToken() {
 }
 
 func (s *TestSuite) TestModuleAddressEVM() {
-	addr := evm.ModuleAddressEVM()
+	addr := evm.EVM_MODULE_ADDRESS
 	s.Equal(addr.Hex(), "0x603871c2ddd41c26Ee77495E2E31e6De7f9957e0")
 
 	// Sanity check

--- a/x/evm/keeper/erc20.go
+++ b/x/evm/keeper/erc20.go
@@ -297,7 +297,7 @@ func (k Keeper) LoadERC20String(
 ) (out string, err error) {
 	res, err := k.CallContract(
 		ctx, erc20Abi,
-		evm.ModuleAddressEVM(),
+		evm.EVM_MODULE_ADDRESS,
 		&erc20Contract,
 		false, methodName,
 	)
@@ -323,7 +323,7 @@ func (k Keeper) loadERC20Uint8(
 ) (out uint8, err error) {
 	res, err := k.CallContract(
 		ctx, erc20Abi,
-		evm.ModuleAddressEVM(),
+		evm.EVM_MODULE_ADDRESS,
 		&erc20Contract,
 		false, methodName,
 	)
@@ -352,7 +352,7 @@ func (k Keeper) LoadERC20BigInt(
 	res, err := k.CallContract(
 		ctx,
 		erc20Abi,
-		evm.ModuleAddressEVM(),
+		evm.EVM_MODULE_ADDRESS,
 		&erc20Contract,
 		commit,
 		methodName,

--- a/x/evm/keeper/erc20_test.go
+++ b/x/evm/keeper/erc20_test.go
@@ -397,7 +397,7 @@ func (s *Suite) TestSendFunTokenToEvm() {
 			recipientERC20Balance, err := deps.EvmKeeper.CallContract(
 				deps.Ctx,
 				embeds.SmartContract_ERC20Minter.ABI,
-				evm.ModuleAddressEVM(),
+				evm.EVM_MODULE_ADDRESS,
 				&funTokenErc20Addr,
 				false,
 				"balanceOf",
@@ -438,7 +438,7 @@ func (s *Suite) TestERC20Calls() {
 	contract := funtoken.Erc20Addr.ToAddr()
 
 	theUser := deps.Sender.EthAddr
-	theEvm := evm.ModuleAddressEVM()
+	theEvm := evm.EVM_MODULE_ADDRESS
 
 	s.T().Log("Mint tokens - Fail from non-owner")
 	{

--- a/x/evm/keeper/funtoken_from_coin.go
+++ b/x/evm/keeper/funtoken_from_coin.go
@@ -80,7 +80,7 @@ func (k *Keeper) DeployERC20ForBankCoin(
 	}
 	bytecodeForCall := append(erc20Embed.Bytecode, packedArgs...)
 
-	fromEvmAddr := evm.ModuleAddressEVM()
+	fromEvmAddr := evm.EVM_MODULE_ADDRESS
 	nonce := k.GetAccNonce(ctx, fromEvmAddr)
 	erc20Addr = crypto.CreateAddress(fromEvmAddr, nonce)
 	erc20Contract := (*gethcommon.Address)(nil) // nil >> doesn't exist yet

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -612,7 +612,7 @@ func (k *Keeper) SendFunTokenToEvm(
 	evmResp, err := k.CallContract(
 		ctx,
 		embeds.SmartContract_ERC20Minter.ABI,
-		evm.ModuleAddressEVM(),
+		evm.EVM_MODULE_ADDRESS,
 		&erc20ContractAddr,
 		true,
 		"mint",

--- a/x/evm/precompile/funtoken.go
+++ b/x/evm/precompile/funtoken.go
@@ -153,7 +153,7 @@ func (p precompileFunToken) bankSend(
 	}
 
 	// Caller transfers ERC20 to the EVM account
-	transferTo := evm.ModuleAddressEVM()
+	transferTo := evm.EVM_MODULE_ADDRESS
 	_, err = p.EvmKeeper.ERC20().Transfer(erc20, caller, transferTo, amount, ctx)
 	if err != nil {
 		err = fmt.Errorf("failed to send from caller to the EVM account: %w", err)
@@ -166,7 +166,7 @@ func (p precompileFunToken) bankSend(
 	err = p.BankKeeper.MintCoins(ctx, evm.ModuleName, coins)
 	if err != nil {
 		err = fmt.Errorf("mint failed for module \"%s\" (%s): contract caller %s: %w",
-			evm.ModuleName, evm.ModuleAddressEVM().Hex(), caller.Hex(), err,
+			evm.ModuleName, evm.EVM_MODULE_ADDRESS.Hex(), caller.Hex(), err,
 		)
 		return
 	}
@@ -174,7 +174,7 @@ func (p precompileFunToken) bankSend(
 	err = p.BankKeeper.SendCoinsFromModuleToAccount(ctx, evm.ModuleName, toAddr, coins)
 	if err != nil {
 		err = fmt.Errorf("send failed for module \"%s\" (%s): contract caller %s: %w",
-			evm.ModuleName, evm.ModuleAddressEVM().Hex(), caller.Hex(), err,
+			evm.ModuleName, evm.EVM_MODULE_ADDRESS.Hex(), caller.Hex(), err,
 		)
 		return
 	}
@@ -184,7 +184,7 @@ func (p precompileFunToken) bankSend(
 	// Since we're sending them away and want accurate total supply tracking, the
 	// tokens need to be burned.
 	if funtoken.IsMadeFromCoin {
-		caller := evm.ModuleAddressEVM()
+		caller := evm.EVM_MODULE_ADDRESS
 		_, err = p.EvmKeeper.ERC20().Burn(erc20, caller, amount, ctx)
 		if err != nil {
 			err = fmt.Errorf("ERC20.Burn: %w", err)

--- a/x/evm/precompile/funtoken_test.go
+++ b/x/evm/precompile/funtoken_test.go
@@ -58,7 +58,7 @@ func (s *Suite) FunToken_PrecompileExists() {
 		err, fmt.Sprintf("argument count mismatch: got %d for 3", len(callArgs)),
 		"callArgs: ", callArgs)
 
-	fromEvmAddr := evm.ModuleAddressEVM()
+	fromEvmAddr := evm.EVM_MODULE_ADDRESS
 	contractAddr := precompileAddr.ToAddr()
 	commit := true
 	bytecodeForCall := packedArgs
@@ -75,7 +75,7 @@ func (s *Suite) FunToken_HappyPath() {
 	deps := evmtest.NewTestDeps()
 
 	theUser := deps.Sender.EthAddr
-	theEvm := evm.ModuleAddressEVM()
+	theEvm := evm.EVM_MODULE_ADDRESS
 
 	s.True(deps.EvmKeeper.PrecompileSet().Has(precompileAddr.ToAddr()),
 		"did not see precompile address during \"InitPrecompiles\"")


### PR DESCRIPTION
# Purpose / Abstract

Simplifies the EVM module address initialization

<!-- 
Why is this PR important? 
What does this PR do?
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the handling of wei units to utilize the atto denomination, clarifying that 1 ether equals 1 NIBI.
	- Introduced a new constraint for transactions, restricting amounts to micronibi (unibi) only.
  
- **Bug Fixes**
	- Adjusted error messages related to ERC20 token transfers and minting to align with the updated module address references.

- **Refactor**
	- Streamlined access to the EVM module address by replacing method calls with constant references throughout the codebase, enhancing performance and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->