### PR TITLE
refactor(test): rename test deps Chain to App

### DIFF
--- a/.github/workflows/e2e-evm.yml
+++ b/.github/workflows/e2e-evm.yml
@@ -74,7 +74,7 @@ jobs:
       - name: "Launch localnet"
         run: |
           just localnet --no-build &
-          sleep 6
+          sleep 10
 
       - name: "Run tests (just test)"
         run: just test

--- a/app/evmante/evmante_can_transfer_test.go
+++ b/app/evmante/evmante_can_transfer_test.go
@@ -23,7 +23,7 @@ func (s *TestSuite) TestCanTransferDecorator() {
 			beforeTxSetup: func(deps *evmtest.TestDeps, sdb *statedb.StateDB) {
 				s.NoError(
 					testapp.FundAccount(
-						deps.Chain.BankKeeper,
+						deps.App.BankKeeper,
 						deps.Ctx,
 						deps.Sender.NibiruAddr,
 						sdk.NewCoins(sdk.NewInt64Coin(eth.EthBaseDenom, 100)),
@@ -34,7 +34,7 @@ func (s *TestSuite) TestCanTransferDecorator() {
 				txMsg := evmtest.HappyTransferTx(deps, 0)
 				txBuilder := deps.EncCfg.TxConfig.NewTxBuilder()
 
-				gethSigner := deps.Sender.GethSigner(deps.Chain.EvmKeeper.EthChainID(deps.Ctx))
+				gethSigner := deps.Sender.GethSigner(deps.App.EvmKeeper.EthChainID(deps.Ctx))
 				keyringSigner := deps.Sender.KeyringSigner
 				err := txMsg.Sign(gethSigner, keyringSigner)
 				s.Require().NoError(err)
@@ -52,7 +52,7 @@ func (s *TestSuite) TestCanTransferDecorator() {
 				txMsg := evmtest.HappyTransferTx(deps, 0)
 				txBuilder := deps.EncCfg.TxConfig.NewTxBuilder()
 
-				gethSigner := deps.Sender.GethSigner(deps.Chain.EvmKeeper.EthChainID(deps.Ctx))
+				gethSigner := deps.Sender.GethSigner(deps.App.EvmKeeper.EthChainID(deps.Ctx))
 				keyringSigner := deps.Sender.KeyringSigner
 				err := txMsg.Sign(gethSigner, keyringSigner)
 				s.Require().NoError(err)
@@ -90,7 +90,7 @@ func (s *TestSuite) TestCanTransferDecorator() {
 		s.Run(tc.name, func() {
 			deps := evmtest.NewTestDeps()
 			stateDB := deps.StateDB()
-			anteDec := evmante.NewCanTransferDecorator(&deps.Chain.AppKeepers.EvmKeeper)
+			anteDec := evmante.NewCanTransferDecorator(&deps.App.AppKeepers.EvmKeeper)
 			tx := tc.txSetup(&deps)
 
 			if tc.ctxSetup != nil {

--- a/app/evmante/evmante_emit_event_test.go
+++ b/app/evmante/evmante_emit_event_test.go
@@ -42,7 +42,7 @@ func (s *TestSuite) TestEthEmitEventDecorator() {
 		s.Run(tc.name, func() {
 			deps := evmtest.NewTestDeps()
 			stateDB := deps.StateDB()
-			anteDec := evmante.NewEthEmitEventDecorator(&deps.Chain.AppKeepers.EvmKeeper)
+			anteDec := evmante.NewEthEmitEventDecorator(&deps.App.AppKeepers.EvmKeeper)
 
 			tx := tc.txSetup(&deps)
 			s.Require().NoError(stateDB.Commit())

--- a/app/evmante/evmante_gas_consume_test.go
+++ b/app/evmante/evmante_gas_consume_test.go
@@ -61,7 +61,7 @@ func (s *TestSuite) TestAnteDecEthGasConsume() {
 			deps := evmtest.NewTestDeps()
 			stateDB := deps.StateDB()
 			anteDec := evmante.NewAnteDecEthGasConsume(
-				&deps.Chain.AppKeepers.EvmKeeper, tc.maxGasWanted,
+				&deps.App.AppKeepers.EvmKeeper, tc.maxGasWanted,
 			)
 
 			tc.beforeTxSetup(&deps, stateDB)

--- a/app/evmante/evmante_handler_test.go
+++ b/app/evmante/evmante_handler_test.go
@@ -52,7 +52,7 @@ func (s *TestSuite) TestAnteHandlerEVM() {
 				txMsg := evmtest.HappyTransferTx(deps, 0)
 				txBuilder := deps.EncCfg.TxConfig.NewTxBuilder()
 
-				gethSigner := deps.Sender.GethSigner(deps.Chain.EvmKeeper.EthChainID(deps.Ctx))
+				gethSigner := deps.Sender.GethSigner(deps.App.EvmKeeper.EthChainID(deps.Ctx))
 				keyringSigner := deps.Sender.KeyringSigner
 				err := txMsg.Sign(gethSigner, keyringSigner)
 				s.Require().NoError(err)
@@ -74,15 +74,15 @@ func (s *TestSuite) TestAnteHandlerEVM() {
 			anteHandlerEVM := evmante.NewAnteHandlerEVM(
 				ante.AnteHandlerOptions{
 					HandlerOptions: authante.HandlerOptions{
-						AccountKeeper:          deps.Chain.AccountKeeper,
-						BankKeeper:             deps.Chain.BankKeeper,
-						FeegrantKeeper:         deps.Chain.FeeGrantKeeper,
+						AccountKeeper:          deps.App.AccountKeeper,
+						BankKeeper:             deps.App.BankKeeper,
+						FeegrantKeeper:         deps.App.FeeGrantKeeper,
 						SignModeHandler:        deps.EncCfg.TxConfig.SignModeHandler(),
 						SigGasConsumer:         authante.DefaultSigVerificationGasConsumer,
 						ExtensionOptionChecker: func(*codectypes.Any) bool { return true },
 					},
-					EvmKeeper:     deps.Chain.EvmKeeper,
-					AccountKeeper: deps.Chain.AccountKeeper,
+					EvmKeeper:     deps.App.EvmKeeper,
+					AccountKeeper: deps.App.AccountKeeper,
 				})
 
 			tx := tc.txSetup(&deps)

--- a/app/evmante/evmante_increment_sender_seq_test.go
+++ b/app/evmante/evmante_increment_sender_seq_test.go
@@ -67,7 +67,7 @@ func (s *TestSuite) TestAnteDecEthIncrementSenderSequence() {
 		s.Run(tc.name, func() {
 			deps := evmtest.NewTestDeps()
 			stateDB := deps.StateDB()
-			anteDec := evmante.NewAnteDecEthIncrementSenderSequence(&deps.Chain.EvmKeeper, deps.Chain.AccountKeeper)
+			anteDec := evmante.NewAnteDecEthIncrementSenderSequence(&deps.App.EvmKeeper, deps.App.AccountKeeper)
 
 			if tc.beforeTxSetup != nil {
 				tc.beforeTxSetup(&deps, stateDB)
@@ -85,7 +85,7 @@ func (s *TestSuite) TestAnteDecEthIncrementSenderSequence() {
 			s.Require().NoError(err)
 
 			if tc.wantSeq > 0 {
-				seq := deps.Chain.AccountKeeper.GetAccount(deps.Ctx, deps.Sender.NibiruAddr).GetSequence()
+				seq := deps.App.AccountKeeper.GetAccount(deps.Ctx, deps.Sender.NibiruAddr).GetSequence()
 				s.Require().Equal(tc.wantSeq, seq)
 			}
 		})

--- a/app/evmante/evmante_mempool_fees_test.go
+++ b/app/evmante/evmante_mempool_fees_test.go
@@ -82,7 +82,7 @@ func (s *TestSuite) TestMempoolGasFeeDecorator() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			deps := evmtest.NewTestDeps()
-			anteDec := evmante.NewMempoolGasPriceDecorator(&deps.Chain.AppKeepers.EvmKeeper)
+			anteDec := evmante.NewMempoolGasPriceDecorator(&deps.App.AppKeepers.EvmKeeper)
 
 			tx := tc.txSetup(&deps)
 

--- a/app/evmante/evmante_setup_ctx_test.go
+++ b/app/evmante/evmante_setup_ctx_test.go
@@ -13,13 +13,13 @@ import (
 func (s *TestSuite) TestEthSetupContextDecorator() {
 	deps := evmtest.NewTestDeps()
 	stateDB := deps.StateDB()
-	anteDec := evmante.NewEthSetUpContextDecorator(&deps.Chain.EvmKeeper)
+	anteDec := evmante.NewEthSetUpContextDecorator(&deps.App.EvmKeeper)
 
 	s.Require().NoError(stateDB.Commit())
 	tx := evmtest.HappyCreateContractTx(&deps)
 
 	// Set block gas used to non 0 to check that handler resets it
-	deps.Chain.EvmKeeper.EvmState.BlockGasUsed.Set(deps.Ctx, 1000)
+	deps.App.EvmKeeper.EvmState.BlockGasUsed.Set(deps.Ctx, 1000)
 
 	// Ante handler returns new context
 	newCtx, err := anteDec.AnteHandle(
@@ -37,7 +37,7 @@ func (s *TestSuite) TestEthSetupContextDecorator() {
 	s.Require().Equal(defaultGasConfig, newCtx.TransientKVGasConfig())
 
 	// Check that block gas used is reset to 0
-	gas, err := deps.Chain.EvmKeeper.EvmState.BlockGasUsed.Get(newCtx)
+	gas, err := deps.App.EvmKeeper.EvmState.BlockGasUsed.Get(newCtx)
 	s.Require().NoError(err)
 	s.Require().Equal(gas, uint64(0))
 }

--- a/app/evmante/evmante_sigverify_test.go
+++ b/app/evmante/evmante_sigverify_test.go
@@ -54,7 +54,7 @@ func (s *TestSuite) TestEthSigVerificationDecorator() {
 			name: "happy: signed ethereum tx",
 			txSetup: func(deps *evmtest.TestDeps) sdk.Tx {
 				tx := evmtest.HappyCreateContractTx(deps)
-				gethSigner := deps.Sender.GethSigner(deps.Chain.EvmKeeper.EthChainID(deps.Ctx))
+				gethSigner := deps.Sender.GethSigner(deps.App.EvmKeeper.EthChainID(deps.Ctx))
 				keyringSigner := deps.Sender.KeyringSigner
 				err := tx.Sign(gethSigner, keyringSigner)
 				s.Require().NoError(err)
@@ -68,7 +68,7 @@ func (s *TestSuite) TestEthSigVerificationDecorator() {
 		s.Run(tc.name, func() {
 			deps := evmtest.NewTestDeps()
 			stateDB := deps.StateDB()
-			anteDec := evmante.NewEthSigVerificationDecorator(&deps.Chain.AppKeepers.EvmKeeper)
+			anteDec := evmante.NewEthSigVerificationDecorator(&deps.App.AppKeepers.EvmKeeper)
 
 			tx := tc.txSetup(&deps)
 			s.Require().NoError(stateDB.Commit())

--- a/app/evmante/evmante_validate_basic_test.go
+++ b/app/evmante/evmante_validate_basic_test.go
@@ -113,7 +113,7 @@ func (s *TestSuite) TestEthValidateBasicDecorator() {
 				s.Require().NoError(err)
 				txMsg := evmtest.HappyCreateContractTx(deps)
 
-				gethSigner := deps.Sender.GethSigner(deps.Chain.EvmKeeper.EthChainID(deps.Ctx))
+				gethSigner := deps.Sender.GethSigner(deps.App.EvmKeeper.EthChainID(deps.Ctx))
 				keyringSigner := deps.Sender.KeyringSigner
 				err = txMsg.Sign(gethSigner, keyringSigner)
 				s.Require().NoError(err)
@@ -127,7 +127,7 @@ func (s *TestSuite) TestEthValidateBasicDecorator() {
 		{
 			name: "sad: tx without extension options should fail",
 			txSetup: func(deps *evmtest.TestDeps) sdk.Tx {
-				chainID := deps.Chain.EvmKeeper.EthChainID(deps.Ctx)
+				chainID := deps.App.EvmKeeper.EthChainID(deps.Ctx)
 				gasLimit := uint64(10)
 				fees := sdk.NewCoins(sdk.NewInt64Coin("unibi", int64(gasLimit)))
 				msg := buildEthMsg(chainID, gasLimit, deps.Sender.NibiruAddr.String(), nil)
@@ -152,7 +152,7 @@ func (s *TestSuite) TestEthValidateBasicDecorator() {
 		{
 			name: "sad: tx with from value set should fail",
 			txSetup: func(deps *evmtest.TestDeps) sdk.Tx {
-				chainID := deps.Chain.EvmKeeper.EthChainID(deps.Ctx)
+				chainID := deps.App.EvmKeeper.EthChainID(deps.Ctx)
 				gasLimit := uint64(10)
 				fees := sdk.NewCoins(sdk.NewInt64Coin("unibi", int64(gasLimit)))
 				msg := buildEthMsg(chainID, gasLimit, deps.Sender.NibiruAddr.String(), nil)
@@ -163,7 +163,7 @@ func (s *TestSuite) TestEthValidateBasicDecorator() {
 		{
 			name: "sad: tx with fee <> msg fee",
 			txSetup: func(deps *evmtest.TestDeps) sdk.Tx {
-				chainID := deps.Chain.EvmKeeper.EthChainID(deps.Ctx)
+				chainID := deps.App.EvmKeeper.EthChainID(deps.Ctx)
 				gasLimit := uint64(10)
 				fees := sdk.NewCoins(sdk.NewInt64Coin("unibi", 5))
 				msg := buildEthMsg(chainID, gasLimit, "", nil)
@@ -174,7 +174,7 @@ func (s *TestSuite) TestEthValidateBasicDecorator() {
 		{
 			name: "sad: tx with gas limit <> msg gas limit",
 			txSetup: func(deps *evmtest.TestDeps) sdk.Tx {
-				chainID := deps.Chain.EvmKeeper.EthChainID(deps.Ctx)
+				chainID := deps.App.EvmKeeper.EthChainID(deps.Ctx)
 				gasLimit := uint64(10)
 				fees := sdk.NewCoins(sdk.NewInt64Coin("unibi", int64(gasLimit)))
 				msg := buildEthMsg(chainID, gasLimit, "", nil)
@@ -188,7 +188,7 @@ func (s *TestSuite) TestEthValidateBasicDecorator() {
 		s.Run(tc.name, func() {
 			deps := evmtest.NewTestDeps()
 			stateDB := deps.StateDB()
-			anteDec := evmante.NewEthValidateBasicDecorator(&deps.Chain.AppKeepers.EvmKeeper)
+			anteDec := evmante.NewEthValidateBasicDecorator(&deps.App.AppKeepers.EvmKeeper)
 
 			tx := tc.txSetup(&deps)
 			s.Require().NoError(stateDB.Commit())

--- a/app/evmante/evmante_verify_eth_acc_test.go
+++ b/app/evmante/evmante_verify_eth_acc_test.go
@@ -65,7 +65,7 @@ func (s *TestSuite) TestAnteDecoratorVerifyEthAcc_CheckTx() {
 		s.Run(tc.name, func() {
 			deps := evmtest.NewTestDeps()
 			stateDB := deps.StateDB()
-			anteDec := evmante.NewAnteDecVerifyEthAcc(&deps.Chain.AppKeepers.EvmKeeper, &deps.Chain.AppKeepers.AccountKeeper)
+			anteDec := evmante.NewAnteDecVerifyEthAcc(&deps.App.AppKeepers.EvmKeeper, &deps.App.AppKeepers.AccountKeeper)
 
 			tc.beforeTxSetup(&deps, stateDB)
 			tx := tc.txSetup(&deps)

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -185,6 +185,7 @@ val_address=${val_address:-"nibi1zaavvzxez0elundtn32qnk9lkm8kmcsz44g7xl"}
 $BINARY add-genesis-account $val_address $GENESIS_COINS
 # EVM encoded nibi address for the same account
 $BINARY add-genesis-account nibi1cr6tg4cjvux00pj6zjqkh6d0jzg7mksaywxyl3 $GENESIS_COINS
+$BINARY add-genesis-account nibi1ltez0kkshywzm675rkh8rj2eaf8et78cqjqrhc $GENESIS_COINS
 echo_success "Successfully added genesis account: $val_key_name"
 
 # ------------------------------------------------------------------------

--- a/x/evm/evmmodule/genesis_test.go
+++ b/x/evm/evmmodule/genesis_test.go
@@ -68,9 +68,9 @@ func (s *Suite) TestExportInitGenesis() {
 
 	// Fund sender's wallet
 	spendableCoins := sdk.NewCoins(sdk.NewInt64Coin("unibi", totalSupply.Int64()))
-	err = deps.Chain.BankKeeper.MintCoins(deps.Ctx, evm.ModuleName, spendableCoins)
+	err = deps.App.BankKeeper.MintCoins(deps.Ctx, evm.ModuleName, spendableCoins)
 	s.Require().NoError(err)
-	err = deps.Chain.BankKeeper.SendCoinsFromModuleToAccount(
+	err = deps.App.BankKeeper.SendCoinsFromModuleToAccount(
 		deps.Ctx, evm.ModuleName, deps.Sender.NibiruAddr, spendableCoins,
 	)
 	s.Require().NoError(err)
@@ -87,13 +87,13 @@ func (s *Suite) TestExportInitGenesis() {
 	s.Require().NoError(err)
 
 	// Export genesis
-	evmGenesisState := evmmodule.ExportGenesis(deps.Ctx, &deps.EvmKeeper, deps.Chain.AccountKeeper)
-	authGenesisState := deps.Chain.AccountKeeper.ExportGenesis(deps.Ctx)
+	evmGenesisState := evmmodule.ExportGenesis(deps.Ctx, &deps.EvmKeeper, deps.App.AccountKeeper)
+	authGenesisState := deps.App.AccountKeeper.ExportGenesis(deps.Ctx)
 
 	// Init genesis from the exported state
 	deps = evmtest.NewTestDeps()
-	deps.Chain.AccountKeeper.InitGenesis(deps.Ctx, *authGenesisState)
-	evmmodule.InitGenesis(deps.Ctx, &deps.EvmKeeper, deps.Chain.AccountKeeper, *evmGenesisState)
+	deps.App.AccountKeeper.InitGenesis(deps.Ctx, *authGenesisState)
+	evmmodule.InitGenesis(deps.Ctx, &deps.EvmKeeper, deps.App.AccountKeeper, *evmGenesisState)
 
 	// Verify erc20 balances for users A, B and sender
 	balance, err := deps.EvmKeeper.ERC20().BalanceOf(erc20Addr, toUserA, deps.Ctx)

--- a/x/evm/evmtest/erc20.go
+++ b/x/evm/evmtest/erc20.go
@@ -51,14 +51,14 @@ func CreateFunTokenForBankCoin(
 		Name:    bankDenom,
 		Symbol:  bankDenom,
 	}
-	if deps.Chain.BankKeeper.HasDenomMetaData(deps.Ctx, bankDenom) {
+	if deps.App.BankKeeper.HasDenomMetaData(deps.Ctx, bankDenom) {
 		s.Failf("setting bank.DenomMetadata would overwrite existing denom \"%s\"", bankDenom)
 	}
-	deps.Chain.BankKeeper.SetDenomMetaData(deps.Ctx, bankMetadata)
+	deps.App.BankKeeper.SetDenomMetaData(deps.Ctx, bankMetadata)
 
 	// Give the sender funds for the fee
 	err := testapp.FundAccount(
-		deps.Chain.BankKeeper,
+		deps.App.BankKeeper,
 		deps.Ctx,
 		deps.Sender.NibiruAddr,
 		deps.EvmKeeper.FeeForCreateFunToken(deps.Ctx),

--- a/x/evm/evmtest/evmante.go
+++ b/x/evm/evmtest/evmante.go
@@ -21,7 +21,7 @@ var NextNoOpAnteHandler sdk.AnteHandler = func(
 func HappyTransferTx(deps *TestDeps, nonce uint64) *evm.MsgEthereumTx {
 	to := NewEthAccInfo().EthAddr
 	ethContractCreationTxParams := &evm.EvmTxArgs{
-		ChainID:  deps.Chain.EvmKeeper.EthChainID(deps.Ctx),
+		ChainID:  deps.App.EvmKeeper.EthChainID(deps.Ctx),
 		Nonce:    nonce,
 		Amount:   big.NewInt(10),
 		GasLimit: GasLimitCreateContract().Uint64(),
@@ -68,7 +68,7 @@ func buildTx(
 
 func HappyCreateContractTx(deps *TestDeps) *evm.MsgEthereumTx {
 	ethContractCreationTxParams := &evm.EvmTxArgs{
-		ChainID:  deps.Chain.EvmKeeper.EthChainID(deps.Ctx),
+		ChainID:  deps.App.EvmKeeper.EthChainID(deps.Ctx),
 		Nonce:    1,
 		Amount:   big.NewInt(10),
 		GasLimit: GasLimitCreateContract().Uint64(),

--- a/x/evm/evmtest/test_deps.go
+++ b/x/evm/evmtest/test_deps.go
@@ -19,7 +19,7 @@ import (
 )
 
 type TestDeps struct {
-	Chain     *app.NibiruApp
+	App       *app.NibiruApp
 	Ctx       sdk.Context
 	EncCfg    codec.EncodingConfig
 	EvmKeeper keeper.Keeper
@@ -36,21 +36,21 @@ func NewTestDeps() TestDeps {
 	encCfg := app.MakeEncodingConfig()
 	evm.RegisterInterfaces(encCfg.InterfaceRegistry)
 	eth.RegisterInterfaces(encCfg.InterfaceRegistry)
-	chain, ctx := testapp.NewNibiruTestAppAndContext()
+	app, ctx := testapp.NewNibiruTestAppAndContext()
 	ctx = ctx.WithChainID(eth.EIP155ChainID_Testnet)
 	ethAcc := NewEthAccInfo()
 	return TestDeps{
-		Chain:     chain,
+		App:       app,
 		Ctx:       ctx,
 		EncCfg:    encCfg,
-		EvmKeeper: chain.EvmKeeper,
+		EvmKeeper: app.EvmKeeper,
 		GenState:  evm.DefaultGenesisState(),
 		Sender:    ethAcc,
 	}
 }
 
 func (deps TestDeps) StateDB() *statedb.StateDB {
-	return statedb.New(deps.Ctx, &deps.Chain.EvmKeeper,
+	return statedb.New(deps.Ctx, &deps.App.EvmKeeper,
 		statedb.NewEmptyTxConfig(
 			gethcommon.BytesToHash(deps.Ctx.HeaderHash().Bytes()),
 		),
@@ -59,5 +59,5 @@ func (deps TestDeps) StateDB() *statedb.StateDB {
 
 func (deps *TestDeps) GethSigner() gethcore.Signer {
 	ctx := deps.Ctx
-	return deps.Sender.GethSigner(deps.Chain.EvmKeeper.EthChainID(ctx))
+	return deps.Sender.GethSigner(deps.App.EvmKeeper.EthChainID(ctx))
 }

--- a/x/evm/evmtest/tx.go
+++ b/x/evm/evmtest/tx.go
@@ -123,7 +123,7 @@ func ExecuteNibiTransfer(deps *TestDeps, t *testing.T) *evm.MsgEthereumTx {
 	ethTxMsg, err := GenerateAndSignEthTxMsg(txArgs, deps)
 	require.NoError(t, err)
 
-	resp, err := deps.Chain.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
+	resp, err := deps.App.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
 	require.NoError(t, err)
 	require.Empty(t, resp.VmError)
 	return ethTxMsg
@@ -160,7 +160,7 @@ func DeployContract(
 	ethTxMsg, err := GenerateAndSignEthTxMsg(jsonTxArgs, deps)
 	require.NoError(t, err)
 
-	resp, err := deps.Chain.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
+	resp, err := deps.App.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
 	require.NoError(t, err)
 	require.Empty(t, resp.VmError)
 
@@ -187,7 +187,7 @@ func DeployAndExecuteERC20Transfer(
 
 	// Contract address is deterministic
 	contractAddress := crypto.CreateAddress(deps.Sender.EthAddr, nonce)
-	deps.Chain.Commit()
+	deps.App.Commit()
 	predecessors := []*evm.MsgEthereumTx{
 		deployResp.EthTxMsg,
 	}
@@ -207,7 +207,7 @@ func DeployAndExecuteERC20Transfer(
 	ethTxMsg, err := GenerateAndSignEthTxMsg(txArgs, deps)
 	require.NoError(t, err)
 
-	resp, err := deps.Chain.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
+	resp, err := deps.App.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
 	require.NoError(t, err)
 	require.Empty(t, resp.VmError)
 
@@ -222,11 +222,11 @@ func GenerateAndSignEthTxMsg(
 	if err != nil {
 		return nil, err
 	}
-	res, err := deps.Chain.EvmKeeper.EstimateGas(deps.GoCtx(), &evm.EthCallRequest{
+	res, err := deps.App.EvmKeeper.EstimateGas(deps.GoCtx(), &evm.EthCallRequest{
 		Args:            estimateArgs,
 		GasCap:          srvconfig.DefaultEthCallGasLimit,
 		ProposerAddress: []byte{},
-		ChainId:         deps.Chain.EvmKeeper.EthChainID(deps.Ctx).Int64(),
+		ChainId:         deps.App.EvmKeeper.EthChainID(deps.Ctx).Int64(),
 	})
 	if err != nil {
 		return nil, err
@@ -234,7 +234,7 @@ func GenerateAndSignEthTxMsg(
 	txArgs.Gas = (*hexutil.Uint64)(&res.Gas)
 
 	txMsg := txArgs.ToTransaction()
-	gethSigner := deps.Sender.GethSigner(deps.Chain.EvmKeeper.EthChainID(deps.Ctx))
+	gethSigner := deps.Sender.GethSigner(deps.App.EvmKeeper.EthChainID(deps.Ctx))
 	keyringSigner := deps.Sender.KeyringSigner
 	return txMsg, txMsg.Sign(gethSigner, keyringSigner)
 }
@@ -261,7 +261,7 @@ func TransferWei(
 		return fmt.Errorf("error while transferring wei: %w", err)
 	}
 
-	_, err = deps.Chain.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
+	_, err = deps.App.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
 	if err != nil {
 		return fmt.Errorf("error while transferring wei: %w", err)
 	}

--- a/x/evm/keeper/erc20_test.go
+++ b/x/evm/keeper/erc20_test.go
@@ -79,7 +79,7 @@ func (s *Suite) TestCreateFunTokenFromERC20() {
 
 	// Give the sender funds for the fee
 	err = testapp.FundAccount(
-		deps.Chain.BankKeeper,
+		deps.App.BankKeeper,
 		deps.Ctx,
 		deps.Sender.NibiruAddr,
 		deps.EvmKeeper.FeeForCreateFunToken(deps.Ctx),
@@ -118,7 +118,7 @@ func (s *Suite) TestCreateFunTokenFromERC20() {
 	s.T().Log("sad: CreateFunToken for the ERC20: already registered")
 	// Give the sender funds for the fee
 	err = testapp.FundAccount(
-		deps.Chain.BankKeeper,
+		deps.App.BankKeeper,
 		deps.Ctx,
 		deps.Sender.NibiruAddr,
 		deps.EvmKeeper.FeeForCreateFunToken(deps.Ctx),
@@ -197,12 +197,12 @@ func (s *Suite) TestCreateFunTokenFromCoin() {
 	s.T().Log("Setup: Create a coin in the bank state")
 	bankDenom := "sometoken"
 
-	setBankDenomMetadata(deps.Ctx, deps.Chain.BankKeeper, bankDenom)
+	setBankDenomMetadata(deps.Ctx, deps.App.BankKeeper, bankDenom)
 
 	s.T().Log("happy: CreateFunToken for the bank coin")
 	// Give the sender funds for the fee
 	err = testapp.FundAccount(
-		deps.Chain.BankKeeper,
+		deps.App.BankKeeper,
 		deps.Ctx,
 		deps.Sender.NibiruAddr,
 		deps.EvmKeeper.FeeForCreateFunToken(deps.Ctx),
@@ -260,7 +260,7 @@ func (s *Suite) TestCreateFunTokenFromCoin() {
 	s.T().Log("sad: CreateFunToken for the bank coin: already registered")
 	// Give the sender funds for the fee
 	err = testapp.FundAccount(
-		deps.Chain.BankKeeper,
+		deps.App.BankKeeper,
 		deps.Ctx,
 		deps.Sender.NibiruAddr,
 		deps.EvmKeeper.FeeForCreateFunToken(deps.Ctx),
@@ -314,24 +314,24 @@ func (s *Suite) TestSendFunTokenToEvm() {
 			deps := evmtest.NewTestDeps()
 			bankDenom := "unibi"
 			recipientEVMAddr := eth.MustNewHexAddrFromStr("0x1234500000000000000000000000000000000000")
-			evmModuleAddr := deps.Chain.AccountKeeper.GetModuleAddress(evm.ModuleName)
+			evmModuleAddr := deps.App.AccountKeeper.GetModuleAddress(evm.ModuleName)
 			spendableAmount := tc.senderBalanceBefore.Int64()
 			spendableCoins := sdk.NewCoins(sdk.NewInt64Coin(bankDenom, spendableAmount))
 
 			ctx := deps.GoCtx()
-			setBankDenomMetadata(deps.Ctx, deps.Chain.BankKeeper, bankDenom)
+			setBankDenomMetadata(deps.Ctx, deps.App.BankKeeper, bankDenom)
 
 			// Fund sender's wallet
-			err := deps.Chain.BankKeeper.MintCoins(deps.Ctx, evm.ModuleName, spendableCoins)
+			err := deps.App.BankKeeper.MintCoins(deps.Ctx, evm.ModuleName, spendableCoins)
 			s.Require().NoError(err)
-			err = deps.Chain.BankKeeper.SendCoinsFromModuleToAccount(
+			err = deps.App.BankKeeper.SendCoinsFromModuleToAccount(
 				deps.Ctx, evm.ModuleName, deps.Sender.NibiruAddr, spendableCoins,
 			)
 			s.Require().NoError(err)
 
 			// Give the sender funds for the fee
 			err = testapp.FundAccount(
-				deps.Chain.BankKeeper,
+				deps.App.BankKeeper,
 				deps.Ctx,
 				deps.Sender.NibiruAddr,
 				deps.EvmKeeper.FeeForCreateFunToken(deps.Ctx),
@@ -378,7 +378,7 @@ func (s *Suite) TestSendFunTokenToEvm() {
 			)
 
 			// Check 1: coins are stored on a module balance
-			moduleBalance, err := deps.Chain.BankKeeper.Balance(ctx, &bank.QueryBalanceRequest{
+			moduleBalance, err := deps.App.BankKeeper.Balance(ctx, &bank.QueryBalanceRequest{
 				Address: evmModuleAddr.String(),
 				Denom:   bankDenom,
 			})
@@ -386,7 +386,7 @@ func (s *Suite) TestSendFunTokenToEvm() {
 			s.Equal(tc.amountToSend, moduleBalance.Balance.Amount)
 
 			// Check 2: Sender balance reduced by send amount
-			senderBalance, err := deps.Chain.BankKeeper.Balance(ctx, &bank.QueryBalanceRequest{
+			senderBalance, err := deps.App.BankKeeper.Balance(ctx, &bank.QueryBalanceRequest{
 				Address: deps.Sender.NibiruAddr.String(),
 				Denom:   bankDenom,
 			})

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -77,7 +77,7 @@ func (s *Suite) TestQueryEvmAccount() {
 				// fund account with 420 tokens
 				ethAddr := deps.Sender.EthAddr
 				coins := sdk.Coins{sdk.NewInt64Coin(evm.DefaultEVMDenom, 420)}
-				err := testapp.FundAccount(deps.Chain.BankKeeper, deps.Ctx, ethAddr.Bytes(), coins)
+				err := testapp.FundAccount(deps.App.BankKeeper, deps.Ctx, ethAddr.Bytes(), coins)
 				s.Require().NoError(err)
 			},
 			scenario: func(deps *evmtest.TestDeps) (req In, wantResp Out) {
@@ -102,7 +102,7 @@ func (s *Suite) TestQueryEvmAccount() {
 				// fund account with 420 tokens
 				ethAddr := deps.Sender.EthAddr
 				coins := sdk.Coins{sdk.NewInt64Coin(evm.DefaultEVMDenom, 420)}
-				err := testapp.FundAccount(deps.Chain.BankKeeper, deps.Ctx, ethAddr.Bytes(), coins)
+				err := testapp.FundAccount(deps.App.BankKeeper, deps.Ctx, ethAddr.Bytes(), coins)
 				s.Require().NoError(err)
 			},
 			scenario: func(deps *evmtest.TestDeps) (req In, wantResp Out) {
@@ -211,7 +211,7 @@ func (s *Suite) TestQueryValidatorAccount() {
 			name:  "happy: default values",
 			setup: func(deps *evmtest.TestDeps) {},
 			scenario: func(deps *evmtest.TestDeps) (req In, wantResp Out) {
-				valopers := deps.Chain.StakingKeeper.GetValidators(deps.Ctx, 1)
+				valopers := deps.App.StakingKeeper.GetValidators(deps.Ctx, 1)
 				valAddrBz := valopers[0].GetOperator().Bytes()
 				_, err := sdk.ConsAddressFromBech32(valopers[0].OperatorAddress)
 				s.ErrorContains(err, "expected nibivalcons, got nibivaloper")
@@ -233,7 +233,7 @@ func (s *Suite) TestQueryValidatorAccount() {
 			name:  "happy: with nonce",
 			setup: func(deps *evmtest.TestDeps) {},
 			scenario: func(deps *evmtest.TestDeps) (req In, wantResp Out) {
-				valopers := deps.Chain.StakingKeeper.GetValidators(deps.Ctx, 1)
+				valopers := deps.App.StakingKeeper.GetValidators(deps.Ctx, 1)
 				valAddrBz := valopers[0].GetOperator().Bytes()
 				consAddr := sdk.ConsAddress(valAddrBz)
 
@@ -242,7 +242,7 @@ func (s *Suite) TestQueryValidatorAccount() {
 				coinsToSend := sdk.NewCoins(sdk.NewCoin(eth.EthBaseDenom, math.NewInt(69420)))
 				valAddr := sdk.AccAddress(valAddrBz)
 				s.NoError(testapp.FundAccount(
-					deps.Chain.BankKeeper,
+					deps.App.BankKeeper,
 					deps.Ctx, valAddr,
 					coinsToSend,
 				))
@@ -251,7 +251,7 @@ func (s *Suite) TestQueryValidatorAccount() {
 					ConsAddress: consAddr.String(),
 				}
 
-				ak := deps.Chain.AccountKeeper
+				ak := deps.App.AccountKeeper
 				acc := ak.GetAccount(deps.Ctx, valAddr)
 				s.NoError(acc.SetAccountNumber(420), "acc: ", acc.String())
 				s.NoError(acc.SetSequence(69), "acc: ", acc.String())
@@ -491,7 +491,7 @@ func (s *Suite) TestQueryEthCall() {
 				tc.setup(&deps)
 			}
 			req, wantResp := tc.scenario(&deps)
-			gotResp, err := deps.Chain.EvmKeeper.EthCall(deps.GoCtx(), req)
+			gotResp, err := deps.App.EvmKeeper.EthCall(deps.GoCtx(), req)
 			if tc.wantErr != "" {
 				s.Require().ErrorContains(err, tc.wantErr)
 				return
@@ -537,7 +537,7 @@ func (s *Suite) TestQueryBalance() {
 		{
 			name: "happy: non zero balance",
 			setup: func(deps *evmtest.TestDeps) {
-				chain := deps.Chain
+				chain := deps.App
 				ethAddr := deps.Sender.EthAddr
 
 				// fund account with 420 tokens
@@ -656,7 +656,7 @@ func (s *Suite) TestEstimateGasForEvmCallType() {
 			name: "happy: estimate gas for transfer",
 			scenario: func(deps *evmtest.TestDeps) (req In, wantResp Out) {
 				// fund the account
-				chain := deps.Chain
+				chain := deps.App
 				ethAddr := deps.Sender.EthAddr
 				coins := sdk.Coins{sdk.NewInt64Coin(evm.DefaultEVMDenom, 1000)}
 				err := chain.BankKeeper.MintCoins(deps.Ctx, evm.ModuleName, coins)
@@ -666,7 +666,7 @@ func (s *Suite) TestEstimateGasForEvmCallType() {
 				s.Require().NoError(err)
 
 				// assert balance of 1000 * 10^12 wei
-				resp, _ := deps.Chain.EvmKeeper.Balance(deps.GoCtx(), &evm.QueryBalanceRequest{
+				resp, _ := deps.App.EvmKeeper.Balance(deps.GoCtx(), &evm.QueryBalanceRequest{
 					Address: deps.Sender.EthAddr.Hex(),
 				})
 				s.Equal("1000", resp.Balance)

--- a/x/evm/keeper/msg_ethereum_tx_test.go
+++ b/x/evm/keeper/msg_ethereum_tx_test.go
@@ -35,7 +35,7 @@ func (s *Suite) TestMsgEthereumTx_CreateContract() {
 				// Leftover gas fee is refunded within ApplyEvmTx from the FeeCollector
 				// so, the module must have some coins
 				err := testapp.FundModuleAccount(
-					deps.Chain.BankKeeper,
+					deps.App.BankKeeper,
 					deps.Ctx,
 					authtypes.FeeCollectorName,
 					sdk.NewCoins(sdk.NewCoin("unibi", math.NewInt(1000_000))),
@@ -55,7 +55,7 @@ func (s *Suite) TestMsgEthereumTx_CreateContract() {
 				s.Require().NoError(ethTxMsg.ValidateBasic())
 				s.Equal(ethTxMsg.GetGas(), gasLimit.Uint64())
 
-				resp, err := deps.Chain.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
+				resp, err := deps.App.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
 				s.Require().NoError(
 					err,
 					"resp: %s\nblock header: %s",
@@ -94,7 +94,7 @@ func (s *Suite) TestMsgEthereumTx_CreateContract() {
 				s.Require().NoError(ethTxMsg.ValidateBasic())
 				s.Equal(ethTxMsg.GetGas(), gasLimit)
 
-				resp, err := deps.Chain.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
+				resp, err := deps.App.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
 				s.Require().ErrorContains(
 					err,
 					core.ErrIntrinsicGas.Error(),
@@ -118,7 +118,7 @@ func (s *Suite) TestMsgEthereumTx_ExecuteContract() {
 	// Leftover gas fee is refunded within ApplyEvmTx from the FeeCollector
 	// so, the module must have some coins
 	err := testapp.FundModuleAccount(
-		deps.Chain.BankKeeper,
+		deps.App.BankKeeper,
 		deps.Ctx,
 		authtypes.FeeCollectorName,
 		sdk.NewCoins(sdk.NewCoin("unibi", math.NewInt(1000_000))),
@@ -148,7 +148,7 @@ func (s *Suite) TestMsgEthereumTx_ExecuteContract() {
 	s.NoError(err)
 	s.Require().NoError(ethTxMsg.ValidateBasic())
 	s.Equal(ethTxMsg.GetGas(), gasLimit.Uint64())
-	resp, err := deps.Chain.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
+	resp, err := deps.App.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
 	s.Require().NoError(
 		err,
 		"resp: %s\nblock header: %s",
@@ -189,7 +189,7 @@ func (s *Suite) TestMsgEthereumTx_SimpleTransfer() {
 
 		fundedAmount := evm.NativeToWei(big.NewInt(123)).Int64()
 		err := testapp.FundAccount(
-			deps.Chain.BankKeeper,
+			deps.App.BankKeeper,
 			deps.Ctx,
 			deps.Sender.NibiruAddr,
 			sdk.NewCoins(sdk.NewInt64Coin("unibi", fundedAmount)),
@@ -213,7 +213,7 @@ func (s *Suite) TestMsgEthereumTx_SimpleTransfer() {
 		)
 		s.NoError(err)
 
-		resp, err := deps.Chain.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
+		resp, err := deps.App.EvmKeeper.EthereumTx(deps.GoCtx(), ethTxMsg)
 		s.Require().NoError(err)
 		s.Require().Empty(resp.VmError)
 

--- a/x/evm/keeper/statedb_test.go
+++ b/x/evm/keeper/statedb_test.go
@@ -26,7 +26,7 @@ func (s *Suite) TestStateDBBalance() {
 
 		s.T().Log("fund account in unibi. See expected wei amount.")
 		err := testapp.FundAccount(
-			deps.Chain.BankKeeper,
+			deps.App.BankKeeper,
 			deps.Ctx,
 			deps.Sender.NibiruAddr,
 			sdk.NewCoins(sdk.NewInt64Coin(evm.DefaultEVMDenom, 42)),
@@ -38,7 +38,7 @@ func (s *Suite) TestStateDBBalance() {
 		)
 		s.Equal(
 			"42",
-			deps.Chain.BankKeeper.GetBalance(deps.Ctx, deps.Sender.NibiruAddr, evm.DefaultEVMDenom).Amount.String(),
+			deps.App.BankKeeper.GetBalance(deps.Ctx, deps.Sender.NibiruAddr, evm.DefaultEVMDenom).Amount.String(),
 		)
 	}
 
@@ -67,13 +67,13 @@ func (s *Suite) TestStateDBBalance() {
 		deps := evmtest.NewTestDeps()
 		toNibiAddr := eth.EthAddrToNibiruAddr(to)
 		err := testapp.FundAccount(
-			deps.Chain.BankKeeper,
+			deps.App.BankKeeper,
 			deps.Ctx,
 			deps.Sender.NibiruAddr,
 			sdk.NewCoins(sdk.NewInt64Coin(evm.DefaultEVMDenom, 8)),
 		)
 		s.NoError(err)
-		err = deps.Chain.BankKeeper.SendCoins(
+		err = deps.App.BankKeeper.SendCoins(
 			deps.Ctx, deps.Sender.NibiruAddr,
 			toNibiAddr,
 			sdk.NewCoins(sdk.NewInt64Coin(evm.DefaultEVMDenom, 3)),

--- a/x/evm/precompile/funtoken_test.go
+++ b/x/evm/precompile/funtoken_test.go
@@ -122,7 +122,7 @@ func (s *Suite) FunToken_HappyPath() {
 		evmtest.AssertERC20BalanceEqual(s.T(), deps, contract, theUser, big.NewInt(69_419))
 		evmtest.AssertERC20BalanceEqual(s.T(), deps, contract, theEvm, big.NewInt(1))
 		s.Equal("0",
-			deps.Chain.BankKeeper.GetBalance(deps.Ctx, randomAcc, funtoken.BankDenom).Amount.String(),
+			deps.App.BankKeeper.GetBalance(deps.Ctx, randomAcc, funtoken.BankDenom).Amount.String(),
 		)
 	}
 
@@ -140,12 +140,12 @@ func (s *Suite) FunToken_HappyPath() {
 	evmtest.AssertERC20BalanceEqual(s.T(), deps, contract, theUser, big.NewInt(69_419-amtToSend))
 	evmtest.AssertERC20BalanceEqual(s.T(), deps, contract, theEvm, big.NewInt(1))
 	s.Equal(fmt.Sprintf("%d", amtToSend),
-		deps.Chain.BankKeeper.GetBalance(deps.Ctx, randomAcc, funtoken.BankDenom).Amount.String(),
+		deps.App.BankKeeper.GetBalance(deps.Ctx, randomAcc, funtoken.BankDenom).Amount.String(),
 	)
 
 	evmtest.AssertERC20BalanceEqual(s.T(), deps, contract, theUser, big.NewInt(69_000))
 	evmtest.AssertERC20BalanceEqual(s.T(), deps, contract, theEvm, big.NewInt(1))
 	s.Equal("419",
-		deps.Chain.BankKeeper.GetBalance(deps.Ctx, randomAcc, funtoken.BankDenom).Amount.String(),
+		deps.App.BankKeeper.GetBalance(deps.Ctx, randomAcc, funtoken.BankDenom).Amount.String(),
 	)
 }

--- a/x/evm/precompile/precompile_test.go
+++ b/x/evm/precompile/precompile_test.go
@@ -27,7 +27,7 @@ func (s *Suite) TestOrderedPrecompileAddresses() {
 	// Note that orderedKeys must be set after InitPrecompiles to mirror the
 	// behavior of the Nibiru BaseApp.
 	deps := evmtest.NewTestDeps()
-	var unorderedMap map[gethcommon.Address]vm.PrecompiledContract = precompile.InitPrecompiles(deps.Chain.PublicKeepers)
+	var unorderedMap map[gethcommon.Address]vm.PrecompiledContract = precompile.InitPrecompiles(deps.App.PublicKeepers)
 	var orderedKeys []gethcommon.Address = vm.PrecompiledAddressesBerlin
 
 	s.T().Log("2 | Compute ordered keys from VM")

--- a/x/evm/statedb/statedb_test.go
+++ b/x/evm/statedb/statedb_test.go
@@ -520,7 +520,7 @@ func (s *Suite) TestLog() {
 	)
 
 	deps := evmtest.NewTestDeps()
-	db := statedb.New(deps.Ctx, &deps.Chain.EvmKeeper, txConfig)
+	db := statedb.New(deps.Ctx, &deps.App.EvmKeeper, txConfig)
 
 	logData := []byte("hello world")
 	log := &gethcore.Log{


### PR DESCRIPTION
# Purpose / Abstract

`testapp.NewNibiruTestAppAndContext()` returns an App and Context object, so it's easier to call it `App` rather than `Chain`.

<!-- 
Why is this PR important? 
What does this PR do?
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added functionality to include an additional genesis account in the local network setup script.
- **Refactor**
	- Updated dependency references from `deps.Chain` to `deps.App` across multiple test files, enhancing the structure of dependency management.
- **Bug Fixes**
	- Adjusted various tests to ensure they access the correct application context, potentially resolving issues with dependency visibility.
- **Chores**
	- Increased sleep duration in the workflow to ensure local network initialization before executing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->