### PR TITLE
feat(evm): Emit block bloom event in EndBlock hook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2003](https://github.com/NibiruChain/nibiru/pull/2003) - fix(evm): fix FunToken conversions between Cosmos and EVM
 - [#2004](https://github.com/NibiruChain/nibiru/pull/2004) - refactor(evm)!: replace `HexAddr` with `EIP55Addr`
 - [#2008](https://github.com/NibiruChain/nibiru/pull/2008) - refactor(evm): clean up precompile setups
+- [#2014](https://github.com/NibiruChain/nibiru/pull/2014) - feat(evm): Emit block bloom event in EndBlock hook.
 
 #### Dapp modules: perp, spot, oracle, etc
 

--- a/x/evm/keeper/hooks.go
+++ b/x/evm/keeper/hooks.go
@@ -2,21 +2,23 @@
 package keeper
 
 import (
+	"github.com/NibiruChain/nibiru/v2/x/evm"
 	abci "github.com/cometbft/cometbft/abci/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	gethcoretypes "github.com/ethereum/go-ethereum/core/types"
 )
 
-// BeginBlock sets the sdk Context and EIP155 chain id to the Keeper.
-func (k *Keeper) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
-	// TODO: feat(evm): impl BeginBlock
-	// Is it necessary to set a local variable, or can we use ctx everywhere?
-}
+// BeginBlock hook for the EVM module.
+func (k *Keeper) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {}
 
 // EndBlock also retrieves the bloom filter value from the transient store and commits it to the
-// KVStore. The EVM end block logic doesn't update the validator set, thus it returns
-// an empty slice.
 func (k *Keeper) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
-	// TODO: Do we care about bloom here?
+	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
+	bloom := gethcoretypes.BytesToBloom(k.EvmState.GetBlockBloomTransient(ctx).Bytes())
+	ctx.EventManager().EmitTypedEvent(&evm.EventBlockBloom{
+		Bloom: string(bloom.Bytes()),
+	})
+	// The bloom logic doesn't update the validator set.
 	return []abci.ValidatorUpdate{}
 }

--- a/x/evm/keeper/hooks.go
+++ b/x/evm/keeper/hooks.go
@@ -2,8 +2,9 @@
 package keeper
 
 import (
-	"github.com/NibiruChain/nibiru/v2/x/evm"
 	abci "github.com/cometbft/cometbft/abci/types"
+
+	"github.com/NibiruChain/nibiru/v2/x/evm"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	gethcoretypes "github.com/ethereum/go-ethereum/core/types"
@@ -16,7 +17,7 @@ func (k *Keeper) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {}
 func (k *Keeper) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
 	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 	bloom := gethcoretypes.BytesToBloom(k.EvmState.GetBlockBloomTransient(ctx).Bytes())
-	ctx.EventManager().EmitTypedEvent(&evm.EventBlockBloom{
+	_ = ctx.EventManager().EmitTypedEvent(&evm.EventBlockBloom{
 		Bloom: string(bloom.Bytes()),
 	})
 	// The bloom logic doesn't update the validator set.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a feature to emit a block bloom event in the EndBlock hook, enhancing event tracking and state management during block finalization.

- **Documentation**
  - Updated `CHANGELOG.md` to reflect the new feature related to the Ethereum Virtual Machine (EVM).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->