### PR TITLE
fix(evm): non-deterministic gas usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ tests for race conditions within funtoken precompile
 - [#2107](https://github.com/NibiruChain/nibiru/pull/2107) -
 feat(evm-funtoken-precompile): Implement methods: balance, bankBalance, whoAmI
 - [#2108](https://github.com/NibiruChain/nibiru/pull/2108) - fix(evm): removed deprecated root key from eth_getTransactionReceipt
-
+- [#2108](https://github.com/NibiruChain/nibiru/pull/2110) - fix(evm): get rid of non-deterministic gas usage of NibiruBankKeeper
 
 #### Nibiru EVM | Before Audit 1 - 2024-10-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@ tests for race conditions within funtoken precompile
 - [#2107](https://github.com/NibiruChain/nibiru/pull/2107) -
 feat(evm-funtoken-precompile): Implement methods: balance, bankBalance, whoAmI
 - [#2108](https://github.com/NibiruChain/nibiru/pull/2108) - fix(evm): removed deprecated root key from eth_getTransactionReceipt
-- [#2108](https://github.com/NibiruChain/nibiru/pull/2110) - fix(evm): get rid of non-deterministic gas usage of NibiruBankKeeper
+- [#2110](https://github.com/NibiruChain/nibiru/pull/2110) - fix(evm): Restore StateDB to its state prior to ApplyEvmMsg call to ensure deterministic gas usage. This fixes an issue where the StateDB pointer field in NibiruBankKeeper was being updated during readonly query endpoints like eth_estimateGas, leading to non-deterministic gas usage in subsequent transactions.
 
 #### Nibiru EVM | Before Audit 1 - 2024-10-18
 

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -454,7 +454,7 @@ func (k Keeper) EstimateGasForEvmCallType(
 				return nil, fmt.Errorf("gas required exceeds allowance (%d)", gasCap)
 			}
 
-			return nil, fmt.Errorf("Estimgate gas VMError: %s", result.VmError)
+			return nil, fmt.Errorf("Estimate gas VMError: %s", result.VmError)
 		}
 	}
 

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -259,6 +259,12 @@ func (k *Keeper) ApplyEvmMsg(ctx sdk.Context,
 		vmErr error  // vm errors do not effect consensus and are therefore not assigned to err
 	)
 
+	// save a reference to return to the previous stateDB
+	oldStateDb := k.Bank.StateDB
+	defer func() {
+		k.Bank.StateDB = oldStateDb
+	}()
+
 	stateDB := k.NewStateDB(ctx, txConfig)
 	evmObj = k.NewEVM(ctx, msg, evmConfig, tracer, stateDB)
 


### PR DESCRIPTION
# Purpose / Abstract

- #2095 introduced a custom Nibiru BankKeeper extension that adds StateDB as a pointer field. The pointer field is updated in readonly query endpoints (e.g. eth_estimateGas) which makes gas usage non-deterministic in future transactions because of the conditional program flow path arising from a nil check. The conditional check causes consensus failures because of the difference in gas used.
- The solution is to restore the StateDB to what it was prior to the ApplyEvmMsg call, after the ApplyEvmMsg call.
- How I tested it on localnet:
  1) measure gas usage of a simple x/bank send
  2) manually call the `eth_estimateGas` endpoint to trigger a BankKeeper.StateDB pointer update
  3) measure gas usage of x/bank send again
  4) prior to the fix (`v2.0.0-rc.12`), the gas_used is different. On this branch, the gas_used is identical.

See https://www.notion.so/nibiru/2024-11-07-testnet-1-consensus-failure-137d2597a03c8064a399eec8f24614aa?pvs=4 for more details


<!-- 
Why is this PR important? 
What does this PR do?
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enabled WASM light clients on IBC.
	- Introduced support for foundry in Nibiru EVM development.
	- Added validation for FunToken creation fees.
	- Enhanced functionality for gas usage in precompiles.
	- Implemented a new method for retrieving fun token mappings.

- **Bug Fixes**
	- Improved handling of ERC20 transfers with false success values.
	- Ensured state consistency in precompile execution.
	- Addressed gas consumption issues during ERC20 contract execution.
	- Enhanced error handling and removed deprecated API keys.

- **Documentation**
	- Updated CHANGELOG.md to reflect recent changes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->