### PR TITLE
fix(evm): make conditional balance check free in gas cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ feat(evm-funtoken-precompile): Implement methods: balance, bankBalance, whoAmI
 - [#2108](https://github.com/NibiruChain/nibiru/pull/2108) - fix(evm): removed deprecated root key from eth_getTransactionReceipt
 - [#2110](https://github.com/NibiruChain/nibiru/pull/2110) - fix(evm): Restore StateDB to its state prior to ApplyEvmMsg call to ensure deterministic gas usage. This fixes an issue where the StateDB pointer field in NibiruBankKeeper was being updated during readonly query endpoints like eth_estimateGas, leading to non-deterministic gas usage in subsequent transactions.
 - [#2111](https://github.com/NibiruChain/nibiru/pull/2111) - fix: e2e-evm-cron.yml
+- [#2114](https://github.com/NibiruChain/nibiru/pull/2114) - fix(evm): make gas cost zero in conditional bank keeper flow
 
 #### Nibiru EVM | Before Audit 1 - 2024-10-18
 

--- a/x/evm/keeper/bank_extension.go
+++ b/x/evm/keeper/bank_extension.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	auth "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
@@ -84,6 +85,14 @@ func (bk *NibiruBankKeeper) SyncStateDBWithAccount(
 	if bk.StateDB == nil {
 		return
 	}
+
+	cachedGasConfig := ctx.KVGasConfig()
+	defer func() {
+		ctx = ctx.WithKVGasConfig(cachedGasConfig)
+	}()
+
+	// set gas cost to zero for this conditional operation
+	ctx = ctx.WithKVGasConfig(storetypes.GasConfig{})
 	balanceWei := evm.NativeToWei(
 		bk.GetBalance(ctx, acc, evm.EVMBankDenom).Amount.BigInt(),
 	)


### PR DESCRIPTION
# Purpose / Abstract

We recently experienced another consensus failure on devnet-3. It happened again with the gas_used value in the last_results block. It's likely due to parallel calls to `ApplyEvmMsg` thrashing the StateDB pointer on the NibiruBankKeeper. 

In order to ensure that all nodes calculate the same `gas_used` value, we make the conditional path cost zero gas, which shouldn't be a major issue because there's only a tiny db read in that path.

<!-- 
Why is this PR important? 
What does this PR do?
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented WASM light clients on IBC.
  - Added fun token creation fee validation.
  - Introduced validation for WASM multi-message execution.
  - Provided support and template for Nibiru EVM development.

- **Bug Fixes**
  - Improved ERC20 metadata handling during FunToken creation.
  - Enhanced gas fee calculations and consumption handling.
  - Fixed state consistency in precompile execution.
  - Resolved issues with ERC20 transfers returning false success values.

- **Documentation**
  - Updated CHANGELOG.md to reflect recent changes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->