### PR TITLE
fix(evm): Guarantee that gas consumed during any send operation of the "NibiruBankKeeper" depends only on the "bankkeeper.BaseKeeper"'s gas consumption.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Nibiru EVM
 
-#### Nibiru EVM | Before Audit 2 [Nov, 2024]
+- [#2xxx](https://github.com/NibiruChain/nibiru/pull/2xxx) - fix(evm): Guarantee
+that gas consumed during any send operation of the "NibiruBankKeeper" depends
+only on the "bankkeeper.BaseKeeper"'s gas consumption.
+
+#### Nibiru EVM | Before Audit 2 - 2024-12-06
 
 The codebase went through a third-party [Code4rena
 Zenith](https://code4rena.com/zenith) Audit, running from 2024-10-07 until

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Nibiru EVM
 
-- [#2xxx](https://github.com/NibiruChain/nibiru/pull/2xxx) - fix(evm): Guarantee
+- [#2119](https://github.com/NibiruChain/nibiru/pull/2119) - fix(evm): Guarantee
 that gas consumed during any send operation of the "NibiruBankKeeper" depends
 only on the "bankkeeper.BaseKeeper"'s gas consumption.
 

--- a/app/ante/commission_test.go
+++ b/app/ante/commission_test.go
@@ -1,8 +1,6 @@
 package ante_test
 
 import (
-	"testing"
-
 	"cosmossdk.io/math"
 	sdkclienttx "github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -109,7 +107,7 @@ func (s *AnteTestSuite) TestAnteDecoratorStakingCommission() {
 			wantErr: ante.ErrMaxValidatorCommission.Error(),
 		},
 	} {
-		s.T().Run(tc.name, func(t *testing.T) {
+		s.Run(tc.name, func() {
 			txGasCoins := sdk.NewCoins(
 				sdk.NewCoin("unibi", math.NewInt(1_000)),
 				sdk.NewCoin("utoken", math.NewInt(500)),

--- a/app/ante/fixed_gas_test.go
+++ b/app/ante/fixed_gas_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
-	"github.com/cosmos/cosmos-sdk/x/bank/types"
+	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/NibiruChain/nibiru/v2/app/ante"
 	"github.com/NibiruChain/nibiru/v2/app/appconst"
@@ -62,7 +62,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 					Feeder:    addr.String(),
 					Validator: addr.String(),
 				},
-				&types.MsgSend{
+				&bank.MsgSend{
 					FromAddress: addr.String(),
 					ToAddress:   addr.String(),
 					Amount:      sdk.NewCoins(sdk.NewInt64Coin(appconst.BondDenom, 100)),
@@ -74,7 +74,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 		{
 			name: "Two messages in a transaction, one of them is an oracle vote message should fail (with MsgAggregateExchangeRatePrevote) permutation 2",
 			messages: []sdk.Msg{
-				&types.MsgSend{
+				&bank.MsgSend{
 					FromAddress: addr.String(),
 					ToAddress:   addr.String(),
 					Amount:      sdk.NewCoins(sdk.NewInt64Coin(appconst.BondDenom, 100)),
@@ -97,7 +97,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 					Feeder:        addr.String(),
 					Validator:     addr.String(),
 				},
-				&types.MsgSend{
+				&bank.MsgSend{
 					FromAddress: addr.String(),
 					ToAddress:   addr.String(),
 					Amount:      sdk.NewCoins(sdk.NewInt64Coin(appconst.BondDenom, 100)),
@@ -109,7 +109,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 		{
 			name: "Two messages in a transaction, one of them is an oracle vote message should fail (with MsgAggregateExchangeRateVote) permutation 2",
 			messages: []sdk.Msg{
-				&types.MsgSend{
+				&bank.MsgSend{
 					FromAddress: addr.String(),
 					ToAddress:   addr.String(),
 					Amount:      sdk.NewCoins(sdk.NewInt64Coin(appconst.BondDenom, 100)),
@@ -169,7 +169,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 					Feeder:        addr.String(),
 					Validator:     addr.String(),
 				},
-				&types.MsgSend{
+				&bank.MsgSend{
 					FromAddress: addr.String(),
 					ToAddress:   addr.String(),
 					Amount:      sdk.NewCoins(sdk.NewInt64Coin(appconst.BondDenom, 100)),
@@ -186,25 +186,25 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 		{
 			name: "Other two messages",
 			messages: []sdk.Msg{
-				&types.MsgSend{
+				&bank.MsgSend{
 					FromAddress: addr.String(),
 					ToAddress:   addr.String(),
 					Amount:      sdk.NewCoins(sdk.NewInt64Coin(appconst.BondDenom, 100)),
 				},
-				&types.MsgSend{
+				&bank.MsgSend{
 					FromAddress: addr.String(),
 					ToAddress:   addr.String(),
 					Amount:      sdk.NewCoins(sdk.NewInt64Coin(appconst.BondDenom, 200)),
 				},
 			},
-			expectedGas: 67193,
+			expectedGas: 38175,
 			expectedErr: nil,
 		},
 	}
 
 	for _, tc := range tests {
 		tc := tc
-		suite.T().Run(tc.name, func(t *testing.T) {
+		suite.Run(tc.name, func() {
 			suite.SetupTest() // setup
 			suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
 

--- a/app/evmante/suite_test.go
+++ b/app/evmante/suite_test.go
@@ -60,7 +60,7 @@ func (s *TestSuite) TestGenesis() {
 			wantErr: "min_commission must be positive",
 		},
 	} {
-		s.T().Run(tc.name, func(t *testing.T) {
+		s.Run(tc.name, func() {
 			genStakingJson := s.encCfg.Codec.MustMarshalJSON(tc.gen)
 			err := app.StakingModule{}.ValidateGenesis(
 				s.encCfg.Codec,

--- a/app/modules_test.go
+++ b/app/modules_test.go
@@ -60,7 +60,7 @@ func (s *TestSuite) TestGenesis() {
 			wantErr: "min_commission must be positive",
 		},
 	} {
-		s.T().Run(tc.name, func(t *testing.T) {
+		s.Run(tc.name, func() {
 			genStakingJson := s.encCfg.Codec.MustMarshalJSON(tc.gen)
 			err := app.StakingModule{}.ValidateGenesis(
 				s.encCfg.Codec,

--- a/eth/rpc/block_test.go
+++ b/eth/rpc/block_test.go
@@ -7,6 +7,7 @@ import (
 
 	grpctypes "github.com/cosmos/cosmos-sdk/types/grpc"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/metadata"
 )
@@ -129,7 +130,7 @@ func (s *BlockSuite) TestUnmarshalBlockNumberOrHash() {
 	}
 
 	for _, tc := range testCases {
-		fmt.Printf("Case %s", tc.msg)
+		log.Info().Msgf("Case %s", tc.msg)
 		// reset input
 		bnh = new(BlockNumberOrHash)
 		err := bnh.UnmarshalJSON(tc.input)

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/net v0.23.0
 	golang.org/x/text v0.14.0
+	github.com/rs/zerolog v1.32.0
 )
 
 require (
@@ -197,7 +198,6 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rjeczalik/notify v0.9.1 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
-	github.com/rs/zerolog v1.32.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect

--- a/x/common/paginate_test.go
+++ b/x/common/paginate_test.go
@@ -74,7 +74,7 @@ func (s *paginateSuite) TestParsePagination() {
 			wantOffset: 99,
 		},
 	} {
-		s.T().Run(tc.name, func(t *testing.T) {
+		s.Run(tc.name, func() {
 			gotPageReq, gotPage, gotErr := common.ParsePagination(tc.pageReq)
 
 			s.EqualValues(tc.wantPage, gotPage)

--- a/x/common/testutil/testnetwork/tx_test.go
+++ b/x/common/testutil/testnetwork/tx_test.go
@@ -1,8 +1,6 @@
 package testnetwork_test
 
 import (
-	"testing"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"cosmossdk.io/math"
@@ -37,7 +35,7 @@ func (s *TestSuite) TestExecTx() {
 	s.NoError(err)
 	s.EqualValues(0, txResp.Code)
 
-	s.T().Run("test tx option changes", func(t *testing.T) {
+	s.Run("test tx option changes", func() {
 		defaultOpts := testnetwork.DEFAULT_TX_OPTIONS
 		opts := testnetwork.WithTxOptions(testnetwork.TxOptionChanges{
 			BroadcastMode:    &defaultOpts.BroadcastMode,
@@ -52,7 +50,7 @@ func (s *TestSuite) TestExecTx() {
 		s.EqualValues(0, txResp.Code)
 	})
 
-	s.T().Run("fail when validators are missing", func(t *testing.T) {
+	s.Run("fail when validators are missing", func() {
 		networkNoVals := new(testnetwork.Network)
 		*networkNoVals = *s.network
 		networkNoVals.Validators = []*testnetwork.Validator{}

--- a/x/devgas/v1/ante/ante_test.go
+++ b/x/devgas/v1/ante/ante_test.go
@@ -236,7 +236,8 @@ func (suite *AnteTestSuite) TestDevGasPayout() {
 	}
 
 	for _, tc := range testCases {
-		suite.T().Run(tc.name, func(t *testing.T) {
+		suite.Run(tc.name, func() {
+			t := suite.T()
 			bapp, ctx := tc.setup()
 			ctx = ctx.WithChainID("mock-chain-id")
 			anteDecorator := devgasante.NewDevGasPayoutDecorator(

--- a/x/devgas/v1/genesis_test.go
+++ b/x/devgas/v1/genesis_test.go
@@ -109,7 +109,7 @@ func (s *GenesisTestSuite) TestGenesis() {
 	}
 
 	for _, tc := range testCases {
-		s.T().Run(fmt.Sprintf("Case %s", tc.name), func(t *testing.T) {
+		s.Run(fmt.Sprintf("Case %s", tc.name), func() {
 			s.SetupTest() // reset
 
 			if tc.expPanic {

--- a/x/devgas/v1/types/msg_test.go
+++ b/x/devgas/v1/types/msg_test.go
@@ -276,7 +276,7 @@ func (s *MsgsTestSuite) TestQuery_ValidateBasic() {
 			},
 		},
 	} {
-		s.T().Run(tc.name, func(t *testing.T) {
+		s.Run(tc.name, func() {
 			tc.test()
 		})
 	}

--- a/x/evm/keeper/bank_extension_test.go
+++ b/x/evm/keeper/bank_extension_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/NibiruChain/nibiru/v2/x/evm/evmtest"
 )
 
-// TODO: UD-DEBUG:
-// non-nil StaetDB bank send and record gas consumed
-// nil StaetDB bank send and record gas consumed
-// Both should be equal.
-
 // TestGasConsumedInvariantSend: The "NibiruBankKeeper" is defined such that
 // send operations are meant to have consistent gas consumption regardless of the
 // whether the active "StateDB" instance is defined or undefined (nil). This is
@@ -214,6 +209,7 @@ func (f FunctionalGasConsumedInvariantScenario) Run(s *Suite) {
 	)
 }
 
+// See [Suite.TestGasConsumedInvariantSend].
 func (s *Suite) TestGasConsumedInvariantOther() {
 	to := evmtest.NewEthPrivAcc() // arbitrary constant
 	bankDenom := evm.EVMBankDenom

--- a/x/evm/keeper/bank_extension_test.go
+++ b/x/evm/keeper/bank_extension_test.go
@@ -1,0 +1,181 @@
+package keeper_test
+
+import (
+	"fmt"
+
+	"github.com/NibiruChain/nibiru/v2/x/common/testutil/testapp"
+	"github.com/NibiruChain/nibiru/v2/x/evm"
+	"github.com/NibiruChain/nibiru/v2/x/evm/evmtest"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/rs/zerolog/log"
+)
+
+// TODO: UD-DEBUG:
+// non-nil StaetDB bank send and record gas consumed
+// nil StaetDB bank send and record gas consumed
+// Both should be equal.
+
+// TestGasConsumedInvariant: The "NibiruBankKeeper" is defined such that
+// send operations are meant to have consistent gas consumption regardless of the
+// whether the active "StateDB" instance is defined or undefined (nil). This is
+// important to prevent consensus failures resulting from nodes reaching an
+// inconsistent state after processing the same state transitions and gettng
+// conflicting gas results.
+func (s *Suite) TestGasConsumedInvariant() {
+	to := evmtest.NewEthPrivAcc() // arbitrary constant
+
+	testCases := []struct {
+		GasConsumedInvariantScenario
+		name string
+	}{
+		{
+			name: "StateDB nil",
+			GasConsumedInvariantScenario: GasConsumedInvariantScenario{
+				BankDenom:  evm.EVMBankDenom,
+				NilStateDB: true,
+			},
+		},
+
+		{
+			name: "StateDB defined",
+			GasConsumedInvariantScenario: GasConsumedInvariantScenario{
+				BankDenom:  evm.EVMBankDenom,
+				NilStateDB: false,
+			},
+		},
+
+		{
+			name: "StateDB nil, uniba",
+			GasConsumedInvariantScenario: GasConsumedInvariantScenario{
+				BankDenom:  "uniba",
+				NilStateDB: true,
+			},
+		},
+	}
+
+	s.T().Log("Check that gas consumption is equal in all scenarios")
+	var first uint64
+	for idx, tc := range testCases {
+		s.Run(tc.name, func() {
+			gasConsumed := tc.GasConsumedInvariantScenario.Run(s, to)
+			if idx == 0 {
+				first = gasConsumed
+				return
+			}
+			// Each elem being equal to "first" implies that each elem is equal
+			s.Equalf(
+				fmt.Sprintf("%d", first),
+				fmt.Sprintf("%d", gasConsumed),
+				"Gas consumed should be equal",
+			)
+		})
+	}
+
+}
+
+func (s *Suite) populateStateDB(deps *evmtest.TestDeps) {
+	// evmtest.DeployAndExecuteERC20Transfer(deps, s.T())
+	deps.NewStateDB()
+	s.NotNil(deps.EvmKeeper.Bank.StateDB)
+}
+
+type GasConsumedInvariantScenario struct {
+	BankDenom  string
+	NilStateDB bool
+}
+
+func (scenario GasConsumedInvariantScenario) Run(
+	s *Suite,
+	to evmtest.EthPrivKeyAcc,
+) (gasConsumed uint64) {
+	bankDenom, nilStateDB := scenario.BankDenom, scenario.NilStateDB
+	deps := evmtest.NewTestDeps()
+	if nilStateDB {
+		s.Require().Nil(deps.EvmKeeper.Bank.StateDB)
+	} else {
+		s.populateStateDB(&deps)
+	}
+
+	sendCoins := sdk.NewCoins(sdk.NewInt64Coin(bankDenom, 420))
+	s.NoError(
+		testapp.FundAccount(deps.App.BankKeeper, deps.Ctx, deps.Sender.NibiruAddr, sendCoins),
+	)
+
+	gasConsumedBefore := deps.Ctx.GasMeter().GasConsumed()
+	s.NoError(
+		deps.App.BankKeeper.SendCoins(
+			deps.Ctx, deps.Sender.NibiruAddr, to.NibiruAddr, sendCoins,
+		),
+	)
+	gasConsumedAfter := deps.Ctx.GasMeter().GasConsumed()
+	log.Debug().Msgf("gasConsumedBefore: %d", gasConsumedBefore)
+	log.Debug().Msgf("gasConsumedAfter: %d", gasConsumedAfter)
+	log.Debug().Msgf("nilStateDB: %v", nilStateDB)
+
+	s.GreaterOrEqualf(gasConsumedAfter, gasConsumedBefore,
+		"gas meter consumed should not be negative: gas consumed after = %d, gas consumed before = %d ",
+		gasConsumedAfter, gasConsumedBefore,
+	)
+
+	return gasConsumedAfter - gasConsumedBefore
+}
+
+func (s *Suite) TestGasConsumedInvariantNotNibi() {
+	to := evmtest.NewEthPrivAcc() // arbitrary constant
+
+	testCases := []struct {
+		GasConsumedInvariantScenario
+		name string
+	}{
+		{
+			name: "StateDB nil A",
+			GasConsumedInvariantScenario: GasConsumedInvariantScenario{
+				BankDenom:  "dummy_token_A",
+				NilStateDB: true,
+			},
+		},
+
+		{
+			name: "StateDB defined A",
+			GasConsumedInvariantScenario: GasConsumedInvariantScenario{
+				BankDenom:  "dummy_token_A",
+				NilStateDB: false,
+			},
+		},
+
+		{
+			name: "StateDB nil B",
+			GasConsumedInvariantScenario: GasConsumedInvariantScenario{
+				BankDenom:  "dummy_token_B",
+				NilStateDB: true,
+			},
+		},
+
+		{
+			name: "StateDB defined B",
+			GasConsumedInvariantScenario: GasConsumedInvariantScenario{
+				BankDenom:  "dummy_token_B",
+				NilStateDB: false,
+			},
+		},
+	}
+
+	s.T().Log("Check that gas consumption is equal in all scenarios")
+	var first uint64
+	for idx, tc := range testCases {
+		s.Run(tc.name, func() {
+			gasConsumed := tc.GasConsumedInvariantScenario.Run(s, to)
+			if idx == 0 {
+				first = gasConsumed
+				return
+			}
+			// Each elem being equal to "first" implies that each elem is equal
+			s.Equalf(
+				fmt.Sprintf("%d", first),
+				fmt.Sprintf("%d", gasConsumed),
+				"Gas consumed should be equal",
+			)
+		})
+	}
+
+}

--- a/x/evm/keeper/bank_extension_test.go
+++ b/x/evm/keeper/bank_extension_test.go
@@ -3,11 +3,12 @@ package keeper_test
 import (
 	"fmt"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	"github.com/NibiruChain/nibiru/v2/x/common/testutil/testapp"
 	"github.com/NibiruChain/nibiru/v2/x/evm"
 	"github.com/NibiruChain/nibiru/v2/x/evm/evmtest"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // TODO: UD-DEBUG:
@@ -70,13 +71,6 @@ func (s *Suite) TestGasConsumedInvariantSend() {
 			)
 		})
 	}
-
-}
-
-func (s *Suite) populateStateDB(deps *evmtest.TestDeps) {
-	// evmtest.DeployAndExecuteERC20Transfer(deps, s.T())
-	deps.NewStateDB()
-	s.NotNil(deps.EvmKeeper.Bank.StateDB)
 }
 
 type GasConsumedInvariantScenario struct {
@@ -241,7 +235,6 @@ func (s *Suite) TestGasConsumedInvariantOther() {
 				)
 			},
 		}.Run(s)
-
 	})
 
 	s.Run("BurnCoins", func() {
@@ -259,7 +252,6 @@ func (s *Suite) TestGasConsumedInvariantOther() {
 				)
 			},
 		}.Run(s)
-
 	})
 
 	s.Run("SendCoinsFromAccountToModule", func() {
@@ -277,7 +269,6 @@ func (s *Suite) TestGasConsumedInvariantOther() {
 				)
 			},
 		}.Run(s)
-
 	})
 
 	s.Run("SendCoinsFromModuleToAccount", func() {
@@ -295,7 +286,6 @@ func (s *Suite) TestGasConsumedInvariantOther() {
 				)
 			},
 		}.Run(s)
-
 	})
 
 	s.Run("SendCoinsFromModuleToModule", func() {
@@ -313,7 +303,5 @@ func (s *Suite) TestGasConsumedInvariantOther() {
 				)
 			},
 		}.Run(s)
-
 	})
-
 }

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -255,17 +255,28 @@ func (k *Keeper) ApplyEvmMsg(ctx sdk.Context,
 	fullRefundLeftoverGas bool,
 ) (resp *evm.MsgEthereumTxResponse, evmObj *vm.EVM, err error) {
 	var (
-		ret   []byte // return bytes from evm execution
-		vmErr error  // vm errors do not effect consensus and are therefore not assigned to err
+		// return bytes from evm execution
+		ret []byte
+		// vm errors do not imply a failed query, thus they don't populate the
+		// function's "err" value.
+		vmErr error
 	)
 
-	// save a reference to return to the previous stateDB
-	oldStateDb := k.Bank.StateDB
+	var (
+		stateDB *statedb.StateDB
+		// save a reference to return to the previous stateDB
+		oldStateDB *statedb.StateDB = k.Bank.StateDB
+	)
+
 	defer func() {
-		k.Bank.StateDB = oldStateDb
+		if commit && err == nil && !resp.Failed() {
+			k.Bank.StateDB = stateDB
+		} else {
+			k.Bank.StateDB = oldStateDB
+		}
 	}()
 
-	stateDB := k.NewStateDB(ctx, txConfig)
+	stateDB = k.NewStateDB(ctx, txConfig)
 	evmObj = k.NewEVM(ctx, msg, evmConfig, tracer, stateDB)
 
 	leftoverGas := msg.Gas()

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -269,7 +269,7 @@ func (k *Keeper) ApplyEvmMsg(ctx sdk.Context,
 	)
 
 	defer func() {
-		if commit && err == nil && !resp.Failed() {
+		if commit && err == nil && resp != nil && !resp.Failed() {
 			k.Bank.StateDB = stateDB
 		} else {
 			k.Bank.StateDB = oldStateDB

--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -184,6 +184,16 @@ func (k *Keeper) DeleteAccount(ctx sdk.Context, addr gethcommon.Address) error {
 	return nil
 }
 
+func GaslessOperation(ctx sdk.Context, op func(ctx sdk.Context)) {
+	gasMeterBeforeOp := ctx.GasMeter()
+	defer func() {
+		ctx = ctx.WithGasMeter(gasMeterBeforeOp)
+	}()
+
+	freeGasCtx := ctx.WithGasMeter(sdk.NewGasMeter(gasMeterBeforeOp.Limit()))
+	op(freeGasCtx)
+}
+
 // GetAccountWithoutBalance load nonce and codehash without balance,
 // more efficient in cases where balance is not needed.
 func (k *Keeper) GetAccountWithoutBalance(ctx sdk.Context, addr gethcommon.Address) *statedb.Account {

--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -184,16 +184,6 @@ func (k *Keeper) DeleteAccount(ctx sdk.Context, addr gethcommon.Address) error {
 	return nil
 }
 
-func GaslessOperation(ctx sdk.Context, op func(ctx sdk.Context)) {
-	gasMeterBeforeOp := ctx.GasMeter()
-	defer func() {
-		ctx = ctx.WithGasMeter(gasMeterBeforeOp)
-	}()
-
-	freeGasCtx := ctx.WithGasMeter(sdk.NewGasMeter(gasMeterBeforeOp.Limit()))
-	op(freeGasCtx)
-}
-
 // GetAccountWithoutBalance load nonce and codehash without balance,
 // more efficient in cases where balance is not needed.
 func (k *Keeper) GetAccountWithoutBalance(ctx sdk.Context, addr gethcommon.Address) *statedb.Account {


### PR DESCRIPTION
# Purpose / Abstract

The prior conditional behavior in the `NibiruBankKeeper` where we switched out the gas config to try to prevent the EVM `StateDB` from affecting gas consumption during send operations was not effective.  

I set up some test cases where I'd bank send in the same manner when the `StateDB` was nil and when the `StateDB` was defined to compare the gas results:

![wk49-n3630-WindowsTerminal_8fDt](https://github.com/user-attachments/assets/b71d42fb-a660-429c-a00c-c6bda6bf6228)

# Code Changes

1. Updates each send operation to use only the gas consumed by the
   `bankkeeper.BaseKeeper`, making the value consistent regardless of whether the
   EVM `StateDB` exists
2. Adds several test cases that display this consistent gas behavior to help
   prevent regressions. [link to file](https://github.com/NibiruChain/nibiru/pull/2119/files#diff-d8c972183061b323d07a0bac4da0dc3f83103d3ccc9135d136763fc760adc14f)
3. Edits the `defer` statement in evm/keeper/msg_server.go to only set the value
   for the `NibiruBankKeeper` `StateDB` pointer if `commit` is true and the state
   transition is a success
