### PR TITLE
refactor(evm): Remove unnecessary argument in the `VerifyFee` function, which returns the token payment required based on the effective fee from the tx data. Improve documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ that gas consumed during any send operation of the "NibiruBankKeeper" depends
 only on the "bankkeeper.BaseKeeper"'s gas consumption.
 - [#2120](https://github.com/NibiruChain/nibiru/pull/2120) - fix: Use canonical hexadecimal strings for Eip155 address encoding 
 - [#2122](https://github.com/NibiruChain/nibiru/pull/2122) - test(evm): more bank extension tests and EVM ABCI integration tests to prevent regressions
+- [#21xx](https://github.com/NibiruChain/nibiru/pull/21xx) - refactor(evm):
+Remove unnecessary argument in the `VerifyFee` function, which returns the token
+payment required based on the effective fee from the tx data. Improve
+documentation.
 
 #### Nibiru EVM | Before Audit 2 - 2024-12-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ that gas consumed during any send operation of the "NibiruBankKeeper" depends
 only on the "bankkeeper.BaseKeeper"'s gas consumption.
 - [#2120](https://github.com/NibiruChain/nibiru/pull/2120) - fix: Use canonical hexadecimal strings for Eip155 address encoding 
 - [#2122](https://github.com/NibiruChain/nibiru/pull/2122) - test(evm): more bank extension tests and EVM ABCI integration tests to prevent regressions
-- [#21xx](https://github.com/NibiruChain/nibiru/pull/21xx) - refactor(evm):
+- [#2124](https://github.com/NibiruChain/nibiru/pull/2124) - refactor(evm):
 Remove unnecessary argument in the `VerifyFee` function, which returns the token
 payment required based on the effective fee from the tx data. Improve
 documentation.

--- a/app/evmante/evmante_gas_consume.go
+++ b/app/evmante/evmante_gas_consume.go
@@ -99,7 +99,6 @@ func (anteDec AnteDecEthGasConsume) AnteHandle(
 
 		fees, err := keeper.VerifyFee(
 			txData,
-			evm.EVMBankDenom,
 			baseFeeMicronibiPerGas,
 			ctx.IsCheckTx(),
 		)

--- a/x/evm/keeper/gas_fees_test.go
+++ b/x/evm/keeper/gas_fees_test.go
@@ -101,19 +101,18 @@ func (s *Suite) TestVerifyFee() {
 			}
 		},
 	} {
-		feeDenom := evm.EVMBankDenom
 		isCheckTx := true
 		tc := getTestCase()
 		s.Run(tc.name, func() {
 			gotCoins, err := evmkeeper.VerifyFee(
-				tc.txData, feeDenom, tc.baseFeeMicronibi, isCheckTx,
+				tc.txData, tc.baseFeeMicronibi, isCheckTx,
 			)
 			if tc.wantErr != "" {
 				s.Require().ErrorContains(err, tc.wantErr)
 				return
 			}
 			s.Require().NoError(err)
-			s.Equal(tc.wantCoinAmt, gotCoins.AmountOf(feeDenom).String())
+			s.Equal(tc.wantCoinAmt, gotCoins.AmountOf(evm.EVMBankDenom).String())
 		})
 	}
 }

--- a/x/evm/tx_data.go
+++ b/x/evm/tx_data.go
@@ -32,6 +32,8 @@ var (
 // provide custom implementations for these methods without creating a new TxData
 // data structure. Thus, the current interface exists.
 type TxData interface {
+	// TxType returns a byte (uint8) identifying the tx as a [LegacyTx] (0),
+	// [AccessListTx] (1), or [DynamicFeeTx] (2).
 	TxType() byte
 	Copy() TxData
 	GetChainID() *big.Int
@@ -86,14 +88,24 @@ type TxData interface {
 	AsEthereumData() gethcore.TxData
 	Validate() error
 
-	// static fee
+	// Fee in units of wei := gasPrice (wei per gas)  * gasLimit (gas).
 	Fee() *big.Int
-	// Cost is the gas cost of the transaction in wei
+	// Cost in units of wei := Fee * Value. Cost is the gas cost of the
+	// transaction in wei, accounting for value transferred.
 	Cost() *big.Int
 
-	// effective gasPrice/fee/cost according to current base fee
+	// EffectiveGasPriceWeiPerGas is effective gas price in units of wei per gas.
+	// "Effective" means depending on the base fee of the network.
 	EffectiveGasPriceWeiPerGas(baseFeeWei *big.Int) *big.Int
+
+	// EffectiveFeeWei := effectiveGasPrice (wei per gas) * gasLimit (gas).
+	// "Effective" means depending on the base fee of the network.
 	EffectiveFeeWei(baseFeeWei *big.Int) *big.Int
+
+	// EffectiveCostWei is the same as cost, except it uses effective fee in wei
+	// rathen than fee. Effective cost is the gas cost of the transaction in wei,
+	// accounting for value (wei) transferred and using effective gas price (wei
+	// per gas).
 	EffectiveCostWei(baseFeeWei *big.Int) *big.Int
 }
 

--- a/x/evm/tx_data_access_list.go
+++ b/x/evm/tx_data_access_list.go
@@ -101,7 +101,8 @@ func newAccessListTx(tx *gethcore.Transaction) (*AccessListTx, error) {
 	return txData, nil
 }
 
-// TxType returns the tx type
+// TxType returns a byte (uint8) identifying the tx as a [LegacyTx] (0),
+// [AccessListTx] (1), or [DynamicFeeTx] (2).
 func (tx *AccessListTx) TxType() uint8 {
 	return gethcore.AccessListTxType
 }
@@ -280,12 +281,12 @@ func (tx AccessListTx) Validate() error {
 	return nil
 }
 
-// Fee returns gasprice * gaslimit.
+// Fee returns gasPrice * gasLimit.
 func (tx AccessListTx) Fee() *big.Int {
 	return priceTimesGas(tx.GetGasPrice(), tx.GetGas())
 }
 
-// Cost returns amount + gasprice * gaslimit.
+// Cost returns amount + gasPrice * gasLimit.
 func (tx AccessListTx) Cost() *big.Int {
 	return cost(tx.Fee(), tx.GetValueWei())
 }

--- a/x/evm/tx_data_dynamic_fee.go
+++ b/x/evm/tx_data_dynamic_fee.go
@@ -75,7 +75,8 @@ func NewDynamicFeeTx(tx *gethcore.Transaction) (*DynamicFeeTx, error) {
 	return txData, nil
 }
 
-// TxType returns the tx type
+// TxType returns a byte (uint8) identifying the tx as a [LegacyTx] (0),
+// [AccessListTx] (1), or [DynamicFeeTx] (2).
 func (tx *DynamicFeeTx) TxType() uint8 {
 	return gethcore.DynamicFeeTxType
 }
@@ -285,12 +286,12 @@ func (tx DynamicFeeTx) Validate() error {
 	return nil
 }
 
-// Fee returns gasprice * gaslimit.
+// Fee returns gasPrice * gasLimit.
 func (tx DynamicFeeTx) Fee() *big.Int {
 	return priceTimesGas(tx.GetGasFeeCapWei(), tx.GasLimit)
 }
 
-// Cost returns amount + gasprice * gaslimit.
+// Cost returns amount + gasPrice * gasLimit.
 func (tx DynamicFeeTx) Cost() *big.Int {
 	return cost(tx.Fee(), tx.GetValueWei())
 }
@@ -305,12 +306,12 @@ func (tx *DynamicFeeTx) EffectiveGasPriceWeiPerGas(baseFeeWei *big.Int) *big.Int
 	return BigIntMax(baseFeeWei, rawEffectiveGasPrice)
 }
 
-// EffectiveFeeWei returns effective_gasprice * gaslimit.
+// EffectiveFeeWei returns effective_gasPrice * gasLimit.
 func (tx DynamicFeeTx) EffectiveFeeWei(baseFeeWei *big.Int) *big.Int {
 	return priceTimesGas(tx.EffectiveGasPriceWeiPerGas(baseFeeWei), tx.GasLimit)
 }
 
-// EffectiveCostWei returns amount + effective_gasprice * gaslimit.
+// EffectiveCostWei returns amount + effective_gasPrice * gasLimit.
 func (tx DynamicFeeTx) EffectiveCostWei(baseFeeWei *big.Int) *big.Int {
 	return cost(tx.EffectiveFeeWei(baseFeeWei), tx.GetValueWei())
 }

--- a/x/evm/tx_data_legacy.go
+++ b/x/evm/tx_data_legacy.go
@@ -43,7 +43,8 @@ func NewLegacyTx(tx *gethcore.Transaction) (*LegacyTx, error) {
 	return txData, nil
 }
 
-// TxType returns the tx type
+// TxType returns a byte (uint8) identifying the tx as a [LegacyTx] (0),
+// [AccessListTx] (1), or [DynamicFeeTx] (2).
 func (tx *LegacyTx) TxType() uint8 {
 	return gethcore.LegacyTxType
 }
@@ -184,12 +185,13 @@ func (tx LegacyTx) Validate() error {
 	return nil
 }
 
-// Fee returns gasprice * gaslimit.
+// Fee := gasPrice (wei per gas)  * gasLimit (gas). Thus, fee is in units of
+// wei.
 func (tx LegacyTx) Fee() *big.Int {
 	return priceTimesGas(tx.GetGasPrice(), tx.GetGas())
 }
 
-// Cost returns amount + gasprice * gaslimit.
+// Cost returns amount + gasPrice * gasLimit.
 func (tx LegacyTx) Cost() *big.Int {
 	return cost(tx.Fee(), tx.GetValueWei())
 }


### PR DESCRIPTION
# Purpose / Abstract

refactor(evm): Remove unnecessary argument in the `VerifyFee` function, which returns the token payment required based on the effective fee from the tx data. Improve documentation.

- Closes https://github.com/NibiruChain/nibiru/issues/2078

<!-- 
Why is this PR important? 
What does this PR do?
-->
