### PR TITLE
fix(evm): query of NIBI should use bank state, not the StateDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ payment required based on the effective fee from the tx data. Improve
 documentation.
 - [#2125](https://github.com/NibiruChain/nibiru/pull/2125) - feat(evm-precompile):Emit EVM events created to reflect the ABCI events that occur outside the EVM to make sure that block explorers and indexers can find indexed ABCI event information. 
 - [#2129](https://github.com/NibiruChain/nibiru/pull/2129) - fix(evm): issue with infinite recursion in erc20 funtoken contracts
+- [#2134](https://github.com/NibiruChain/nibiru/pull/2134) - fix(evm): query of NIBI should use bank state, not the StateDB
 
 #### Nibiru EVM | Before Audit 2 - 2024-12-06
 

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -65,12 +65,13 @@ func (k Keeper) EthAccount(
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	acct := k.GetAccountOrEmpty(ctx, addrEth)
+	balNative := k.Bank.GetBalance(ctx, addrBech32, evm.EVMBankDenom).Amount.BigInt()
 
 	return &evm.QueryEthAccountResponse{
 		EthAddress:    addrEth.Hex(),
 		Bech32Address: addrBech32.String(),
-		Balance:       acct.BalanceNative.String(),
-		BalanceWei:    evm.NativeToWei(acct.BalanceNative).String(),
+		Balance:       balNative.String(),
+		BalanceWei:    evm.NativeToWei(balNative).String(),
 		CodeHash:      gethcommon.BytesToHash(acct.CodeHash).Hex(),
 		Nonce:         acct.Nonce,
 	}, nil


### PR DESCRIPTION
# Purpose / Abstract

- Closes https://github.com/NibiruChain/nibiru/issues/2133


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue with NIBI query to use the correct bank state instead of StateDB
	- Improved balance retrieval for Ethereum accounts by fetching balance directly from the bank

- **Documentation**
	- Updated CHANGELOG.md with the latest changes and issue reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->