### PR TITLE
fix(bank): fix gas invariant wrapper to actually charge gas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,15 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2119](https://github.com/NibiruChain/nibiru/pull/2119) - fix(evm): Guarantee
 that gas consumed during any send operation of the "NibiruBankKeeper" depends
 only on the "bankkeeper.BaseKeeper"'s gas consumption.
-- [#2120](https://github.com/NibiruChain/nibiru/pull/2120) - fix: Use canonical hexadecimal strings for Eip155 address encoding 
+- [#2120](https://github.com/NibiruChain/nibiru/pull/2120) - fix: Use canonical hexadecimal strings for Eip155 address encoding
 - [#2122](https://github.com/NibiruChain/nibiru/pull/2122) - test(evm): more bank extension tests and EVM ABCI integration tests to prevent regressions
 - [#2124](https://github.com/NibiruChain/nibiru/pull/2124) - refactor(evm):
 Remove unnecessary argument in the `VerifyFee` function, which returns the token
 payment required based on the effective fee from the tx data. Improve
 documentation.
-- [#2125](https://github.com/NibiruChain/nibiru/pull/2125) - feat(evm-precompile):Emit EVM events created to reflect the ABCI events that occur outside the EVM to make sure that block explorers and indexers can find indexed ABCI event information. 
+- [#2125](https://github.com/NibiruChain/nibiru/pull/2125) - feat(evm-precompile):Emit EVM events created to reflect the ABCI events that occur outside the EVM to make sure that block explorers and indexers can find indexed ABCI event information.
 - [#2129](https://github.com/NibiruChain/nibiru/pull/2129) - fix(evm): issue with infinite recursion in erc20 funtoken contracts
 - [#2134](https://github.com/NibiruChain/nibiru/pull/2134) - fix(evm): query of NIBI should use bank state, not the StateDB
+- [#2140](https://github.com/NibiruChain/nibiru/pull/2140) - fix(bank): bank keeper extension now charges gas for the bank operations
 
 #### Nibiru EVM | Before Audit 2 - 2024-12-06
 

--- a/app/ante/fixed_gas_test.go
+++ b/app/ante/fixed_gas_test.go
@@ -197,7 +197,7 @@ func (suite *AnteTestSuite) TestOraclePostPriceTransactionsHaveFixedPrice() {
 					Amount:      sdk.NewCoins(sdk.NewInt64Coin(appconst.BondDenom, 200)),
 				},
 			},
-			expectedGas: 38175,
+			expectedGas: 67193,
 			expectedErr: nil,
 		},
 	}

--- a/x/evm/keeper/bank_extension.go
+++ b/x/evm/keeper/bank_extension.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	store "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	auth "github.com/cosmos/cosmos-sdk/x/auth/types"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
@@ -120,16 +119,6 @@ func (bk NibiruBankKeeper) ForceGasInvariant(
 
 	AfterOp(ctx)
 	return nil
-}
-
-var zeroCostGasConfig store.GasConfig = store.GasConfig{
-	HasCost:          0,
-	DeleteCost:       0,
-	ReadCostFlat:     0,
-	ReadCostPerByte:  0,
-	WriteCostFlat:    0,
-	WriteCostPerByte: 0,
-	IterNextCostFlat: 0,
 }
 
 func (bk NibiruBankKeeper) SendCoins(

--- a/x/evm/keeper/bank_extension.go
+++ b/x/evm/keeper/bank_extension.go
@@ -109,9 +109,7 @@ func (bk NibiruBankKeeper) ForceGasInvariant(
 	// we have to branch off with a new gas meter instance to avoid mutating the
 	// "true" gas meter (called GasMeterBefore here).
 	ctx = ctx.
-		WithGasMeter(sdk.NewGasMeter(gasMeterBefore.Limit())).
-		WithKVGasConfig(zeroCostGasConfig).
-		WithTransientKVGasConfig(zeroCostGasConfig)
+		WithGasMeter(sdk.NewGasMeter(gasMeterBefore.GasRemaining()))
 
 	err := BaseOp(ctx)
 	baseOpGasConsumed = ctx.GasMeter().GasConsumed()

--- a/x/evm/keeper/bank_extension.go
+++ b/x/evm/keeper/bank_extension.go
@@ -108,8 +108,9 @@ func (bk NibiruBankKeeper) ForceGasInvariant(
 	// Note that because the ctx gas meter uses private variables to track gas,
 	// we have to branch off with a new gas meter instance to avoid mutating the
 	// "true" gas meter (called GasMeterBefore here).
-	ctx = ctx.
-		WithGasMeter(sdk.NewGasMeter(gasMeterBefore.GasRemaining()))
+	// We use an infinite gas meter because we consume gas in the deferred function
+	// and gasMeterBefore will panic if we consume too much gas.
+	ctx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
 
 	err := BaseOp(ctx)
 	baseOpGasConsumed = ctx.GasMeter().GasConsumed()

--- a/x/evm/keeper/bank_extension_test.go
+++ b/x/evm/keeper/bank_extension_test.go
@@ -61,14 +61,15 @@ func (s *Suite) TestGasConsumedInvariantSend() {
 	for idx, tc := range testCases {
 		s.Run(tc.name, func() {
 			gasConsumed := tc.GasConsumedInvariantScenario.Run(s, to)
+			s.T().Logf("gasConsumed: %d", gasConsumed)
 			if idx == 0 {
 				first = gasConsumed
 				return
 			}
 			// Each elem being equal to "first" implies that each elem is equal
 			s.Equalf(
-				fmt.Sprintf("%d", first),
-				fmt.Sprintf("%d", gasConsumed),
+				first,
+				gasConsumed,
 				"Gas consumed should be equal",
 			)
 		})
@@ -106,7 +107,7 @@ func (scenario GasConsumedInvariantScenario) Run(
 	)
 	gasConsumedAfter := deps.Ctx.GasMeter().GasConsumed()
 
-	s.GreaterOrEqualf(gasConsumedAfter, gasConsumedBefore,
+	s.Greaterf(gasConsumedAfter, gasConsumedBefore,
 		"gas meter consumed should not be negative: gas consumed after = %d, gas consumed before = %d ",
 		gasConsumedAfter, gasConsumedBefore,
 	)

--- a/x/evm/keeper/bank_extension_test.go
+++ b/x/evm/keeper/bank_extension_test.go
@@ -62,6 +62,7 @@ func (s *Suite) TestGasConsumedInvariantSend() {
 		s.Run(tc.name, func() {
 			gasConsumed := tc.GasConsumedInvariantScenario.Run(s, to)
 			s.T().Logf("gasConsumed: %d", gasConsumed)
+			s.Require().NotZerof(gasConsumed, "gasConsumed should not be zero")
 			if idx == 0 {
 				first = gasConsumed
 				return


### PR DESCRIPTION
The bank keeper extension was charging zero gas for its operations.

Related: #2119 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a method to synchronize state database with account balances.
	- Introduced a function to detect Ether balance changes.

- **Bug Fixes**
	- Enhanced gas consumption logic to prevent panics during operations.
	- Adjusted expected gas consumption in specific test cases.

- **Tests**
	- Updated gas consumption test cases with more precise assertions.
	- Added logging for gas consumption values.
	- Improved clarity of assertions related to gas consumption invariants.

- **Documentation**
	- Updated changelog entries for clarity and organization, including new sections for recent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->