### PR TITLE
refactor: simplify account retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,15 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2119](https://github.com/NibiruChain/nibiru/pull/2119) - fix(evm): Guarantee
 that gas consumed during any send operation of the "NibiruBankKeeper" depends
 only on the "bankkeeper.BaseKeeper"'s gas consumption.
-- [#2120](https://github.com/NibiruChain/nibiru/pull/2120) - fix: Use canonical hexadecimal strings for Eip155 address encoding 
+- [#2120](https://github.com/NibiruChain/nibiru/pull/2120) - fix: Use canonical hexadecimal strings for Eip155 address encoding
 - [#2122](https://github.com/NibiruChain/nibiru/pull/2122) - test(evm): more bank extension tests and EVM ABCI integration tests to prevent regressions
 - [#2124](https://github.com/NibiruChain/nibiru/pull/2124) - refactor(evm):
 Remove unnecessary argument in the `VerifyFee` function, which returns the token
 payment required based on the effective fee from the tx data. Improve
 documentation.
-- [#2125](https://github.com/NibiruChain/nibiru/pull/2125) - feat(evm-precompile):Emit EVM events created to reflect the ABCI events that occur outside the EVM to make sure that block explorers and indexers can find indexed ABCI event information. 
+- [#2125](https://github.com/NibiruChain/nibiru/pull/2125) - feat(evm-precompile):Emit EVM events created to reflect the ABCI events that occur outside the EVM to make sure that block explorers and indexers can find indexed ABCI event information.
 - [#2129](https://github.com/NibiruChain/nibiru/pull/2129) - fix(evm): issue with infinite recursion in erc20 funtoken contracts
 - [#2134](https://github.com/NibiruChain/nibiru/pull/2134) - fix(evm): query of NIBI should use bank state, not the StateDB
+- [#2141](https://github.com/NibiruChain/nibiru/pull/2141) - refactor: simplify account retrieval operation in `nibid q evm account`.
 
 #### Nibiru EVM | Before Audit 2 - 2024-12-06
 

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -64,7 +64,10 @@ func (k Keeper) EthAccount(
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	acct := k.GetAccountOrEmpty(ctx, addrEth)
+	acct := k.getAccountWithoutBalance(ctx, addrEth)
+	if acct == nil {
+		return nil, fmt.Errorf("account not found for %s", addrEth.Hex())
+	}
 	balNative := k.Bank.GetBalance(ctx, addrBech32, evm.EVMBankDenom).Amount.BigInt()
 
 	return &evm.QueryEthAccountResponse{
@@ -205,7 +208,7 @@ func (k Keeper) Code(
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	address := gethcommon.HexToAddress(req.Address)
-	acct := k.GetAccountWithoutBalance(ctx, address)
+	acct := k.getAccountWithoutBalance(ctx, address)
 
 	var code []byte
 	if acct != nil && acct.IsContract() {

--- a/x/evm/keeper/grpc_query_test.go
+++ b/x/evm/keeper/grpc_query_test.go
@@ -144,17 +144,10 @@ func (s *Suite) TestQueryEvmAccount() {
 				req = &evm.QueryEthAccountRequest{
 					Address: ethAcc.EthAddr.String(),
 				}
-				wantResp = &evm.QueryEthAccountResponse{
-					Balance:       "0",
-					BalanceWei:    "0",
-					CodeHash:      gethcommon.BytesToHash(evm.EmptyCodeHash).Hex(),
-					Nonce:         0,
-					EthAddress:    ethAcc.EthAddr.String(),
-					Bech32Address: ethAcc.NibiruAddr.String(),
-				}
+				wantResp = nil
 				return req, wantResp
 			},
-			wantErr: "",
+			wantErr: "account not found for",
 		},
 		{
 			name: "happy: nonexistent account (bech32 input)",
@@ -163,17 +156,10 @@ func (s *Suite) TestQueryEvmAccount() {
 				req = &evm.QueryEthAccountRequest{
 					Address: ethAcc.NibiruAddr.String(),
 				}
-				wantResp = &evm.QueryEthAccountResponse{
-					Balance:       "0",
-					BalanceWei:    "0",
-					CodeHash:      gethcommon.BytesToHash(evm.EmptyCodeHash).Hex(),
-					Nonce:         0,
-					EthAddress:    ethAcc.EthAddr.String(),
-					Bech32Address: ethAcc.NibiruAddr.String(),
-				}
+				wantResp = nil
 				return req, wantResp
 			},
-			wantErr: "",
+			wantErr: "account not found for",
 		},
 	}
 

--- a/x/evm/keeper/statedb.go
+++ b/x/evm/keeper/statedb.go
@@ -25,7 +25,7 @@ var _ statedb.Keeper = &Keeper{}
 // Implements the `statedb.Keeper` interface.
 // Returns nil if the account does not exist or has the wrong type.
 func (k *Keeper) GetAccount(ctx sdk.Context, addr gethcommon.Address) *statedb.Account {
-	acct := k.GetAccountWithoutBalance(ctx, addr)
+	acct := k.getAccountWithoutBalance(ctx, addr)
 	if acct == nil {
 		return nil
 	}
@@ -184,11 +184,10 @@ func (k *Keeper) DeleteAccount(ctx sdk.Context, addr gethcommon.Address) error {
 	return nil
 }
 
-// GetAccountWithoutBalance load nonce and codehash without balance,
+// getAccountWithoutBalance load nonce and codehash without balance,
 // more efficient in cases where balance is not needed.
-func (k *Keeper) GetAccountWithoutBalance(ctx sdk.Context, addr gethcommon.Address) *statedb.Account {
-	nibiruAddr := sdk.AccAddress(addr.Bytes())
-	acct := k.accountKeeper.GetAccount(ctx, nibiruAddr)
+func (k *Keeper) getAccountWithoutBalance(ctx sdk.Context, addr gethcommon.Address) *statedb.Account {
+	acct := k.accountKeeper.GetAccount(ctx, eth.EthAddrToNibiruAddr(addr))
 	if acct == nil {
 		return nil
 	}
@@ -202,21 +201,5 @@ func (k *Keeper) GetAccountWithoutBalance(ctx sdk.Context, addr gethcommon.Addre
 	return &statedb.Account{
 		Nonce:    acct.GetSequence(),
 		CodeHash: codeHash,
-	}
-}
-
-// GetAccountOrEmpty returns empty account if not exist, returns error if it's not `EthAccount`
-func (k *Keeper) GetAccountOrEmpty(
-	ctx sdk.Context, addr gethcommon.Address,
-) statedb.Account {
-	acct := k.GetAccount(ctx, addr)
-	if acct != nil {
-		return *acct
-	}
-
-	// empty account
-	return statedb.Account{
-		BalanceNative: new(big.Int),
-		CodeHash:      evm.EmptyCodeHash,
 	}
 }


### PR DESCRIPTION
# Purpose / Abstract

Simplifies the account retrieval operation in `nibid q evm account`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
  - Simplified account retrieval operation for `nibid q evm account` command
  - Updated error handling for nonexistent Ethereum accounts
  - Improved method visibility and address conversion logic in EVM keeper

- **Bug Fixes**
  - Enhanced account not found error messaging
  - Removed redundant account retrieval method

- **Documentation**
  - Updated comments for clarity in account-related methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->