### PR TITLE
fix(precompile): consume gas before returning error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,13 +56,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2129](https://github.com/NibiruChain/nibiru/pull/2129) - fix(evm): issue with infinite recursion in erc20 funtoken contracts
 - [#2130](https://github.com/NibiruChain/nibiru/pull/2130) - fix(evm): proper nonce management in statedb
 - [#2134](https://github.com/NibiruChain/nibiru/pull/2134) - fix(evm): query of NIBI should use bank state, not the StateDB
-- [#2139](https://github.com/NibiruChain/nibiru/pull/2139) - fix(evm): erc20 born funtoken: properly burn bank coins after converting coin back to erc20 
+- [#2139](https://github.com/NibiruChain/nibiru/pull/2139) - fix(evm): erc20 born funtoken: properly burn bank coins after converting coin back to erc20
 - [#2140](https://github.com/NibiruChain/nibiru/pull/2140) - fix(bank): bank keeper extension now charges gas for the bank operations
 - [#2141](https://github.com/NibiruChain/nibiru/pull/2141) - refactor: simplify account retrieval operation in `nibid q evm account`.
 - [#2142](https://github.com/NibiruChain/nibiru/pull/2142) - fix(bank): add additional missing methods to the NibiruBankKeeper
 - [#2144](https://github.com/NibiruChain/nibiru/pull/2144) - feat(token-registry): Implement strongly typed Nibiru Token Registry and generation command
 - [#2145](https://github.com/NibiruChain/nibiru/pull/2145) - chore(token-registry): add xNIBI Astrovault LST to registry
 - [#2147](https://github.com/NibiruChain/nibiru/pull/2147) - fix(simapp): manually add x/vesting Cosmos-SDK module types to the codec in simulation tests since they are expected by default
+- [#2152](https://github.com/NibiruChain/nibiru/pull/2152) - fix(precompile): consume gas for precompile calls regardless of error
 
 #### Nibiru EVM | Before Audit 2 - 2024-12-06
 

--- a/x/evm/precompile/funtoken.go
+++ b/x/evm/precompile/funtoken.go
@@ -84,6 +84,8 @@ func (p precompileFunToken) Run(
 		err = fmt.Errorf("invalid method called with name \"%s\"", method.Name)
 		return
 	}
+	// Gas consumed by a local gas meter
+	contract.UseGas(startResult.CacheCtx.GasMeter().GasConsumed())
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +101,6 @@ func (p precompileFunToken) Run(
 		)
 	}
 
-	// Gas consumed by a local gas meter
-	contract.UseGas(startResult.CacheCtx.GasMeter().GasConsumed())
 	return bz, err
 }
 

--- a/x/evm/precompile/oracle.go
+++ b/x/evm/precompile/oracle.go
@@ -57,11 +57,11 @@ func (p precompileOracle) Run(
 		err = fmt.Errorf("invalid method called with name \"%s\"", method.Name)
 		return
 	}
+	contract.UseGas(startResult.CacheCtx.GasMeter().GasConsumed())
 	if err != nil {
 		return nil, err
 	}
 
-	contract.UseGas(startResult.CacheCtx.GasMeter().GasConsumed())
 	return bz, err
 }
 

--- a/x/evm/precompile/wasm.go
+++ b/x/evm/precompile/wasm.go
@@ -70,6 +70,12 @@ func (p precompileWasm) Run(
 		err = fmt.Errorf("invalid method called with name \"%s\"", startResult.Method.Name)
 		return
 	}
+	// Gas consumed by a local gas meter
+	// The reason it's unnecessary to check for a success value is because
+	// GasConsumed is guaranteed to be less than the contract.Gas because the gas
+	// meter was initialized....
+	contract.UseGas(startResult.CacheCtx.GasMeter().GasConsumed())
+
 	if err != nil {
 		return nil, err
 	}
@@ -85,11 +91,6 @@ func (p precompileWasm) Run(
 		)
 	}
 
-	// Gas consumed by a local gas meter
-	// The reason it's unnecessary to check for a success value is because
-	// GasConsumed is guaranteed to be less than the contract.Gas because the gas
-	// meter was initialized....
-	contract.UseGas(startResult.CacheCtx.GasMeter().GasConsumed())
 	return bz, err
 }
 


### PR DESCRIPTION
# Purpose / Abstract

- Closes https://github.com/code-423n4/2024-11-nibiru-findings/issues/25

<!-- 
Why is this PR important? 
What does this PR do?
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed gas consumption for precompile calls to ensure gas is consumed regardless of errors
  - Corrected ERC20 token burning process after converting coins back to ERC20

- **Documentation**
  - Updated CHANGELOG.md with recent fixes and improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->