### PR TITLE
fix(evm): JSON encoding for the `EIP55Addr` struct was not following the Go conventions and needed to include double quotes around the hexadecimal string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ ChainLink interface. Publish all precompiled contracts and ABIs on npm under
 the `@nibiruchain/solidity` package.
 - [#2151](https://github.com/NibiruChain/nibiru/pull/2151) - feat(evm): randao support for evm
 - [#2152](https://github.com/NibiruChain/nibiru/pull/2152) - fix(precompile): consume gas for precompile calls regardless of error
+- [#2154](https://github.com/NibiruChain/nibiru/pull/2154) - fix(evm):
+JSON encoding for the `EIP55Addr` struct was not following the Go conventions and
+needed to include double quotes around the hexadecimal string.
 
 #### Nibiru EVM | Before Audit 2 - 2024-12-06
 

--- a/eth/eip55.go
+++ b/eth/eip55.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"encoding/json"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -42,7 +43,7 @@ func (h EIP55Addr) Marshal() ([]byte, error) {
 // Implements the gogo proto custom type interface.
 // Ref: https://github.com/cosmos/gogoproto/blob/v1.5.0/custom_types.md
 func (h EIP55Addr) MarshalJSON() ([]byte, error) {
-	return []byte(h.String()), nil
+	return json.Marshal(h.String())
 }
 
 // MarshalTo serializes a EIP55Addr directly into a pre-allocated byte slice ("data").
@@ -68,7 +69,13 @@ func (h *EIP55Addr) Unmarshal(data []byte) error {
 // UnmarshalJSON implements the gogo proto custom type interface.
 // Ref: https://github.com/cosmos/gogoproto/blob/v1.5.0/custom_types.md
 func (h *EIP55Addr) UnmarshalJSON(bz []byte) error {
-	addr, err := NewEIP55AddrFromStr(string(bz))
+	var addrStr string
+	if err := json.Unmarshal(bz, &addrStr); err != nil {
+		return fmt.Errorf(
+			"EIP55AddrError: UnmarhsalJSON had invalid input %s: %w", bz, err,
+		)
+	}
+	addr, err := NewEIP55AddrFromStr(addrStr)
 	if err != nil {
 		return err
 	}

--- a/eth/eip55_test.go
+++ b/eth/eip55_test.go
@@ -1,7 +1,9 @@
 package eth_test
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
@@ -116,15 +118,15 @@ func (s *EIP55AddrSuite) TestProtobufEncoding() {
 	}{
 		{
 			input:        threeValidAddrs[0],
-			expectedJson: "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed",
+			expectedJson: `"0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"`,
 		},
 		{
 			input:        threeValidAddrs[1],
-			expectedJson: "0xAe967917c465db8578ca9024c205720b1a3651A9",
+			expectedJson: `"0xAe967917c465db8578ca9024c205720b1a3651A9"`,
 		},
 		{
 			input:        threeValidAddrs[2],
-			expectedJson: "0x1111111111111111111112222222222223333323",
+			expectedJson: `"0x1111111111111111111112222222222223333323"`,
 		},
 	} {
 		s.Run(strconv.Itoa(tcIdx), func() {
@@ -140,7 +142,7 @@ func (s *EIP55AddrSuite) TestProtobufEncoding() {
 
 			bz, err := tc.input.Marshal()
 			s.NoError(err)
-			s.Equal(tc.expectedJson, string(bz),
+			s.Equal(strings.Trim(tc.expectedJson, `"`), string(bz),
 				"Marshaling to bytes gives different value than the test case specifies. test case #%d", tcIdx)
 
 			err = eip55Addr.Unmarshal(bz)
@@ -188,10 +190,10 @@ func (s *EIP55AddrSuite) TestStringEncoding() {
 
 	bz, err := addr.MarshalJSON()
 	s.NoError(err)
-	s.Equal(addrHex, string(bz))
+	s.Equal(fmt.Sprintf(`"%s"`, addrHex), string(bz))
 
 	addrb := new(eth.EIP55Addr)
-	err = addrb.UnmarshalJSON([]byte(addrHex))
+	err = addrb.UnmarshalJSON([]byte(fmt.Sprintf(`"%s"`, addrHex)))
 	s.NoError(err)
 	s.EqualValues(addrb, addr)
 }


### PR DESCRIPTION
# Purpose / Abstract

- Closes https://github.com/NibiruChain/nibiru/issues/2128


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved JSON encoding for Ethereum addresses to follow Go conventions
	- Enhanced error handling during JSON marshaling and unmarshaling of addresses

- **Tests**
	- Added new test cases for JSON serialization of Ethereum addresses and message types
	- Verified JSON marshaling and unmarshaling integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->