### PR TITLE
fix(evm): Fix unit inconsistency related to AuthInfo.Fee and txData.Fee 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ the `@nibiruchain/solidity` package.
 JSON encoding for the `EIP55Addr` struct was not following the Go conventions and
 needed to include double quotes around the hexadecimal string.
 - [#2156](https://github.com/NibiruChain/nibiru/pull/2156) - test(evm-e2e): add E2E test using the Nibiru Oracle's ChainLink impl
+- [#2157](https://github.com/NibiruChain/nibiru/pull/2157) - fix(evm): Fix unit inconsistency related to AuthInfo.Fee and txData.Fee using effective fee
 
 #### Nibiru EVM | Before Audit 2 - 2024-12-06
 

--- a/app/evmante/evmante_validate_basic.go
+++ b/app/evmante/evmante_validate_basic.go
@@ -122,10 +122,12 @@ func (vbd EthValidateBasicDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simu
 			)
 		}
 
+		// Compute fees using effective fee to enforce 1unibi minimum gas price
+		effectiveFeeMicronibi := evm.WeiToNative(txData.EffectiveFeeWei(evm.BASE_FEE_WEI))
 		txFee = txFee.Add(
 			sdk.Coin{
 				Denom:  evm.EVMBankDenom,
-				Amount: sdkmath.NewIntFromBigInt(txData.Fee()),
+				Amount: sdkmath.NewIntFromBigInt(effectiveFeeMicronibi),
 			},
 		)
 	}

--- a/x/evm/msg.go
+++ b/x/evm/msg.go
@@ -345,7 +345,7 @@ func (msg *MsgEthereumTx) UnmarshalBinary(b []byte) error {
 	return msg.FromEthereumTx(tx)
 }
 
-// BuildTx builds the canonical cosmos tx from ethereum msg
+// BuildTx builds the Cosmos-SDK [signing.Tx] from ethereum tx ([MsgEthereumTx])
 func (msg *MsgEthereumTx) BuildTx(b client.TxBuilder, evmDenom string) (signing.Tx, error) {
 	builder, ok := b.(authtx.ExtensionOptionsTxBuilder)
 	if !ok {
@@ -361,10 +361,13 @@ func (msg *MsgEthereumTx) BuildTx(b client.TxBuilder, evmDenom string) (signing.
 	if err != nil {
 		return nil, err
 	}
+
+	// Compute fees using effective fee to enforce 1unibi minimum gas price
 	fees := make(sdk.Coins, 0)
-	feeAmt := sdkmath.NewIntFromBigInt(txData.Fee())
-	if feeAmt.Sign() > 0 {
-		fees = append(fees, sdk.NewCoin(evmDenom, feeAmt))
+	effectiveFeeMicronibi := WeiToNative(txData.EffectiveFeeWei(BASE_FEE_WEI))
+	feeAmtMicronibi := sdkmath.NewIntFromBigInt(effectiveFeeMicronibi)
+	if feeAmtMicronibi.Sign() > 0 {
+		fees = append(fees, sdk.NewCoin(evmDenom, feeAmtMicronibi))
 	}
 
 	builder.SetExtensionOptions(option)


### PR DESCRIPTION
# Purpose / Abstract

- Meant to close https://github.com/code-423n4/2024-11-nibiru-findings/issues/44
- Part of https://github.com/NibiruChain/nibiru/issues/2155

fix(evm): Fix unit inconsistency related to AuthInfo.Fee and txData.Fee by using effective fee. Prior to this change, there were two areas where a wei amount was passed as an argument to a "Cosmos" fee where it expects units of unibi (micronibi). 

Since `txData.Fee` does not take into account the fact that the network has a global and absolute minimum gas price of 1 unibi == 10^{12} wei, this is fixed by using `txData.EffectiveFeeWei`, as the latter function guarantees the minimum gas price without adding configuration on the part of end-users. This is similar to what we do to compute `weiPerGas` in `EthereumTx`: 
```go
	weiPerGas := txMsg.EffectiveGasPriceWeiPerGas(evmConfig.BaseFeeWei)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved unit inconsistency in transaction fees for Nibiru EVM
	- Improved fee computation logic to ensure correct effective fee calculation
	- Enforced minimum gas price of 1 unibi in transaction processing

- **Documentation**
	- Updated changelog to reflect recent EVM-related fixes
	- Enhanced code comments for fee calculation methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->