### PR TITLE
fix(evm-precompile): use bank.MsgServer Send in precompile IFunToken.bankMsgSend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ JSON encoding for the `EIP55Addr` struct was not following the Go conventions an
 needed to include double quotes around the hexadecimal string.
 - [#2156](https://github.com/NibiruChain/nibiru/pull/2156) - test(evm-e2e): add E2E test using the Nibiru Oracle's ChainLink impl
 - [#2157](https://github.com/NibiruChain/nibiru/pull/2157) - fix(evm): Fix unit inconsistency related to AuthInfo.Fee and txData.Fee using effective fee
+- [#2160](https://github.com/NibiruChain/nibiru/pull/2160) - fix(evm-precompile): use bank.MsgServer Send in precompile IFunToken.bankMsgSend
 
 #### Nibiru EVM | Before Audit 2 - 2024-12-06
 

--- a/x/evm/precompile/funtoken.go
+++ b/x/evm/precompile/funtoken.go
@@ -6,6 +6,8 @@ import (
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 	gethabi "github.com/ethereum/go-ethereum/accounts/abi"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -701,9 +703,6 @@ func (p precompileFunToken) bankMsgSend(
 	if err != nil {
 		return nil, ErrInvalidArgs(err)
 	}
-	if amount.Sign() != 1 {
-		return nil, fmt.Errorf("msgSend amount must be positive")
-	}
 
 	// parse toStr (bech32 or hex)
 	toEthAddr, e := parseToAddr(toStr)
@@ -715,8 +714,16 @@ func (p precompileFunToken) bankMsgSend(
 
 	// do the bank send
 	coin := sdk.NewCoins(sdk.NewCoin(denom, math.NewIntFromBigInt(amount)))
-	if err := p.evmKeeper.Bank.SendCoins(
-		ctx, fromBech32, toBech32, coin,
+	bankMsg := &bank.MsgSend{
+		FromAddress: fromBech32.String(),
+		ToAddress:   toBech32.String(),
+		Amount:      coin,
+	}
+	if err := bankMsg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+	if _, err := bankkeeper.NewMsgServerImpl(p.evmKeeper.Bank).Send(
+		sdk.WrapSDKContext(ctx), bankMsg,
 	); err != nil {
 		return nil, fmt.Errorf("bankMsgSend: %w", err)
 	}

--- a/x/evm/precompile/funtoken.go
+++ b/x/evm/precompile/funtoken.go
@@ -127,6 +127,10 @@ type precompileFunToken struct {
 //	/// @param to the receiving Nibiru base account address as a string
 //	function sendToBank(address erc20, uint256 amount, string memory to) external;
 //	```
+//
+// Because [sendToBank] uses "SendCoinsFromModuleToAccount" to send Bank Coins,
+// this method correctly avoids sending funds to addresses blocked by the Bank
+// module.
 func (p precompileFunToken) sendToBank(
 	startResult OnRunStartResult,
 	caller gethcommon.Address,


### PR DESCRIPTION
# Purpose / Abstract

- Fixes https://github.com/NibiruChain/nibiru/issues/2158

The 3 methods where the above ticket might potentially play a role are `sendToBank`, `sendToEvm` and `bankMsgSend`. 

- `sendToBank`  does not need any changes because it uses "SendCoinsFromModuleToAccount" to send Bank Coins, and this method correctly avoids sending funds to addresses blocked by the Bank module.
- Similarly, `sendToEvm` does not need changes because the only bank.MsgSend operation involved is when the signer transfers funds to the EVM module 
- `bankMsgSend` does include a change because `BaseSendKeeper.Send` does not have the blocked address check, so I've switched that to use `bank.MsgServer.Send`, as it's safer and includes the blocking behavior.