### PR TITLE
chore: add checktx for AnteDecVerifyEthAcc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ needed to include double quotes around the hexadecimal string.
 - [#2168](https://github.com/NibiruChain/nibiru/pull/2168) - chore(evm-solidity): Move unrelated docs, gen-embeds, and add Solidity docs
 - [#2165](https://github.com/NibiruChain/nibiru/pull/2165) - fix(evm): use Singleton StateDB pattern for EVM txs
 - [#2169](https://github.com/NibiruChain/nibiru/pull/2169) - fix(evm): Better handling erc20 metadata
+- [#2171](https://github.com/NibiruChain/nibiru/pull/2171) - chore: add checktx for AnteDecVerifyEthAcc
 #### Nibiru EVM | Before Audit 2 - 2024-12-06
 
 The codebase went through a third-party [Code4rena

--- a/app/evmante/evmante_verify_eth_acc.go
+++ b/app/evmante/evmante_verify_eth_acc.go
@@ -40,6 +40,10 @@ func (anteDec AnteDecVerifyEthAcc) AnteHandle(
 	simulate bool,
 	next sdk.AnteHandler,
 ) (newCtx sdk.Context, err error) {
+	if !ctx.IsCheckTx() {
+		return next(ctx, tx, simulate)
+	}
+	
 	for i, msg := range tx.GetMsgs() {
 		msgEthTx, ok := msg.(*evm.MsgEthereumTx)
 		if !ok {

--- a/app/evmante/evmante_verify_eth_acc.go
+++ b/app/evmante/evmante_verify_eth_acc.go
@@ -43,7 +43,7 @@ func (anteDec AnteDecVerifyEthAcc) AnteHandle(
 	if !ctx.IsCheckTx() {
 		return next(ctx, tx, simulate)
 	}
-	
+
 	for i, msg := range tx.GetMsgs() {
 		msgEthTx, ok := msg.(*evm.MsgEthereumTx)
 		if !ok {


### PR DESCRIPTION
# Purpose / Abstract

Based on [QA-11 Missing CheckTx optimization in account verification leads to redundant processing](https://github.com/code-423n4/2024-11-nibiru-findings/blob/main/data/Bauchibred-Q.md#qa-11-missing-checktx-optimization-in-account-verification-leads-to-redundant-processing)

<!-- 
Why is this PR important? 
What does this PR do?
-->
