### PR TITLE
fix(evm)!: correct EIP55 addr encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,8 @@ needed to include double quotes around the hexadecimal string.
 - [#2180](https://github.com/NibiruChain/nibiru/pull/2180) - fix(evm): apply gas consumption across the entire EVM codebase at `CallContractWithInput`
 - [#2183](https://github.com/NibiruChain/nibiru/pull/2183) - fix(evm): bank keeper extension gas meter type
 - [#2184](https://github.com/NibiruChain/nibiru/pull/2184) - test(evm): e2e tests configuration enhancements
-- 
+- [#2187](https://github.com/NibiruChain/nibiru/pull/2187) - fix(evm): fix eip55 address encoding
+
 #### Nibiru EVM | Before Audit 2 - 2024-12-06
 
 The codebase went through a third-party [Code4rena

--- a/eth/eip55.go
+++ b/eth/eip55.go
@@ -71,9 +71,7 @@ func (h *EIP55Addr) Unmarshal(data []byte) error {
 func (h *EIP55Addr) UnmarshalJSON(bz []byte) error {
 	var addrStr string
 	if err := json.Unmarshal(bz, &addrStr); err != nil {
-		return fmt.Errorf(
-			"EIP55AddrError: UnmarhsalJSON had invalid input %s: %w", bz, err,
-		)
+		addrStr = string(bz)
 	}
 	addr, err := NewEIP55AddrFromStr(addrStr)
 	if err != nil {

--- a/eth/eip55.go
+++ b/eth/eip55.go
@@ -36,7 +36,7 @@ func NewEIP55AddrFromStr(input string) (EIP55Addr, error) {
 // Marshal implements the gogo proto custom type interface.
 // Ref: https://github.com/cosmos/gogoproto/blob/v1.5.0/custom_types.md
 func (h EIP55Addr) Marshal() ([]byte, error) {
-	return []byte(h.Address.Hex()), nil
+	return h.Bytes(), nil
 }
 
 // MarshalJSON returns the [EIP55Addr] as JSON bytes.
@@ -51,18 +51,15 @@ func (h EIP55Addr) MarshalJSON() ([]byte, error) {
 // Implements the gogo proto custom type interface.
 // Ref: https://github.com/cosmos/gogoproto/blob/v1.5.0/custom_types.md
 func (h *EIP55Addr) MarshalTo(data []byte) (n int, err error) {
-	copy(data, []byte(h.Address.Hex()))
+	copy(data, h.Bytes())
 	return h.Size(), nil
 }
 
 // Unmarshal implements the gogo proto custom type interface.
 // Ref: https://github.com/cosmos/gogoproto/blob/v1.5.0/custom_types.md
 func (h *EIP55Addr) Unmarshal(data []byte) error {
-	addr, err := NewEIP55AddrFromStr(string(data))
-	if err != nil {
-		return err
-	}
-	*h = addr
+	addr := gethcommon.BytesToAddress(data)
+	*h = EIP55Addr{Address: addr}
 	return nil
 }
 
@@ -71,7 +68,7 @@ func (h *EIP55Addr) Unmarshal(data []byte) error {
 func (h *EIP55Addr) UnmarshalJSON(bz []byte) error {
 	var addrStr string
 	if err := json.Unmarshal(bz, &addrStr); err != nil {
-		addrStr = string(bz)
+		return err
 	}
 	addr, err := NewEIP55AddrFromStr(addrStr)
 	if err != nil {
@@ -84,5 +81,5 @@ func (h *EIP55Addr) UnmarshalJSON(bz []byte) error {
 // Size implements the gogo proto custom type interface.
 // Ref: https://github.com/cosmos/gogoproto/blob/v1.5.0/custom_types.md
 func (h EIP55Addr) Size() int {
-	return len([]byte(h.Address.Hex()))
+	return len(h.Bytes())
 }


### PR DESCRIPTION
# Purpose / Abstract

- Closes #2185 

At some point between RC14 and RC19, EIP55 address encoding changed and broke state reads. This PR fixes the proto and JSON marshaling functions.

I tested the PR by first spinning up a localnet with RC14, creating and converting some funtokens, then hot swapping to the binary on this branch. Funtoken conversions continued to succeed, whereas with RC19 they would've failed. 

Note: it may break downstream ts-sdk clients, which will unfortunately have to be fixed in TypeScript. Looking at https://github.com/cosmos/gogoproto/blob/v1.5.0/custom_types.md, we follow Alternative 2) which "makes it harder to generate protobuf code in other languages". We are simply experiencing the downstream effects of decisions we made for our protobufs earlier on. 

Related PRs:
- #2120
- #2154 

<!-- 
Why is this PR important? 
What does this PR do?
-->
