### PR TITLE
fix(evm): proper eth tx logs emission for funtoken operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2209](https://github.com/NibiruChain/nibiru/pull/2209) - refator(ci):
 Simplify GitHub actions based on conditional paths, removing the need for files like ".github/workflows/skip-unit-tests.yml".
 - [#2211](https://github.com/NibiruChain/nibiru/pull/2211) - ci(chaosnet): avoid building on cache injected directories
+- [#2212](https://github.com/NibiruChain/nibiru/pull/2212) - fix(evm): proper eth tx logs emission for funtoken operations
 
 ## [v2.0.0-p1](https://github.com/NibiruChain/nibiru/releases/tag/v2.0.0-p1) - 2025-02-10
 

--- a/x/evm/evmtest/erc20.go
+++ b/x/evm/evmtest/erc20.go
@@ -120,12 +120,6 @@ func CreateFunTokenForBankCoin(
 	return funtoken
 }
 
-// BigPow multiplies "amount" by 10 to the "pow10Exp".
-func BigPow(amount *big.Int, pow10Exp uint8) (powAmount *big.Int) {
-	pow10 := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(pow10Exp)), nil)
-	return new(big.Int).Mul(amount, pow10)
-}
-
 type FunTokenBalanceAssert struct {
 	FunToken     evm.FunToken
 	Account      gethcommon.Address

--- a/x/evm/keeper/call_contract.go
+++ b/x/evm/keeper/call_contract.go
@@ -82,15 +82,5 @@ func (k Keeper) CallContractWithInput(
 		err = fmt.Errorf("VMError: %s", evmResp.VmError)
 		return
 	}
-
-	// Success, update block gas used and bloom filter
-	if commit {
-		k.updateBlockBloom(ctx, evmResp, uint64(txConfig.LogIndex))
-
-		err = ctx.EventManager().EmitTypedEvent(&evm.EventTxLog{Logs: evmResp.Logs})
-		if err != nil {
-			return nil, errors.Wrap(err, "error emitting tx logs")
-		}
-	}
 	return evmResp, nil
 }

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -565,6 +565,12 @@ func (k Keeper) convertCoinToEvmBornCoin(
 		BankCoin:             coin,
 	})
 
+	// Emit tx logs of Mint event
+	err = ctx.EventManager().EmitTypedEvent(&evm.EventTxLog{Logs: evmResp.Logs})
+	if err == nil {
+		k.updateBlockBloom(ctx, evmResp, uint64(k.EvmState.BlockTxIndex.GetOr(ctx, 0)))
+	}
+
 	return &evm.MsgConvertCoinToEvmResponse{}, nil
 }
 
@@ -634,7 +640,7 @@ func (k Keeper) convertCoinToEvmBornERC20(
 		true,
 	)
 	evmObj := k.NewEVM(ctx, evmMsg, k.GetEVMConfig(ctx), nil /*tracer*/, stateDB)
-	_, _, err = k.ERC20().Transfer(
+	_, evmResp, err := k.ERC20().Transfer(
 		erc20Addr,
 		evm.EVM_MODULE_ADDRESS,
 		recipient,
@@ -659,6 +665,12 @@ func (k Keeper) convertCoinToEvmBornERC20(
 		ToEthAddr:            recipient.String(),
 		BankCoin:             coin,
 	})
+
+	// Emit tx logs of Transfer event
+	err = ctx.EventManager().EmitTypedEvent(&evm.EventTxLog{Logs: evmResp.Logs})
+	if err == nil {
+		k.updateBlockBloom(ctx, evmResp, uint64(k.EvmState.BlockTxIndex.GetOr(ctx, 0)))
+	}
 
 	return &evm.MsgConvertCoinToEvmResponse{}, nil
 }


### PR DESCRIPTION
## Fixes:

- funtoken precompile `sendToBank` call duplicated logs due to outdated code
- ConvertCoinToEvm for erc20 born coins did not emit Transfer tx log
- CreateFunToken from coin did not emit log of contract creation