### PR TITLE
fix: update 404 link README.md

### DIFF
--- a/evm-forge/README.md
+++ b/evm-forge/README.md
@@ -181,7 +181,7 @@ For this script to work, you need to have a `MNEMONIC` environment variable set 
 [BIP39 mnemonic](https://iancoleman.io/bip39/).
 
 For instructions on how to deploy to a testnet or mainnet, check out the
-[Solidity Scripting](https://book.getfoundry.sh/tutorials/solidity-scripting.html) tutorial.
+[Solidity Scripting](https://book.getfoundry.sh/guides/scripting-with-solidity) tutorial.
 
 ### Format
 


### PR DESCRIPTION
Hi! I fixed a broken link to the Solidity Scripting tutorial. The updated link now points to the correct guide.
