### PR TITLE
fix(evm): disable unprotected tx check in EVM ante handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Simplify GitHub actions based on conditional paths, removing the need for files 
 - [#2214](https://github.com/NibiruChain/nibiru/pull/2214) - chore(wasm): bump wasmvm to `v1.5.8`
 - [#2068](https://github.com/NibiruChain/nibiru/pull/2068) - feat: enable wasm light clients on IBC (08-wasm)
 - [#2217](https://github.com/NibiruChain/nibiru/pull/2217) - fix: app-db-backend not recognized on prune command
+- [#2219](https://github.com/NibiruChain/nibiru/pull/2219) - fix(evm): disable unprotected tx check in EVM ante handler
 
 ## [v2.0.0-p1](https://github.com/NibiruChain/nibiru/releases/tag/v2.0.0-p1) - 2025-02-10
 

--- a/app/evmante/evmante_sigverify.go
+++ b/app/evmante/evmante_sigverify.go
@@ -48,13 +48,13 @@ func (esvd EthSigVerificationDecorator) AnteHandle(
 		}
 
 		ethTx := msgEthTx.AsTransaction()
-		if !ethTx.Protected() {
-			return ctx, errors.Wrapf(
-				sdkerrors.ErrNotSupported,
-				"rejected unprotected Ethereum transaction. "+
-					"Please EIP155 sign your transaction to protect it against replay-attacks",
-			)
-		}
+		// if !ethTx.Protected() {
+		// 	return ctx, errors.Wrapf(
+		// 		sdkerrors.ErrNotSupported,
+		// 		"rejected unprotected Ethereum transaction. "+
+		// 			"Please EIP155 sign your transaction to protect it against replay-attacks",
+		// 	)
+		// }
 
 		sender, err := signer.Sender(ethTx)
 		if err != nil {

--- a/app/evmante/evmante_sigverify_test.go
+++ b/app/evmante/evmante_sigverify_test.go
@@ -26,7 +26,7 @@ func (s *TestSuite) TestEthSigVerificationDecorator() {
 				tx := evmtest.HappyCreateContractTx(deps)
 				return tx
 			},
-			wantErr: "rejected unprotected Ethereum transaction",
+			wantErr: "couldn't retrieve sender address from the ethereum transaction: invalid transaction v, r, s values: tx intended signer does not match the given signer",
 		},
 		{
 			name: "sad: non ethereum tx",


### PR DESCRIPTION
# Purpose / Abstract

A lot of integration partners have been trying to deploy multicall contracts which fail due to the tx not containing the EIP155 chain id in the signature.

We rely on the backend JSON-RPC config for nodes to disable allowing non-replay protected txs.

<!-- 
Why is this PR important? 
What does this PR do?
-->
