### PR TITLE
fix(evm): suppressing error on missing block bloom event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - [#2222](https://github.com/NibiruChain/nibiru/pull/2222) - fix(evm): evm indexer proper stopping of the indexer service
+- [#2224](https://github.com/NibiruChain/nibiru/pull/2224) - fix(evm): suppressing error on missing block bloom event
 
 ## [v2.1.0](https://github.com/NibiruChain/nibiru/releases/tag/v2.1.0) - 2025-02-25
 

--- a/eth/rpc/backend/blocks.go
+++ b/eth/rpc/backend/blocks.go
@@ -339,7 +339,9 @@ func (b *Backend) BlockBloom(blockRes *tmrpctypes.ResultBlockResults) (gethcore.
 		}
 		return gethcore.BytesToBloom(hexutils.HexToBytes(blockBloomEvent.Bloom)), nil
 	}
-	return gethcore.Bloom{}, errors.New(msgType + " not found in end block results")
+
+	// Suppressing error as it is expected to be missing for pruned node or for blocks before evm
+	return gethcore.Bloom{}, nil
 }
 
 // RPCBlockFromTendermintBlock returns a JSON-RPC compatible Ethereum block from a


### PR DESCRIPTION
Block bloom is used in logs filtering. On mainnet it's missing for pre-evm blocks and causing error:
```
{
  code: -32000,
  message: 'eth.evm.v1.EventBlockBloom not found in end block results'
}
```

Returning empty block bloom for such blocks will produce empty tx logs which is an expected result.