### PR TITLE
chore: fix typo in the code

### DIFF
--- a/evm-core-ts/src/ethers/index.ts
+++ b/evm-core-ts/src/ethers/index.ts
@@ -47,7 +47,7 @@ export const funtokenPrecompile = (runner: ContractRunner): IFunToken =>
 
 /**
  * Returns a typed contract instance for one of the NibiruOracleChainLinkLike.sol
- * contracts. These implement ChainLink's inteface, AggregatorV3Interface.sol, but source
+ * contracts. These implement ChainLink's interface, AggregatorV3Interface.sol, but source
  * data from the Nibiru Oracle mechanism, which publishes data much faster than
  * ChainLink.
  * */


### PR DESCRIPTION
# Purpose / Abstract

I’ve corrected a typo where the word "inteface" was used instead of "interface".