### PR TITLE
feat(funtoken): accept either a Nibiru address or EVM address in sendToBank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2222](https://github.com/NibiruChain/nibiru/pull/2222) - fix(evm): evm indexer proper stopping of the indexer service
 - [#2224](https://github.com/NibiruChain/nibiru/pull/2224) - fix(evm): suppressing error on missing block bloom event
 - [#2238](https://github.com/NibiruChain/nibiru/pull/2238) - feat(evm-embeds): Add WNIBI.sol implementatino to contracts and related TypeScript and Solidity package updates for npm.
+- [#2239](https://github.com/NibiruChain/nibiru/pull/2239) - feat(funtoken): update `FunToken.sendToBank` to accept EVM and nibi addresses.
 
 ### Dependencies
+
 - Bump `axios` from 1.7.4 to 1.8.2 ([#2230](https://github.com/NibiruChain/nibiru/pull/2230))
 
 ## [v2.1.0](https://github.com/NibiruChain/nibiru/releases/tag/v2.1.0) - 2025-02-25

--- a/x/evm/precompile/funtoken.go
+++ b/x/evm/precompile/funtoken.go
@@ -161,10 +161,10 @@ func (p precompileFunToken) sendToBank(
 		return nil, fmt.Errorf("transfer amount must be positive")
 	}
 
-	// The "to" argument must be a valid Nibiru address
-	toAddr, err := sdk.AccAddressFromBech32(to)
+	// The "to" argument must be a valid nibi or EVM address
+	toAddr, err := parseToAddr(to)
 	if err != nil {
-		return nil, fmt.Errorf("\"to\" is not a valid address (%s): %w", to, err)
+		return nil, fmt.Errorf("recipient address invalid (%s): %w", to, err)
 	}
 
 	// Caller transfers ERC20 to the EVM module account
@@ -213,7 +213,7 @@ func (p precompileFunToken) sendToBank(
 	err = p.evmKeeper.Bank.SendCoinsFromModuleToAccount(
 		ctx,
 		evm.ModuleName,
-		toAddr,
+		eth.EthAddrToNibiruAddr(toAddr),
 		sdk.NewCoins(coinToSend),
 	)
 	if err != nil {


### PR DESCRIPTION
# Purpose / Abstract

In `sendToEvm`, the `to` parameter accepts either an EVM address or a nibi address. In `sendToBank`, however, it only accepted a nibi address. To maintain parity and make it easier for developers calling `sendToBank` from an EVM contract, this PR updates the `sendToBank`'s `to` parameter to accept either an EVM or nibi address.

Long story short, it's a pain in the ass to convert from an EVM address to a bech32 address in Solidity (e.g. if you have a `msg.sender` and want to figure out the `nibi` representation). 

<!-- 
Why is this PR important? 
What does this PR do?
-->
