### PR TITLE
fix(evm): evm-tx-index cli fix to exclude the latest block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2224](https://github.com/NibiruChain/nibiru/pull/2224) - fix(evm): suppressing error on missing block bloom event
 - [#2238](https://github.com/NibiruChain/nibiru/pull/2238) - feat(evm-embeds): Add WNIBI.sol implementatino to contracts and related TypeScript and Solidity package updates for npm.
 - [#2239](https://github.com/NibiruChain/nibiru/pull/2239) - feat(funtoken): update `FunToken.sendToBank` to accept EVM and nibi addresses.
+- [#2241](https://github.com/NibiruChain/nibiru/pull/2241) - fix(evm): evm-tx-index cli fix to exclude most latest block
 
 ### Dependencies
 

--- a/app/server/evm_tx_indexer_cli.go
+++ b/app/server/evm_tx_indexer_cli.go
@@ -54,7 +54,7 @@ nibid evm-tx-index last-indexed latest
 			}
 			blockStore := tmstore.NewBlockStore(tmdb)
 			minAvailableHeight := blockStore.Base()
-			maxAvailableHeight := blockStore.Height()
+			maxAvailableHeight := blockStore.Height() - 1 // exclude last block as block info could be uncommitted
 			fmt.Printf("Block range available on the node: %d - %d\n", minAvailableHeight, maxAvailableHeight)
 
 			var fromBlock int64


### PR DESCRIPTION
Fixes the issue of evm tx indexing CLI before node start:

```
nibid evm-tx-index last-indexed latest
```

Seems like the latest block info could be unavalable after stopping the node which could cause the issue like this:

```
Error: could not find results for height #755577
```