### PR TITLE
fix(evm): update ERC20 deploy contract gas limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#2259](https://github.com/NibiruChain/nibiru/pull/2259) - feat: add depinject wiring for all sdk modules
 - [#2261](https://github.com/NibiruChain/nibiru/pull/2261) - feat: gen pulsar api and app wiring for sudo
 - [#2262](https://github.com/NibiruChain/nibiru/pull/2262) - feat: app wiring for oracle
+- [#2268](https://github.com/NibiruChain/nibiru/pull/2268) - fix(evm): gas limit for erc20 deploy
 
 ## [v2.2.0](https://github.com/NibiruChain/nibiru/releases/tag/v2.2.0) - 2025-03-27
 

--- a/x/evm/keeper/erc20.go
+++ b/x/evm/keeper/erc20.go
@@ -19,8 +19,7 @@ import (
 
 const (
 	// Erc20GasLimitDeploy only used internally when deploying ERC20Minter.
-	// Deployment requires ~1_600_000 gas
-	Erc20GasLimitDeploy uint64 = 2_000_000
+	Erc20GasLimitDeploy uint64 = 2_500_000
 	// Erc20GasLimitQuery used only for querying name, symbol and decimals
 	// Cannot be heavy. Only if the contract is malicious.
 	Erc20GasLimitQuery uint64 = 100_000


### PR DESCRIPTION
# Purpose / Abstract

- Changing the contract to ERC20MinterWithMetadata in #2251 increased the gas cost to deploy a contract beyond 2M gas units. Increasing the gas limit to 2.5M seems to work.

<!-- 
Why is this PR important? 
What does this PR do?
-->
