### PR TITLE
fix(evm): update revert error reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,10 @@ to geth v1.14 with tracing updates and new StateDB methods.
 - [#2292](https://github.com/NibiruChain/nibiru/pull/2292) - fix: use tmp directory for pre-instantiating app
 - [#2293](https://github.com/NibiruChain/nibiru/pull/2293) - ci(release): pack nibid binary with no enclosing directory
 - [#2296](https://github.com/NibiruChain/nibiru/pull/2296) - chore(ci): use shell script for generating changelog in releases
+- [#2297](https://github.com/NibiruChain/nibiru/pull/2297) - fix(evm): fix error handling for revert errors
 
 ### Dependencies
+
 - Bump `golang.org/x/net` from 0.37.0 to 0.39.0. ([#2284](https://github.com/NibiruChain/nibiru/pull/2284))
 - Bump `github.com/golang-jwt/jwt/v4` from 4.5.1 to 4.5.2 ([#2294](https://github.com/NibiruChain/nibiru/pull/2294))
 

--- a/x/evm/errors.go
+++ b/x/evm/errors.go
@@ -2,6 +2,7 @@
 package evm
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	sdkioerrors "cosmossdk.io/errors"
@@ -54,13 +55,16 @@ var (
 // NewRevertError unpacks the revert return bytes and returns a wrapped error
 // with the return reason.
 func NewRevertError(revertReason []byte) error {
-	reason, unpackingError := abi.UnpackRevert(revertReason)
-
-	if unpackingError != nil {
-		return fmt.Errorf("execution reverted, but unable to parse reason \"%v\"", string(revertReason))
+	if len(revertReason) == 0 {
+		return fmt.Errorf("execution reverted with no reason")
 	}
 
-	return fmt.Errorf("execution reverted with reason \"%v\"", reason)
+	reason, err := abi.UnpackRevert(revertReason)
+	if err == nil {
+		return fmt.Errorf("execution reverted with reason \"%s\"", reason)
+	}
+
+	return fmt.Errorf("execution reverted with undecodable reason (raw hex: %v)", hex.EncodeToString(revertReason))
 }
 
 // RevertError is an API error that encompass an EVM revert with JSON error


### PR DESCRIPTION
# Purpose / Abstract

According to [Solidity docs](https://docs.soliditylang.org/en/latest/control-structures.html#revert), contracts can revert with standard `revert(string)` or `revert CustomError()`.

In the former case, we end up with a message `execution reverted with reason "foo"` which is valid. But in the latter case, we try to blindly decode the bytes as UTF-8 which gives us invalid character sequences like `execution reverted, but unable to parse reason \"\t\ufffd\ufffd\ufffd\"`. 

This PR addresses the latter case and gives back the raw hex of the revert reason (which is the 4-byte ABI-encoding of the CustomError signature).

"Using a custom error instance will usually be much cheaper than a string description, because you can use the name of the error to describe it, which is encoded in only four bytes"
