### PR TITLE
fix(.github): glob patterns broken in nibiru-go filter for dorny/paths-filter

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -34,15 +34,16 @@ jobs:
             changelog: 
               - "**/CHANGELOG.md"
             nibiru-go:
-              - "app/**.go"
-              - "cmd/**.go"
-              - "eth/**.go"
-              - "gosdk/**.go"
-              - "x/**.go"
-              - "**.proto"
+              - "app/**/*.go"
+              - "cmd/**/*.go"
+              - "eth/**/*.go"
+              - "gosdk/**/*.go"
+              - "x/**/*.go"
+              - "**/*.proto"
               - "go.mod"
               - "go.sum"
-              - "contrib/docker/*"
+              - "contrib/docker-compose/*"
+
       - uses: dangoslen/changelog-enforcer@v3
         if: steps.check_changelog.outputs.nibiru-go == 'true' || steps.check_changelog.outputs.changelog == 'false'
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,15 +27,15 @@ jobs:
         with:
           filters: |
             nibiru-go:
-              - "app/**.go"
-              - "cmd/**.go"
-              - "eth/**.go"
-              - "gosdk/**.go"
-              - "x/**.go"
-              - "**.proto"
+              - "app/**/*.go"
+              - "cmd/**/*.go"
+              - "eth/**/*.go"
+              - "gosdk/**/*.go"
+              - "x/**/*.go"
+              - "**/*.proto"
               - "go.mod"
               - "go.sum"
-              - "contrib/docker/*"
+              - "contrib/docker-compose/*"
 
       - uses: actions/setup-go@v5
         if: steps.check_nibiru_go.outputs.nibiru-go == 'true'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,15 +27,15 @@ jobs:
         with:
           filters: |
             nibiru-go:
-              - "app/**.go"
-              - "cmd/**.go"
-              - "eth/**.go"
-              - "gosdk/**.go"
-              - "x/**.go"
-              - "**.proto"
+              - "app/**/*.go"
+              - "cmd/**/*.go"
+              - "eth/**/*.go"
+              - "gosdk/**/*.go"
+              - "x/**/*.go"
+              - "**/*.proto"
               - "go.mod"
               - "go.sum"
-              - "contrib/docker/*"
+              - "contrib/docker-compose/*"
 
       - name: Set up Go
         if: steps.check_nibiru_go.outputs.nibiru-go == 'true'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,15 +20,15 @@ jobs:
         with:
           filters: |
             nibiru-go:
-              - "app/**.go"
-              - "cmd/**.go"
-              - "eth/**.go"
-              - "gosdk/**.go"
-              - "x/**.go"
-              - "**.proto"
+              - "app/**/*.go"
+              - "cmd/**/*.go"
+              - "eth/**/*.go"
+              - "gosdk/**/*.go"
+              - "x/**/*.go"
+              - "**/*.proto"
               - "go.mod"
               - "go.sum"
-              - "contrib/docker/*"
+              - "contrib/docker-compose/*"
 
       - name: skip-tests
         if: steps.check_nibiru_go.outputs.nibiru-go == 'false'
@@ -80,15 +80,15 @@ jobs:
         with:
           filters: |
             nibiru-go:
-              - "app/**.go"
-              - "cmd/**.go"
-              - "eth/**.go"
-              - "gosdk/**.go"
-              - "x/**.go"
-              - "**.proto"
+              - "app/**/*.go"
+              - "cmd/**/*.go"
+              - "eth/**/*.go"
+              - "gosdk/**/*.go"
+              - "x/**/*.go"
+              - "**/*.proto"
               - "go.mod"
               - "go.sum"
-              - "contrib/docker/*"
+              - "contrib/docker-compose/*"
 
       - name: "Set up Go"
         if: steps.check_nibiru_go.outputs.nibiru-go == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ to geth v1.14 with tracing updates and new StateDB methods.
 - [#2296](https://github.com/NibiruChain/nibiru/pull/2296) - chore(ci): use shell script for generating changelog in releases
 - [#2297](https://github.com/NibiruChain/nibiru/pull/2297) - fix(evm): fix error handling for revert errors
 - [#2298](https://github.com/NibiruChain/nibiru/pull/2298) - fix(eth-rpc): clean up error propagation and descriptions in eth namespace
+- [#2301](https://github.com/NibiruChain/nibiru/pull/2301) - fix(.github): glob patterns broken in nibiru-go filter for dorny/paths-filter
 
 ### Dependencies
 


### PR DESCRIPTION
# Purpose / Abstract

Glob patterns are not working as expected with the `nibiru-go` path filter used in our GitHub action tests.
I noticed this from one of our coverage reports missing on main. This PR fixes
that bug.
