### PR TITLE
test(eth-rpcapi): increase coverage of the rpcapi package using JSON-RPC calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ to geth v1.14 with tracing updates and new StateDB methods.
 - [#2298](https://github.com/NibiruChain/nibiru/pull/2298) - fix(eth-rpc): clean up error propagation and descriptions in eth namespace
 - [#2300](https://github.com/NibiruChain/nibiru/pull/2300) - refactor(eth-rpc): combine rpc/backend and rpc/rpcapi since they essentially one package
 - [#2301](https://github.com/NibiruChain/nibiru/pull/2301) - fix(.github): glob patterns broken in nibiru-go filter for dorny/paths-filter
+- [#2303](https://github.com/NibiruChain/nibiru/pull/2303) - test(eth/rpc/rpcapi): increase coverage of the rpcapi package using JSON-RPC calls
 
 ### Dependencies
 

--- a/app/appconst/appconst.go
+++ b/app/appconst/appconst.go
@@ -72,20 +72,20 @@ const (
 )
 
 var knownEthChainIDMap = map[string]int64{
-	"cataclysm-1": 6900,
+	"cataclysm-1": ETH_CHAIN_ID_MAINNET,
 
-	"nibiru-testnet-1": 7210,
-	"nibiru-testnet-2": 6911,
-	"nibiru-testnet-3": 6912,
+	"nibiru-testnet-1": ETH_CHAIN_ID_TESTNET_1,
+	"nibiru-testnet-2": ETH_CHAIN_ID_TESTNET_2,
+	"nibiru-testnet-3": ETH_CHAIN_ID_TESTNET_3,
 
-	"nibiru-devnet-1": 6920,
-	"nibiru-devnet-2": 6921,
-	"nibiru-devnet-3": 6922,
+	"nibiru-devnet-1": ETH_CHAIN_ID_DEVNET_1,
+	"nibiru-devnet-2": ETH_CHAIN_ID_DEVNET_2,
+	"nibiru-devnet-3": ETH_CHAIN_ID_DEVNET_3,
 
-	"nibiru-localnet-0": 6930,
-	"nibiru-localnet-1": 6931,
-	"nibiru-localnet-2": 6932,
-	"nibiru-localnet-3": 6933,
+	"nibiru-localnet-0": ETH_CHAIN_ID_LOCALNET_0,
+	"nibiru-localnet-1": ETH_CHAIN_ID_LOCALNET_1,
+	"nibiru-localnet-2": ETH_CHAIN_ID_LOCALNET_2,
+	"nibiru-localnet-3": ETH_CHAIN_ID_LOCALNET_3,
 }
 
 // GetEthChainID: Maps the given chain ID from the block's `sdk.Context` to an

--- a/eth/rpc/rpcapi/api_eth.go
+++ b/eth/rpc/rpcapi/api_eth.go
@@ -314,7 +314,8 @@ func (e *EthAPI) GetProof(address common.Address,
 //
 // Allows developers to read data from the blockchain which includes executing
 // smart contracts. However, no data is published to the blockchain network.
-func (e *EthAPI) Call(args evm.JsonTxArgs,
+func (e *EthAPI) Call(
+	args evm.JsonTxArgs,
 	blockNrOrHash rpc.BlockNumberOrHash,
 	_ *rpc.StateOverride,
 ) (bz hexutil.Bytes, err error) {

--- a/eth/rpc/rpcapi/api_net_test.go
+++ b/eth/rpc/rpcapi/api_net_test.go
@@ -5,9 +5,9 @@ import (
 )
 
 func (s *NodeSuite) TestNetNamespace() {
-	api := s.val.EthRpc_NET
+	api := s.node.EthRpc_NET
 	s.Require().True(api.Listening())
 	s.EqualValues(
-		appconst.GetEthChainID(s.val.ClientCtx.ChainID).String(), api.Version())
+		appconst.GetEthChainID(s.node.ClientCtx.ChainID).String(), api.Version())
 	s.Equal(0, api.PeerCount())
 }

--- a/eth/rpc/rpcapi/blocks_test.go
+++ b/eth/rpc/rpcapi/blocks_test.go
@@ -118,5 +118,8 @@ func AssertBlockContents(s *BackendSuite, blockMap map[string]any) {
 	s.Require().Greater(len(blockMap["transactions"].([]any)), 0)
 	s.Require().NotNil(blockMap["size"])
 	s.Require().NotNil(blockMap["nonce"])
-	s.Require().Equal(int64(blockMap["number"].(hexutil.Uint64)), s.SuccessfulTxTransfer().BlockNumberRpc.Int64())
+	s.T().Logf("blockMap: %s", blockMap)
+	blockNumber, err := hexutil.DecodeBig(blockMap["number"].(string))
+	s.NoError(err)
+	s.Require().Equal(blockNumber.Int64(), s.SuccessfulTxTransfer().BlockNumberRpc.Int64())
 }

--- a/eth/rpc/rpcapi/blocks_test.go
+++ b/eth/rpc/rpcapi/blocks_test.go
@@ -33,7 +33,13 @@ func (s *BackendSuite) TestGetBlockByNumberr() {
 }
 
 func (s *BackendSuite) TestGetBlockByHash() {
-	blockMap, err := s.backend.GetBlockByHash(*s.SuccessfulTxTransfer().BlockHash, true)
+	fullTx := true
+	var blockMap map[string]any
+	err := s.node.EvmRpcClient.Client().Call(
+		&blockMap, "eth_getBlockByHash",
+		*s.SuccessfulTxTransfer().BlockHash,
+		fullTx,
+	)
 	s.Require().NoError(err)
 	AssertBlockContents(s, blockMap)
 }

--- a/go.mod
+++ b/go.mod
@@ -266,7 +266,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/NibiruChain/cosmos-sdk v0.47.11-nibiru.3
 	github.com/cosmos/iavl => github.com/cosmos/iavl v0.20.0
 
-	github.com/ethereum/go-ethereum => github.com/NibiruChain/go-ethereum v1.14.13-nibiru.2
+	github.com/ethereum/go-ethereum => github.com/NibiruChain/go-ethereum v1.14.13-nibiru.3
 
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 

--- a/go.sum
+++ b/go.sum
@@ -674,8 +674,8 @@ github.com/NibiruChain/collections v0.5.0 h1:33pXpVTe1PK/tfdZlAJF1JF7AdzGNARG+iL
 github.com/NibiruChain/collections v0.5.0/go.mod h1:43L6yjuF0BMre/mw4gqn/kUOZz1c2Y3huZ/RQfBFrOQ=
 github.com/NibiruChain/cosmos-sdk v0.47.11-nibiru.3 h1:MI3c8dJjWDYvhGlgKYexu8Gg9vuaYXFG40ulirlYbx0=
 github.com/NibiruChain/cosmos-sdk v0.47.11-nibiru.3/go.mod h1:ADjORYzUQqQv/FxDi0H0K5gW/rAk1CiDR3ZKsExfJV0=
-github.com/NibiruChain/go-ethereum v1.14.13-nibiru.2 h1:ck5YAdn2Fklelh8JfLzU9VwXWXmitkbI0ixyoXcD1U8=
-github.com/NibiruChain/go-ethereum v1.14.13-nibiru.2/go.mod h1:RAC2gVMWJ6FkxSPESfbshrcKpIokgQKsVKmAuqdekDY=
+github.com/NibiruChain/go-ethereum v1.14.13-nibiru.3 h1:vWBieiwll6sjQ4OTagJUXwtjw85Crfk3f7kAPik6BD8=
+github.com/NibiruChain/go-ethereum v1.14.13-nibiru.3/go.mod h1:RAC2gVMWJ6FkxSPESfbshrcKpIokgQKsVKmAuqdekDY=
 github.com/NibiruChain/wasmd v0.44.0-nibiru h1:b+stNdbMFsl0+o4KedXyF83qRnEpB/jCiTGZZgv2h2U=
 github.com/NibiruChain/wasmd v0.44.0-nibiru/go.mod h1:inrbdsixQ0Kdu4mFUg1u7fn3XPOEkzqieGv0H/gR0ck=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=

--- a/gosdk/README.md
+++ b/gosdk/README.md
@@ -10,24 +10,13 @@ transaction types.
 
 ## Dev Notes - Nibiru Go SDK
 
-### Finalizing "v1"
-
-- [ ] Migrate to the [Nibiru repo](https://github.com/NibiruChain/nibiru) and archive this one.
-- [ ] feat: add in transaction broadcasting
-  - [x] initialize keyring obj with mnemonic
-  - [x] initialize keyring obj with priv key
-  - [x] write a test that sends a bank transfer.
-  - [ ] write a test that submits a text gov proposal.
-- [x] docs: for grpc.go
-- [ ] docs: for clients.go
-
 ### Usage Guides & Dev Ex
 
 - [ ] Create a quick start guide: Connecting to Nibiru, querying Nibiru, sending
 transactions on Nibiru
 - [ ] Write usage examples
   - [ ] Creating an account and keyring
-  - [ ] Querying balanaces
+  - [ ] Querying balances
   - [ ] Broadcasting txs to transfer funds
   - [ ] Querying Wasm smart contracts
   - [ ] Broadcasting txs to transfer funds
@@ -47,15 +36,14 @@ transactions on Nibiru
 Q: Should gosdk run as a binary?  
 
 No, or at least, not initially. Since the software required to operate a full
-node has more cumbersome dependencies like RocksDB that involve C-Go and compled
+node has more cumbersome dependencies like RocksDB that involve C-Go and complex
 build steps, we may benefit from splitting "start" command from the bulk of the
-subcommands available on teh Nibiru CLI. This would make it much easier to have a
+subcommands available on the Nibiru CLI. This would make it much easier to have a
 command line tool that builds on Linux, Windows, Mac.
 
 Q: Should there be a way to run queries with JSON-RPC 2 instead of GRPC?
 
-We [implemented this in
-python](https://github.com/NibiruChain/py-sdk/tree/v0.21.12/nibiru/jsonrpc)
+We [implemented this in python](https://github.com/NibiruChain/py-sdk/tree/v0.21.12/nibiru/jsonrpc)
 without too much trouble, and it's not taxing to maintain. If we're going to
 prioritize adding APIs for the CometBFT JSON-RPC methods, it should be in the
 [Nibiru TypeScript SDK](https://github.com/NibiruChain/ts-sdk) first.

--- a/gosdk/gosdk_test.go
+++ b/gosdk/gosdk_test.go
@@ -148,7 +148,7 @@ func (s *TestSuite) TearDownSuite() {
 
 func (s *TestSuite) DoTestGetGrpcConnection_NoNetwork() {
 	grpcConn, err := gosdk.GetGRPCConnection(
-		gosdk.DefaultNetworkInfo.GrpcEndpoint+"notendpoint", true, 2,
+		gosdk.NETWORK_INFO_DEFAULT.GrpcEndpoint+"notendpoint", true, 2,
 	)
 	s.Error(err)
 	s.Nil(grpcConn)

--- a/gosdk/netinfo.go
+++ b/gosdk/netinfo.go
@@ -1,17 +1,47 @@
 package gosdk
 
+import "github.com/NibiruChain/nibiru/v2/app/appconst"
+
 type NetworkInfo struct {
-	GrpcEndpoint      string
-	LcdEndpoint       string
-	TmRpcEndpoint     string
-	WebsocketEndpoint string
-	ChainID           string
+	// Nibiru EVM EIP-155 chain ID as an integer
+	EvmChainID int64 `json:"evmChainID"`
+	// Nibiru EVM EIP-155 chain ID
+	EvmChainIDHex string `json:"evmChainIDHex"`
+	// Nibiru EVM JSON-RPC server endpoint
+	EvmRpc string `json:"evmRpc"`
+	// Nibiru EVM JSON-RPC server endpoint from an archive node (no pruning)
+	EvmRpcArchive string `json:"evmRpcArchive"`
+	EvmWebsocket  string `json:"evmWebsocket"`
+
+	CmtChainID        string `json:"cmtChainID"`
+	GrpcEndpoint      string `json:"grpcEndpoint"`
+	LcdEndpoint       string `json:"lcdEndpoint"`
+	TmRpcEndpoint     string `json:"tmRpcEndpoint"`
+	WebsocketEndpoint string `json:"websocketEndpoint"`
 }
 
-var DefaultNetworkInfo = NetworkInfo{
-	GrpcEndpoint:      "localhost:9090",
-	LcdEndpoint:       "http://localhost:1317",
-	TmRpcEndpoint:     "http://localhost:26657",
-	WebsocketEndpoint: "ws://localhost:26657/websocket",
-	ChainID:           "nibiru-localnet-0",
-}
+var (
+	NETWORK_INFO_DEFAULT = NetworkInfo{
+		EvmChainID:        appconst.ETH_CHAIN_ID_LOCALNET_0,
+		EvmChainIDHex:     "0x1B0A",
+		EvmRpc:            "http://127.0.0.1:8545",
+		EvmRpcArchive:     "",
+		EvmWebsocket:      "http://127.0.0.1:8546",
+		CmtChainID:        "nibiru-localnet-0",
+		GrpcEndpoint:      "localhost:9090",
+		LcdEndpoint:       "http://localhost:1317",
+		TmRpcEndpoint:     "http://localhost:26657",
+		WebsocketEndpoint: "ws://localhost:26657/websocket",
+	}
+	NETWORK_INFO_NIBIRU_MAINNET = NetworkInfo{
+		EvmChainID:        appconst.ETH_CHAIN_ID_MAINNET,
+		EvmChainIDHex:     "0x1AF4",
+		EvmRpc:            "https://evm-rpc.nibiru.fi:443",
+		EvmRpcArchive:     "https://evm-rpc.archive.nibiru.fi:443",
+		EvmWebsocket:      "wss://evm-rpc-ws.nibiru.fi",
+		CmtChainID:        "cataclysm-1",
+		GrpcEndpoint:      "grpc.nibiru.fi:443",
+		TmRpcEndpoint:     "https://rpc.nibiru.fi:443",
+		WebsocketEndpoint: "",
+	}
+)

--- a/x/common/testutil/testnetwork/start_node.go
+++ b/x/common/testutil/testnetwork/start_node.go
@@ -146,9 +146,8 @@ func startNodeAndServers(cfg Config, val *Validator) error {
 			return sdkioerrors.Wrap(err, "failed to start JSON-RPC server")
 		}
 
-		address := fmt.Sprintf("http://%s", val.AppConfig.JSONRPC.Address)
-
-		val.JSONRPCClient, err = ethclient.Dial(address)
+		endpointEvmJsonRpc := fmt.Sprintf("http://%s", val.AppConfig.JSONRPC.Address)
+		val.EvmRpcClient, err = ethclient.Dial(endpointEvmJsonRpc)
 		if err != nil {
 			return fmt.Errorf("failed to dial JSON-RPC at address %s: %w", val.AppConfig.JSONRPC.Address, err)
 		}
@@ -165,7 +164,6 @@ func startNodeAndServers(cfg Config, val *Validator) error {
 
 		val.Logger.Log("Expose typed methods for each namespace")
 		val.EthRPC_ETH = rpcapi.NewImplEthAPI(val.Ctx.Logger, val.EthRpcBackend)
-		val.EthRpc_WEB3 = rpcapi.NewImplWeb3API()
 
 		val.Ctx.Logger = logger // set back to normal setting
 	}

--- a/x/common/testutil/testnetwork/validator_node.go
+++ b/x/common/testutil/testnetwork/validator_node.go
@@ -85,15 +85,14 @@ type Validator struct {
 	// - rpc.Local
 	RPCClient cmtrpcclient.Client
 
-	JSONRPCClient       *ethclient.Client
+	EvmRpcClient        *ethclient.Client
 	EthRpcQueryClient   *ethrpc.QueryClient
 	EthRpcBackend       *rpcapi.Backend
 	EthTxIndexer        eth.EVMTxIndexer
 	EthTxIndexerService *appserver.EVMTxIndexerService
 
-	EthRPC_ETH  *rpcapi.EthAPI
-	EthRpc_WEB3 *rpcapi.APIWeb3
-	EthRpc_NET  *rpcapi.NetAPI
+	EthRPC_ETH *rpcapi.EthAPI
+	EthRpc_NET *rpcapi.NetAPI
 
 	Logger Logger
 
@@ -271,7 +270,7 @@ func (val *Validator) AssertERC20Balance(
 		To:   &contract,
 		Data: input,
 	}
-	recipientBalanceBeforeBytes, err := val.JSONRPCClient.CallContract(context.Background(), msg, nil)
+	recipientBalanceBeforeBytes, err := val.EvmRpcClient.CallContract(context.Background(), msg, nil)
 	s.NoError(err)
 	balance := new(big.Int).SetBytes(recipientBalanceBeforeBytes)
 	s.Equal(expectedBalance.String(), balance.String())
@@ -281,7 +280,7 @@ func (node *Validator) BlockByEthTx(
 	ethTxHash gethcommon.Hash,
 ) (*cmtcore.ResultBlockResults, error) {
 	blankCtx := context.Background()
-	txReceipt, err := node.JSONRPCClient.TransactionReceipt(blankCtx, ethTxHash)
+	txReceipt, err := node.EvmRpcClient.TransactionReceipt(blankCtx, ethTxHash)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Purpose / Abstract

- Partially closes https://github.com/NibiruChain/nibiru/issues/2286
- This commit introduces a broad set of improvements and refactors across
the Nibiru EVM RPC interface

## Summary

- Unified EVM RPC usage by replacing ad hoc `EthAPI` calls with a more
  direct `EvmRpcClient` approach using typed JSON-RPC methods.
- Replaced deprecated or redundant `EthAPI` test calls (e.g.,
  `SendRawTransaction`, `GetPendingTransactions`) with explicit
  `ethclient` or raw RPC usage to improve reliability and alignment with
  production.
- Enhanced EVM test assertions: verified transaction propagation through
  raw receipts and confirmed proper trace results via `debug_trace*`
  methods (block, transaction, call).
- Reduced reliance on stale `EthRpc_WEB3` and clarified test references
  from `val` to `node` for clarity and semantic accuracy.

- Replaced hardcoded EVM chain ID integers with named constants
  (`ETH_CHAIN_ID_MAINNET`, etc.) via `appconst` for easier maintenance
  and semantic clarity.
- Introduced `NETWORK_INFO_DEFAULT` and `NETWORK_INFO_NIBIRU_MAINNET`
  presets to structure Go SDK usage and reduce duplication.

- Bumped `go-ethereum` fork to `v1.14.13-nibiru.3`, aligning internal
  API calls with the latest JSON-RPC format and maintaining parity with
  upstream Geth compatibility layers.
