### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ changelog format](https://keepachangelog.com/en/1.0.0/).
 See https://github.com/dangoslen/changelog-enforcer.
 --> 
 
+- [#2311](https://github.com/NibiruChain/nibiru/pull/2311) - refactor: use Go's built-in min and max functions to simplify logic
 - [#2314](https://github.com/NibiruChain/nibiru/pull/2314) - refactor(upgrades): add public keepers to upgrade handlers + DRY improvements
 
 ## v2.4.0

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -476,11 +476,8 @@ func (k Keeper) TraceTx(
 	}
 
 	// get the context of block beginning
-	contextHeight := req.BlockNumber
-	if contextHeight < 1 {
-		// 0 is a special value in `ContextWithHeight`
-		contextHeight = 1
-	}
+	// 0 is a special value in `ContextWithHeight`
+	contextHeight := max(req.BlockNumber, 1)
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	ctx = ctx.WithBlockHeight(contextHeight)
@@ -575,11 +572,8 @@ func (k Keeper) TraceCall(
 	}
 
 	// get the context of block beginning
-	contextHeight := req.BlockNumber
-	if contextHeight < 1 {
-		// 0 is a special value in `ContextWithHeight`
-		contextHeight = 1
-	}
+	// 0 is a special value in `ContextWithHeight`
+	contextHeight := max(req.BlockNumber, 1)
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	ctx = ctx.WithBlockHeight(contextHeight)
@@ -660,11 +654,8 @@ func (k Keeper) TraceBlock(
 	}
 
 	// get the context of block beginning
-	contextHeight := req.BlockNumber
-	if contextHeight < 1 {
-		// 0 is a special value in `ContextWithHeight`
-		contextHeight = 1
-	}
+	// 0 is a special value in `ContextWithHeight`
+	contextHeight := max(req.BlockNumber, 1)
 
 	ctx := sdk.UnwrapSDKContext(goCtx).
 		WithBlockHeight(contextHeight).


### PR DESCRIPTION
# Purpose / Abstract

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

<!-- 
Why is this PR important? 
What does this PR do?
-->
