### PR TITLE
refactor(upgrades): add public keepers to upgrade handlers + DRY improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+<!-- 
+NOTE: The brackets around the word "Unreleased" are required to pass the [CI test
+that checks if we updated the changelog. This is a convention from the [keep a
+changelog format](https://keepachangelog.com/en/1.0.0/).  
+See https://github.com/dangoslen/changelog-enforcer.
+--> 
+
+- [#2314](https://github.com/NibiruChain/nibiru/pull/2314) - refactor(upgrades): add public keepers to upgrade handlers + DRY improvements
 
 ## v2.4.0
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -73,7 +73,13 @@ func (app *NibiruApp) setupUpgrades() {
 
 func (app *NibiruApp) setUpgradeHandlers() {
 	for _, u := range Upgrades {
-		app.upgradeKeeper.SetUpgradeHandler(u.UpgradeName, u.CreateUpgradeHandler(app.ModuleManager, app.Configurator(), app.ibcKeeper.ClientKeeper))
+		app.upgradeKeeper.SetUpgradeHandler(u.UpgradeName,
+			u.CreateUpgradeHandler(
+				app.ModuleManager,
+				app.Configurator(),
+				&app.PublicKeepers,
+				app.ibcKeeper.ClientKeeper,
+			))
 	}
 }
 

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -1,16 +1,39 @@
 package upgrades
 
 import (
+	"github.com/NibiruChain/nibiru/v2/app/keepers"
+
 	store "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 )
 
 type Upgrade struct {
 	UpgradeName string
 
-	CreateUpgradeHandler func(*module.Manager, module.Configurator, clientkeeper.Keeper) types.UpgradeHandler
+	CreateUpgradeHandler func(
+		mm *module.Manager,
+		cfg module.Configurator,
+		nibiru *keepers.PublicKeepers,
+		ibcKeeperClientKeeper clientkeeper.Keeper,
+	) types.UpgradeHandler
 
 	StoreUpgrades store.StoreUpgrades
+}
+
+// DefaultUpgradeHandler runs module manager migrations without running any other
+// logic that uses the Nibiru keepers. This is the most common value for
+// the "CreateUpgradeHandler" field of an [Upgrade].
+func DefaultUpgradeHandler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	nibiru *keepers.PublicKeepers,
+	clientKeeper clientkeeper.Keeper,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return mm.RunMigrations(ctx, cfg, fromVM)
+	}
 }

--- a/app/upgrades/v1_0_1/constants.go
+++ b/app/upgrades/v1_0_1/constants.go
@@ -2,10 +2,6 @@ package v1_0_1
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
@@ -14,11 +10,7 @@ const UpgradeName = "v1.0.1"
 
 // pretty much a no-op store upgrade to test the upgrade process and include the newer version of rocksdb
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
-	StoreUpgrades: types.StoreUpgrades{},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
+	StoreUpgrades:        types.StoreUpgrades{},
 }

--- a/app/upgrades/v1_0_2/constants.go
+++ b/app/upgrades/v1_0_2/constants.go
@@ -2,10 +2,6 @@ package v1_0_2
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
@@ -14,11 +10,7 @@ const UpgradeName = "v1.0.2"
 
 // a no-op store upgrade to test the upgrade process and include the newer version cosmos-sdk
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
-	StoreUpgrades: types.StoreUpgrades{},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
+	StoreUpgrades:        types.StoreUpgrades{},
 }

--- a/app/upgrades/v1_0_3/constants.go
+++ b/app/upgrades/v1_0_3/constants.go
@@ -2,10 +2,6 @@ package v1_0_3
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
@@ -14,11 +10,7 @@ const UpgradeName = "v1.0.3"
 
 // a no-op store upgrade to test the upgrade process and include the newer version cosmos-sdk
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
-	StoreUpgrades: types.StoreUpgrades{},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
+	StoreUpgrades:        types.StoreUpgrades{},
 }

--- a/app/upgrades/v1_1_0/constants.go
+++ b/app/upgrades/v1_1_0/constants.go
@@ -2,10 +2,6 @@ package v1_1_0
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 	inflationtypes "github.com/NibiruChain/nibiru/v2/x/inflation/types"
@@ -14,12 +10,8 @@ import (
 const UpgradeName = "v1.1.0"
 
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
 	StoreUpgrades: types.StoreUpgrades{
 		Added: []string{inflationtypes.ModuleName},
 	},

--- a/app/upgrades/v1_2_0/constants.go
+++ b/app/upgrades/v1_2_0/constants.go
@@ -2,10 +2,6 @@ package v1_2_0
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
@@ -13,11 +9,7 @@ import (
 const UpgradeName = "v1.2.0"
 
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
-	StoreUpgrades: types.StoreUpgrades{},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
+	StoreUpgrades:        types.StoreUpgrades{},
 }

--- a/app/upgrades/v1_3_0/constants.go
+++ b/app/upgrades/v1_3_0/constants.go
@@ -16,6 +16,7 @@ import (
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
+	"github.com/NibiruChain/nibiru/v2/app/keepers"
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
 
@@ -23,7 +24,12 @@ const UpgradeName = "v1.3.0"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
+	CreateUpgradeHandler: func(
+		mm *module.Manager,
+		cfg module.Configurator,
+		nibiru *keepers.PublicKeepers,
+		clientKeeper clientkeeper.Keeper,
+	) upgradetypes.UpgradeHandler {
 		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			// set the ICS27 consensus version so InitGenesis is not run
 			fromVM[icatypes.ModuleName] = mm.GetVersionMap()[icatypes.ModuleName]

--- a/app/upgrades/v1_4_0/constants.go
+++ b/app/upgrades/v1_4_0/constants.go
@@ -2,10 +2,6 @@ package v1_4_0
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
@@ -13,12 +9,8 @@ import (
 const UpgradeName = "v1.4.0"
 
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
 	StoreUpgrades: types.StoreUpgrades{
 		Added: []string{},
 	},

--- a/app/upgrades/v1_5_0/constants.go
+++ b/app/upgrades/v1_5_0/constants.go
@@ -2,10 +2,6 @@ package v1_5_0
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
@@ -13,11 +9,7 @@ import (
 const UpgradeName = "v1.5.0"
 
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
-	StoreUpgrades: types.StoreUpgrades{},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
+	StoreUpgrades:        types.StoreUpgrades{},
 }

--- a/app/upgrades/v2_0_0/constants.go
+++ b/app/upgrades/v2_0_0/constants.go
@@ -2,10 +2,6 @@ package v2_0_0
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 	evmtypes "github.com/NibiruChain/nibiru/v2/x/evm"
@@ -14,12 +10,8 @@ import (
 const UpgradeName = "v2.0.0"
 
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
 	StoreUpgrades: types.StoreUpgrades{
 		Added: []string{evmtypes.ModuleName},
 	},

--- a/app/upgrades/v2_1_0/constants.go
+++ b/app/upgrades/v2_1_0/constants.go
@@ -1,6 +1,8 @@
 package v2_1_0
 
 import (
+	"slices"
+
 	"github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -8,6 +10,7 @@ import (
 	ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
 	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
+	"github.com/NibiruChain/nibiru/v2/app/keepers"
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
 
@@ -15,18 +18,17 @@ const UpgradeName = "v2.1.0"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
+	CreateUpgradeHandler: func(
+		mm *module.Manager,
+		cfg module.Configurator,
+		nibiru *keepers.PublicKeepers,
+		clientKeeper clientkeeper.Keeper,
+	) upgradetypes.UpgradeHandler {
 		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			// explicitly update the IBC 02-client params, adding the wasm client type if it is not there
 			params := clientKeeper.GetParams(ctx)
 
-			hasWasmClient := false
-			for _, client := range params.AllowedClients {
-				if client == ibcwasmtypes.Wasm {
-					hasWasmClient = true
-					break
-				}
-			}
+			hasWasmClient := slices.Contains(params.AllowedClients, ibcwasmtypes.Wasm)
 
 			if !hasWasmClient {
 				params.AllowedClients = append(params.AllowedClients, ibcwasmtypes.Wasm)

--- a/app/upgrades/v2_2_0/constants.go
+++ b/app/upgrades/v2_2_0/constants.go
@@ -2,10 +2,6 @@ package v2_2_0
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
@@ -13,11 +9,7 @@ import (
 const UpgradeName = "v2.2.0"
 
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
-	StoreUpgrades: types.StoreUpgrades{},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
+	StoreUpgrades:        types.StoreUpgrades{},
 }

--- a/app/upgrades/v2_3_0/constants.go
+++ b/app/upgrades/v2_3_0/constants.go
@@ -2,10 +2,6 @@ package v2_3_0
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
@@ -13,11 +9,7 @@ import (
 const UpgradeName = "v2.3.0"
 
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
-	StoreUpgrades: types.StoreUpgrades{},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
+	StoreUpgrades:        types.StoreUpgrades{},
 }

--- a/app/upgrades/v2_4_0/constants.go
+++ b/app/upgrades/v2_4_0/constants.go
@@ -2,10 +2,6 @@ package v2_4_0
 
 import (
 	"github.com/cosmos/cosmos-sdk/store/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 )
@@ -13,11 +9,7 @@ import (
 const UpgradeName = "v2.4.0"
 
 var Upgrade = upgrades.Upgrade{
-	UpgradeName: UpgradeName,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, clientKeeper clientkeeper.Keeper) upgradetypes.UpgradeHandler {
-		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-			return mm.RunMigrations(ctx, cfg, fromVM)
-		}
-	},
-	StoreUpgrades: types.StoreUpgrades{},
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: upgrades.DefaultUpgradeHandler,
+	StoreUpgrades:        types.StoreUpgrades{},
 }


### PR DESCRIPTION
# Purpose / Abstract

- Prepares for https://github.com/NibiruChain/nibiru/issues/2313 by adding in the
  other keepers to be available in upgrade handlers, similar to Osmosis and Archway.
- Replaces duplicate code on the majority of our upgrade handlers with a
reusable function.
