### PR TITLE
feat(ux): add GET behavior to the Ethereum JSON-RPC endpoints for Nibiru so they return info instead of a blank page or error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ See https://github.com/dangoslen/changelog-enforcer.
 --> 
 
 - [#2314](https://github.com/NibiruChain/nibiru/pull/2314) - refactor(upgrades): add public keepers to upgrade handlers + DRY improvements
+- [#2316](https://github.com/NibiruChain/nibiru/pull/2316) - feat(ux): add GET behavior to the Ethereum JSON-RPC endpoints for Nibiru so they return info instead of a blank page or error.
 
 ## v2.4.0
 

--- a/app/app.go
+++ b/app/app.go
@@ -210,7 +210,7 @@ type NibiruApp struct {
 }
 
 func init() {
-	SetPrefixes("nibi")
+	SetPrefixes(appconst.AccountAddressPrefix)
 	sdk.DefaultBondDenom = appconst.BondDenom
 
 	userHomeDir, err := os.UserHomeDir()

--- a/app/appconst/appconst.go
+++ b/app/appconst/appconst.go
@@ -1,10 +1,14 @@
-// Copyright (c) 2023-2024 Nibi, Inc.
+// Package appconst defines global constants and utility functions
+// used throughout the Nibiru application.
 package appconst
+
+// Copyright (c) 2023-2024 Nibi, Inc.
 
 import (
 	"fmt"
 	"math/big"
 	"runtime"
+	"strings"
 
 	db "github.com/cometbft/cometbft-db"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -12,7 +16,8 @@ import (
 
 const (
 	BinaryName = "nibiru"
-	BondDenom  = "unibi"
+	// BondDenom is the Bank Coin denomination for staking, governance, and gas.
+	BondDenom = "unibi"
 	// AccountAddressPrefix: Bech32 prefix for Nibiru accounts.
 	AccountAddressPrefix = "nibi"
 )
@@ -22,43 +27,27 @@ var (
 	HavePebbleDBBuildTag bool
 )
 
-// Runtime version vars
-var (
-	AppVersion = ""
-	GitCommit  = ""
-	BuildDate  = ""
-
-	GoVersion = ""
-	GoArch    = ""
-)
-
-func init() {
-	verInfo := version.NewInfo()
-	AppVersion = verInfo.Version
-	if len(AppVersion) == 0 {
-		AppVersion = "dev"
-	}
-	GitCommit = verInfo.GitCommit
-	GoVersion = runtime.Version()
-	GoArch = runtime.GOARCH
-}
-
-// RuntimeVersion returns a string containing the traceability info like the
-// client name, version, Git commit, Go version, runtime architecture, and build
-// tags.
+// RuntimeVersion returns a formatted string with versioning and build metadata,
+// including the Nibiru version, Git commit, Go runtime, architecture, and build tags.
 func RuntimeVersion() string {
-	verInfo := version.NewInfo()
+	info := version.NewInfo()
+	nibiruVersion := info.Version
+	if len(nibiruVersion) == 0 {
+		nibiruVersion = "dev"
+	}
+	goVersion := runtime.Version()
+	goArch := runtime.GOARCH
 	return fmt.Sprintf(
-		"Nibiru %s: Compiled at Git commit %s using Go %s, arch %s, build tags %s",
-		AppVersion,
-		GitCommit,
-		GoVersion,
-		GoArch,
-		verInfo.BuildTags,
+		"Nibiru %s: Compiled at Git commit %s using Go %s, arch %s, and build tags (%s)",
+		nibiruVersion,
+		info.GitCommit,
+		goVersion,
+		goArch,
+		strings.TrimRight(info.BuildTags, ","), // build tags have a trailing comma
 	)
 }
 
-// EIP 155 Chain IDs exported for tests.
+// EIP 155 Chain IDs for Nibiru
 const (
 	ETH_CHAIN_ID_MAINNET int64 = 6900
 
@@ -78,6 +67,8 @@ const (
 	ETH_CHAIN_ID_DEFAULT int64 = 6930
 )
 
+// knownEthChainIDMap maps `sdk.Context` chain IDs to their corresponding EIP-155
+// Ethereum Chain IDs, which must be positive integers.
 var knownEthChainIDMap = map[string]int64{
 	"cataclysm-1": ETH_CHAIN_ID_MAINNET,
 
@@ -100,9 +91,7 @@ var knownEthChainIDMap = map[string]int64{
 func GetEthChainID(ctxChainID string) (ethChainID *big.Int) {
 	ethChainIdInt, found := knownEthChainIDMap[ctxChainID]
 	if !found {
-		ethChainID = big.NewInt(ETH_CHAIN_ID_DEFAULT)
-	} else {
-		ethChainID = big.NewInt(ethChainIdInt)
+		return big.NewInt(ETH_CHAIN_ID_DEFAULT)
 	}
-	return ethChainID
+	return big.NewInt(ethChainIdInt)
 }

--- a/app/appconst/appconst.go
+++ b/app/appconst/appconst.go
@@ -43,6 +43,9 @@ func init() {
 	GoArch = runtime.GOARCH
 }
 
+// RuntimeVersion returns a string containing the traceability info like the
+// client name, version, Git commit, Go version, runtime architecture, and build
+// tags.
 func RuntimeVersion() string {
 	verInfo := version.NewInfo()
 	return fmt.Sprintf(

--- a/app/appconst/appconst.go
+++ b/app/appconst/appconst.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	db "github.com/cometbft/cometbft-db"
+	"github.com/cosmos/cosmos-sdk/version"
 )
 
 const (
@@ -32,22 +33,25 @@ var (
 )
 
 func init() {
+	verInfo := version.NewInfo()
+	AppVersion = verInfo.Version
 	if len(AppVersion) == 0 {
 		AppVersion = "dev"
 	}
-
+	GitCommit = verInfo.GitCommit
 	GoVersion = runtime.Version()
 	GoArch = runtime.GOARCH
 }
 
 func RuntimeVersion() string {
+	verInfo := version.NewInfo()
 	return fmt.Sprintf(
-		"Version %s (%s)\nCompiled at %s using Go %s (%s)",
+		"Nibiru %s: Compiled at Git commit %s using Go %s, arch %s, build tags %s",
 		AppVersion,
 		GitCommit,
-		BuildDate,
 		GoVersion,
 		GoArch,
+		verInfo.BuildTags,
 	)
 }
 

--- a/app/server/evm_json_rpc.go
+++ b/app/server/evm_json_rpc.go
@@ -26,10 +26,8 @@ import (
 	srvconfig "github.com/NibiruChain/nibiru/v2/app/server/config"
 )
 
-var (
-	//go:embed evm_json_rpc_get.html
-	htmlTemplateEvmJsonRpc []byte
-)
+//go:embed evm_json_rpc_get.html
+var htmlTemplateEvmJsonRpc []byte
 
 // StartEthereumJSONRPC starts the Ethereum JSON-RPC server and websocket server
 // for Nibiru.

--- a/app/server/evm_json_rpc.go
+++ b/app/server/evm_json_rpc.go
@@ -2,8 +2,13 @@ package server
 
 import (
 	"errors"
+	"html/template"
 	"net/http"
 	"time"
+
+	// The `_ "embed"` import adds access to files embedded in the running Go
+	// program (smart contracts).
+	_ "embed"
 
 	"github.com/NibiruChain/nibiru/v2/eth"
 	"github.com/NibiruChain/nibiru/v2/eth/rpc/rpcapi"
@@ -17,11 +22,18 @@ import (
 	gethlog "github.com/ethereum/go-ethereum/log"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/NibiruChain/nibiru/v2/app/appconst"
 	srvconfig "github.com/NibiruChain/nibiru/v2/app/server/config"
 )
 
-// StartJSONRPC starts the JSON-RPC server
-func StartJSONRPC(
+var (
+	//go:embed evm_json_rpc_get.html
+	htmlTemplateEvmJsonRpc []byte
+)
+
+// StartEthereumJSONRPC starts the Ethereum JSON-RPC server and websocket server
+// for Nibiru.
+func StartEthereumJSONRPC(
 	ctx *server.Context,
 	clientCtx client.Context,
 	tmRPCAddr,
@@ -55,8 +67,37 @@ func StartJSONRPC(
 		}
 	}
 
+	// This router for the Ethereum JSON-RPC matches on both the path ("/")
+	// and method ("POST", "GET", "PUT") to choose a handler. This allows us
+	// to add different behavior based on the type of request to display a
+	// webpage if someone visits the RPC URL.
 	r := mux.NewRouter()
 	r.HandleFunc("/", rpcServer.ServeHTTP).Methods("POST")
+	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		startTime := time.Now()
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.Header().Set("Vary", "User-Agent")
+		w.WriteHeader(http.StatusOK)
+
+		tmpl := template.Must(
+			template.New("evm_json_rpc_get").
+				Parse(string(htmlTemplateEvmJsonRpc)),
+		)
+		err := tmpl.Execute(w,
+			struct {
+				Status            string
+				NowTime           string
+				Web3ClientVersion string
+			}{
+				Status:            "Active",
+				NowTime:           startTime.Format(time.DateTime),
+				Web3ClientVersion: appconst.RuntimeVersion(),
+			})
+		if err != nil {
+			http.Error(w, "Internal template error", http.StatusInternalServerError)
+		}
+	}).Methods("GET")
 
 	handlerWithCors := cors.Default()
 	if config.API.EnableUnsafeCORS {

--- a/app/server/evm_json_rpc_get.html
+++ b/app/server/evm_json_rpc_get.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="canonical" href="https://evm-rpc.nibiru.fi" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter&display=swap"
+      rel="stylesheet"
+    />
+    <style type="text/css">
+      body {
+        margin: 40px auto;
+        max-width: 650px;
+        line-height: 1.6;
+        font-size: 16px;
+        color: #444;
+        padding: 0 10px;
+        font-family: "Inter", Helvetica, sans-serif;
+      }
+      h1,
+      h2,
+      h3 {
+        line-height: 1.2;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Ethereum JSON-RPC endpoint for Nibiru</h1>
+    <p>
+      Often when people open the link to an RPC endpoint, the page is either
+      blank or displays some error. Here's some useful info instead.
+    </p>
+    <ul>
+      <li>RPC Status: {{.Status}}</li>
+      <li>Time: {{.NowTime}}</li>
+    </ul>
+
+    <h2>Nibiru Mainnet Info</h2>
+    <p>
+      EIP-155 Chain ID: 6900 ("0x1AF4" in hex) <br />EVM RPC:
+      <a target="_blank" href="https://evm-rpc.nibiru.fi"
+        >https://evm-rpc.nibiru.fi</a
+      >
+    </p>
+
+    <h2>Awesome Nibiru Links</h2>
+    These ones are useful for building on Nibiru EVM.
+    <ul>
+      <li>
+        <a target="_blank" href="https://nibiru.fi/docs/concepts/gas.html">
+          Gas on Nibiru and Its EVM
+        </a>
+      </li>
+      <li>
+        <a target="_blank" href="https://nibiru.fi/docs/dev/networks/">
+          Nibiru Networks and RPCs
+        </a>
+      </li>
+      <li>
+        <a
+          target="_blank"
+          href="https://nibiru.fi/docs/dev/evm/npm-evm-core.html"
+        >
+          @nibiruchain/evm-core
+        </a>
+        on <code>npm</code>: Core Nibiru EVM TypeScript library with functions
+        to call Nibiru-specific precompiled contracts.
+      </li>
+      <li>
+        <a
+          target="_blank"
+          href="https://nibiru.fi/docs/dev/evm/npm-solidity.html"
+        >
+          @nibiruchain/solidity
+        </a>
+        on <code>npm</code>: Nibiru EVM solidity contracts and ABIs for
+        Nibiru-specific precompiles and core functionality.
+      </li>
+    </ul>
+
+    These links are more general.
+    <ul>
+      <li>
+        <a target="_blank" href="https://nibiru.fi/docs/dev/">
+          Developer Hub
+        </a>
+      </li>
+      <li>
+        <a target="_blank" href="https://nibiru.fi/brand"> Brand Kit </a>
+      </li>
+      <li>
+        <a target="_blank" href="https://nibiru.fi/docs/community/">
+          Community Hub
+        </a>
+      </li>
+    </ul>
+
+    <h2>Using this EVM JSON-RPC Endpoint with <code>curl</code></h2>
+    <p>
+      You can find a comprehensive list of EVM JSON-RPC methods with
+      descriptions and examples
+      <a
+        href="https://ethereum.org/en/developers/docs/apis/json-rpc/#:~:text=On%20this%20page%20we%20provide%20examples"
+        target="_blank"
+        >here on ethereum.org in the RPC page</a
+      >. Here are a few copy-pasteable examples below.
+    </p>
+
+    <div>
+      <h4>
+        Example <code>"web3_clientVersion"</code>: Queries the traceability info
+        like the client name, version, Git commit, Go version, runtime
+        architecture, and build tags.
+      </h4>
+      <textarea
+        readonly
+        rows="9"
+        style="width: 100%; font-family: monospace; padding: 1rem"
+      >
+curl -X POST https://evm-rpc.nibiru.fi \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "web3_clientVersion",
+    "params": [],
+    "id": 1
+  }'
+</textarea
+      >
+      The response looks like this: "<code>{{.Web3ClientVersion}}</code>"
+    </div>
+
+    <div>
+      <h4>
+        Example <code>"eth_chainId"</code>: Queries the EIP-155
+        replay-protection chain id for the current ethereum blockchain (Nibiru).
+      </h4>
+      <textarea
+        readonly
+        rows="9"
+        style="width: 100%; font-family: monospace; padding: 1rem"
+      >
+curl -X POST https://evm-rpc.nibiru.fi \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "eth_chainId",
+    "params": [],
+    "id": 1
+  }'
+</textarea
+      >
+    </div>
+  </body>
+</html>

--- a/app/server/start.go
+++ b/app/server/start.go
@@ -517,7 +517,7 @@ func startInProcess(ctx *sdkserver.Context, clientCtx client.Context, opts Start
 
 		tmEndpoint := "/websocket"
 		tmRPCAddr := cfg.RPC.ListenAddress
-		httpSrv, httpSrvDone, err = StartJSONRPC(
+		httpSrv, httpSrvDone, err = StartEthereumJSONRPC(
 			ctx, clientCtx, tmRPCAddr, tmEndpoint, &conf, evmIdxer,
 		)
 		if err != nil {

--- a/x/common/testutil/testnetwork/start_node.go
+++ b/x/common/testutil/testnetwork/start_node.go
@@ -141,7 +141,7 @@ func startNodeAndServers(cfg Config, val *Validator) error {
 		val.EthTxIndexer = evmTxIndexer
 		val.EthTxIndexerService = evmTxIndexerService
 
-		val.jsonrpc, val.jsonrpcDone, err = server.StartJSONRPC(val.Ctx, val.ClientCtx, tmRPCAddr, tmEndpoint, val.AppConfig, val.EthTxIndexer)
+		val.jsonrpc, val.jsonrpcDone, err = server.StartEthereumJSONRPC(val.Ctx, val.ClientCtx, tmRPCAddr, tmEndpoint, val.AppConfig, val.EthTxIndexer)
 		if err != nil {
 			return sdkioerrors.Wrap(err, "failed to start JSON-RPC server")
 		}


### PR DESCRIPTION
# Purpose / Abstract

- Closes https://github.com/NibiruChain/nibiru/issues/1991
- **fix(appconst): runtime version noew shows git commit, binary version, etc.**

## Behavior Added 

On all EVM RPC endpoints, a GET serves some text instead of an error. The page looks like this. It's lightweight and responsive with minimal CSS.

![image](https://github.com/user-attachments/assets/8fdfb788-6d09-44f1-910d-24241ed5cacc)

## Manual Testing

Run `just localnet` and then visit http://127.0.0.1:8545/