### PR TITLE
fix(token-registry): prevent overwriting embedded JSON files during tests

### DIFF
--- a/token-registry/CHANGELOG.md
+++ b/token-registry/CHANGELOG.md
@@ -6,3 +6,12 @@
 "0x1429B38e58b97de646ACd65fdb8a4502c2131484" (commit: 7f523044a7f7fa887b55f297a4cf3c7debfc3fea)
 - [#2208](https://github.com/NibiruChain/nibiru/pull/2208) - chore(token-registry): Add the xNIBI CW20 token and early wrapped ERC20 tokens for NIBI and AXV
 - [#2317](https://github.com/NibiruChain/nibiru/pull/2317) - chore(evm): add MIM & USDC.arb to official erc20 token registry
+- [#2318](https://github.com/NibiruChain/nibiru/pull/2318) - fix(token-registry): prevent overwriting embedded JSON files during tests.
+  - Refactored `ERC20S` and `BANK_COINS` into `LoadERC20s()` and
+  `LoadBankCoins()` functions that read from disk instead of relying on hardcoded
+  variables. Updated `main.go` to load tokens from `official_erc20s.json` and
+  `official_bank_coins.json` prior to parsing and writing.
+  - This prevents test runs from overwriting source-controlled files when
+  executing the script, resolving issues caused by `os.WriteFile` truncating the
+  embedded JSON files on error.
+

--- a/token-registry/main/main.go
+++ b/token-registry/main/main.go
@@ -51,7 +51,12 @@ func main() {
 
 	// Create token-registry/official_erc20s.json
 	savePath = path.Join(rootPath, SAVE_PATH_OFFICIAL_ERC20S)
-	prettyBz, err = tokenregistry.ParseOfficialSaveBz(tokenregistry.ERC20S)
+	tokens, err := tokenregistry.LoadERC20s()
+	if err != nil {
+		log.Error().Msg(err.Error())
+		return
+	}
+	prettyBz, err = tokenregistry.ParseOfficialSaveBz(tokens)
 	if err != nil {
 		log.Error().Msg(err.Error())
 		return
@@ -64,7 +69,12 @@ func main() {
 
 	// Create token-registry/official_bank_coins.json
 	savePath = path.Join(rootPath, SAVE_PATH_OFFICIAL_BANK_COINS)
-	prettyBz, err = tokenregistry.ParseOfficialSaveBz(tokenregistry.BANK_COINS)
+	tokens, err = tokenregistry.LoadBankCoins()
+	if err != nil {
+		log.Error().Msg(err.Error())
+		return
+	}
+	prettyBz, err = tokenregistry.ParseOfficialSaveBz(tokens)
 	if err != nil {
 		log.Error().Msg(err.Error())
 		return

--- a/token-registry/official_erc20s.json
+++ b/token-registry/official_erc20s.json
@@ -41,7 +41,7 @@
     "contractAddr": "0x08EBA8ff53c6ee5d37A90eD4b5239f2F85e7B291",
     "displayName": "Bridged USDC (VIA Labs)",
     "symbol": "USDC.arb",
-    "logoSrc": "https://raw.githubusercontent.com/NibiruChain/nibiru/main/token-registry/img/002_arb.png"
+    "logoSrc": "https://raw.githubusercontent.com/NibiruChain/nibiru/main/token-registry/img/002_usdc-arb.png"
   },
   {
     "contractAddr": "0xcdA5b77E2E2268D9E09c874c1b9A4c3F07b37555",
@@ -59,7 +59,7 @@
     "contractAddr": "0xfCfc58685101e2914cBCf7551B432500db84eAa8",
     "displayName": "Magic Internet Money",
     "symbol": "MIM",
-    "logoSrc": "https://raw.githubusercontent.com/NibiruChain/nibiru/main/token-registry/img/007_mim.svg"
+    "logoSrc": "https://raw.githubusercontent.com/NibiruChain/nibiru/main/token-registry/img/007_mim.png"
   },
   {
     "contractAddr": "0xF63fCFcd000af6401dc1848E7e147AeDf56f9355",

--- a/token-registry/official_tokens.go
+++ b/token-registry/official_tokens.go
@@ -2,7 +2,9 @@ package tokenregistry
 
 import (
 	"encoding/json"
+	"os"
 	"os/exec"
+	"path"
 	"strings"
 )
 
@@ -13,6 +15,11 @@ type TokenOfficial struct {
 	LogoSrc      string     `json:"logoSrc"`
 	PriceInfo    *PriceInfo `json:"priceInfo,omitempty"`
 }
+
+const (
+	SAVE_PATH_OFFICIAL_ERC20S     = "token-registry/official_erc20s.json"
+	SAVE_PATH_OFFICIAL_BANK_COINS = "token-registry/official_bank_coins.json"
+)
 
 type PriceInfo struct {
 	// "source" identifies where to get the USD price
@@ -49,62 +56,34 @@ func ParseOfficialSaveBz(tokens []TokenOfficial) ([]byte, error) {
 	return json.MarshalIndent(parsedTokens, "", "  ")
 }
 
-var ERC20S []TokenOfficial = []TokenOfficial{
-	{
-		ContractAddr: "0x0CaCF669f8446BeCA826913a3c6B96aCD4b02a97",
-		DisplayName:  "Wrapped Nibiru",
-		Symbol:       "WNIBI",
-		LogoSrc:      "./img/000_nibiru-evm.png",
-		PriceInfo: &PriceInfo{
-			Source:  "bybit",
-			PriceId: "NIBIUSDT",
-		},
-	},
-	{
-		ContractAddr: "0xcA0a9Fb5FBF692fa12fD13c0A900EC56Bb3f0a7b",
-		DisplayName:  "Liquid Staked Nibiru (Wrapped)",
-		Symbol:       "stNIBI",
-		LogoSrc:      "./img/001_stnibi-evm.png",
-	},
-	{
-		ContractAddr: "0x7168634Dd1ee48b1C5cC32b27fD8Fc84E12D00E6",
-		DisplayName:  "Astrovault (Wrapped)",
-		Symbol:       "AXV",
-		LogoSrc:      "./img/003_astrovault-axv.png",
-	},
+func LoadERC20s() (tokens []TokenOfficial, err error) {
+	rootPath, err := FindRootPath()
+	if err != nil {
+		return tokens, err
+	}
+
+	fpath := path.Join(rootPath, SAVE_PATH_OFFICIAL_ERC20S)
+	bz, err := os.ReadFile(fpath)
+	if err != nil {
+		return tokens, err
+	}
+	err = json.Unmarshal(bz, &tokens)
+	return tokens, err
 }
 
-var BANK_COINS []TokenOfficial = []TokenOfficial{
-	{
-		ContractAddr: "unibi",
-		DisplayName:  "Nibiru",
-		Symbol:       "NIBI",
-		LogoSrc:      "./img/000_nibiru.png",
-		PriceInfo: &PriceInfo{
-			Source:  "bybit",
-			PriceId: "NIBIUSDT",
-		},
-	},
-	{
-		ContractAddr: "tf/nibi1udqqx30cw8nwjxtl4l28ym9hhrp933zlq8dqxfjzcdhvl8y24zcqpzmh8m/ampNIBI",
-		DisplayName:  "Liquid Staked Nibiru",
-		Symbol:       "stNIBI",
-		LogoSrc:      "./img/001_stnibi-bank.png",
-	},
-	{
-		ContractAddr: "tf/nibi1vetfuua65frvf6f458xgtjerf0ra7wwjykrdpuyn0jur5x07awxsfka0ga/axv",
-		DisplayName:  "Astrovault",
-		Symbol:       "AXV",
-		LogoSrc:      "./img/003_astrovault-axv-bank.png",
-	},
-	{
-		ContractAddr: "ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349",
-		DisplayName:  "Noble USDC",
-		Symbol:       "USDC.noble",
-		LogoSrc:      "./img/002_usdc-noble.png",
-		PriceInfo: &PriceInfo{
-			Source:  "bybit",
-			PriceId: "USDCUSDT",
-		},
-	},
+func LoadBankCoins() ([]TokenOfficial, error) {
+	rootPath, err := FindRootPath()
+	if err != nil {
+		return nil, err
+	}
+
+	fpath := path.Join(rootPath, SAVE_PATH_OFFICIAL_BANK_COINS)
+	bz, err := os.ReadFile(fpath)
+	if err != nil {
+		return nil, err
+	}
+
+	var tokens []TokenOfficial
+	err = json.Unmarshal(bz, &tokens)
+	return tokens, err
 }


### PR DESCRIPTION
# Purpose / Abstract

- Fixes typos in Token Registry from #2317
- Improves robustness by referencing JSON files directly instead of using
separate variables for constants in the generation script

---

Refactored `ERC20S` and `BANK_COINS` into `LoadERC20s()` and `LoadBankCoins()` functions
that read from disk instead of relying on hardcoded variables. Updated `main.go` to load
tokens from `official_erc20s.json` and `official_bank_coins.json` prior to parsing and writing.

This prevents test runs from overwriting source-controlled files when executing the script,
resolving issues caused by `os.WriteFile` truncating the embedded JSON files on error.
