### PR TITLE
fix: use the first 20 bytes when decoding the EthAddr

### DIFF
--- a/eth/state_encoder.go
+++ b/eth/state_encoder.go
@@ -59,7 +59,7 @@ type keEthAddr struct{}
 
 func (_ keEthAddr) Encode(value gethcommon.Address) []byte { return value.Bytes() }
 func (_ keEthAddr) Decode(bz []byte) (int, gethcommon.Address) {
-	return gethcommon.AddressLength, gethcommon.BytesToAddress(bz)
+	return gethcommon.AddressLength, gethcommon.BytesToAddress(bz[:gethcommon.AddressLength])
 }
 func (_ keEthAddr) Stringify(value gethcommon.Address) string { return value.Hex() }
 


### PR DESCRIPTION
# Purpose / Abstract

- Closes #AAA

<!-- 
Why is this PR important? 
What does this PR do?
-->
