### PR TITLE
fix(evm): ensure stateDB doesn't persist after upgrade handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ See https://github.com/dangoslen/changelog-enforcer.
 - [#2316](https://github.com/NibiruChain/nibiru/pull/2316) - feat(ux): add GET behavior to the Ethereum JSON-RPC endpoints for Nibiru so they return info instead of a blank page or error.
 - [#2324](https://github.com/NibiruChain/nibiru/pull/2324) - fix(evm): adjust the v2.5.0 upgrade handler to maintain the original stNIBI ERC20 contract's state.
 - [#2327](https://github.com/NibiruChain/nibiru/pull/2327) - fix(eth): implement unmarshal json for TransactionReceipt
+- [#2328](https://github.com/NibiruChain/nibiru/pull/2328) - fix(evm): ensure StateDB doesn't persist between EVM calls
 
 ## [v2.4.0](https://github.com/NibiruChain/nibiru/releases/tag/v2.4.0) - 2025-05-29
 

--- a/app/upgrades/v2_5_0/v2_5_0.go
+++ b/app/upgrades/v2_5_0/v2_5_0.go
@@ -149,8 +149,14 @@ func UpgradeStNibiContractOnMainnet(
 		SkipNonceChecks:  false,
 		SkipFromEOACheck: false,
 	}
-	sdb := keepers.EvmKeeper.NewStateDB(ctx, keepers.EvmKeeper.TxConfig(ctx, gethcommon.Hash{}))
-	evmObj := keepers.EvmKeeper.NewEVM(ctx, evmMsg, keepers.EvmKeeper.GetEVMConfig(ctx), nil, sdb)
+	stateDB := keepers.EvmKeeper.Bank.StateDB
+	if stateDB == nil {
+		stateDB = keepers.EvmKeeper.NewStateDB(ctx, keepers.EvmKeeper.TxConfig(ctx, gethcommon.Hash{}))
+	}
+	defer func() {
+		keepers.EvmKeeper.Bank.StateDB = nil
+	}()
+	evmObj := keepers.EvmKeeper.NewEVM(ctx, evmMsg, keepers.EvmKeeper.GetEVMConfig(ctx), nil, stateDB)
 
 	evmResp, err := keepers.EvmKeeper.CallContractWithInput(
 		ctx, evmObj, evmMsg.From, nil, true /*commit*/, contractInput,

--- a/app/upgrades/v2_5_0/v2_5_0_test.go
+++ b/app/upgrades/v2_5_0/v2_5_0_test.go
@@ -118,6 +118,7 @@ func (s *Suite) TestUpgrade() {
 
 	s.Run(fmt.Sprintf("Perform upgrade on stNIBI ERC20 address: %s", funtoken.Erc20Addr.Address), func() {
 		s.T().Log("IMPORTANT: Schedule the upgrade")
+		deps.EvmKeeper.Bank.StateDB = nil // IMPORTANT: make sure to clear the StateDB before running the upgrade
 		s.Require().True(deps.App.UpgradeKeeper.HasHandler(v2_5_0.Upgrade.UpgradeName))
 
 		beforeEvents := deps.Ctx.EventManager().Events()

--- a/x/evm/evmtest/test_deps.go
+++ b/x/evm/evmtest/test_deps.go
@@ -48,7 +48,13 @@ func (deps TestDeps) NewStateDB() *statedb.StateDB {
 }
 
 func (deps TestDeps) NewEVM() (*vm.EVM, *statedb.StateDB) {
-	stateDB := deps.EvmKeeper.NewStateDB(deps.Ctx, statedb.NewEmptyTxConfig(gethcommon.BytesToHash(deps.Ctx.HeaderHash())))
+	if deps.EvmKeeper.Bank.StateDB == nil {
+		deps.EvmKeeper.Bank.StateDB = deps.NewStateDB()
+	}
+	stateDB := deps.EvmKeeper.Bank.StateDB
+	defer func() {
+		deps.EvmKeeper.Bank.StateDB = nil
+	}()
 	evmObj := deps.EvmKeeper.NewEVM(
 		deps.Ctx,
 		MOCK_GETH_MESSAGE,
@@ -60,7 +66,13 @@ func (deps TestDeps) NewEVM() (*vm.EVM, *statedb.StateDB) {
 }
 
 func (deps TestDeps) NewEVMLessVerboseLogger() (*vm.EVM, *statedb.StateDB) {
-	stateDB := deps.EvmKeeper.NewStateDB(deps.Ctx, statedb.NewEmptyTxConfig(gethcommon.BytesToHash(deps.Ctx.HeaderHash())))
+	if deps.EvmKeeper.Bank.StateDB == nil {
+		deps.EvmKeeper.Bank.StateDB = deps.NewStateDB()
+	}
+	stateDB := deps.EvmKeeper.Bank.StateDB
+	defer func() {
+		deps.EvmKeeper.Bank.StateDB = nil
+	}()
 	evmObj := deps.EvmKeeper.NewEVM(
 		deps.Ctx,
 		MOCK_GETH_MESSAGE,

--- a/x/evm/evmtest/test_deps.go
+++ b/x/evm/evmtest/test_deps.go
@@ -48,13 +48,7 @@ func (deps TestDeps) NewStateDB() *statedb.StateDB {
 }
 
 func (deps TestDeps) NewEVM() (*vm.EVM, *statedb.StateDB) {
-	if deps.EvmKeeper.Bank.StateDB == nil {
-		deps.EvmKeeper.Bank.StateDB = deps.NewStateDB()
-	}
-	stateDB := deps.EvmKeeper.Bank.StateDB
-	defer func() {
-		deps.EvmKeeper.Bank.StateDB = nil
-	}()
+	stateDB := deps.EvmKeeper.NewStateDB(deps.Ctx, statedb.NewEmptyTxConfig(gethcommon.BytesToHash(deps.Ctx.HeaderHash())))
 	evmObj := deps.EvmKeeper.NewEVM(
 		deps.Ctx,
 		MOCK_GETH_MESSAGE,
@@ -66,13 +60,7 @@ func (deps TestDeps) NewEVM() (*vm.EVM, *statedb.StateDB) {
 }
 
 func (deps TestDeps) NewEVMLessVerboseLogger() (*vm.EVM, *statedb.StateDB) {
-	if deps.EvmKeeper.Bank.StateDB == nil {
-		deps.EvmKeeper.Bank.StateDB = deps.NewStateDB()
-	}
-	stateDB := deps.EvmKeeper.Bank.StateDB
-	defer func() {
-		deps.EvmKeeper.Bank.StateDB = nil
-	}()
+	stateDB := deps.EvmKeeper.NewStateDB(deps.Ctx, statedb.NewEmptyTxConfig(gethcommon.BytesToHash(deps.Ctx.HeaderHash())))
 	evmObj := deps.EvmKeeper.NewEVM(
 		deps.Ctx,
 		MOCK_GETH_MESSAGE,


### PR DESCRIPTION
# Purpose / Abstract

- Attempt at fixing the consensus issue we saw on some nodes on our testnet-2 environment

<!-- 
Why is this PR important? 
What does this PR do?
-->

This pull request modifies the `UpgradeStNibiContractOnMainnet` function in `v2_5_0.go` to improve the handling of the `StateDB` object by introducing a conditional check and cleanup mechanism.

Key changes:

### StateDB Handling Improvements:
* Replaced direct instantiation of `StateDB` with a conditional check to use `keepers.EvmKeeper.Bank.StateDB` if available. If not, it falls back to creating a new `StateDB` instance.
* Added a `defer` statement to reset `keepers.EvmKeeper.Bank.StateDB` to `nil` after its usage, ensuring proper cleanup and avoiding potential side effects.