### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/eth/rpc/rpcapi/filter_utils.go
+++ b/eth/rpc/rpcapi/filter_utils.go
@@ -3,6 +3,7 @@ package rpcapi
 
 import (
 	"math/big"
+	"slices"
 
 	sdkioerrors "cosmossdk.io/errors"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -56,13 +57,7 @@ Logs:
 }
 
 func includes(addresses []common.Address, a common.Address) bool {
-	for _, addr := range addresses {
-		if addr == a {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(addresses, a)
 }
 
 // https://github.com/ethereum/go-ethereum/blob/v1.10.14/eth/filters/filter.go#L321

--- a/x/devgas/v1/types/params.go
+++ b/x/devgas/v1/types/params.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"slices"
 
 	sdkmath "cosmossdk.io/math"
 )
@@ -64,10 +65,8 @@ func validateArray(i any) error {
 		return fmt.Errorf("invalid parameter type: %T", i)
 	}
 
-	for _, denom := range i.([]string) {
-		if denom == "" {
-			return fmt.Errorf("denom cannot be blank")
-		}
+	if slices.Contains(i.([]string), "") {
+		return fmt.Errorf("denom cannot be blank")
 	}
 
 	return nil


### PR DESCRIPTION
# Purpose / Abstract

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.


<!-- 
Why is this PR important? 
What does this PR do?
-->
