### PR TITLE
feat(evm): add convert messages to codec | MsgCreateFunToken, MsgConvertCoinToEvm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ vote.json
 **__pycache**
 scratch-paper.md
 logs
+Claude.md
 
 ### TypeScript and Friends
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ See https://github.com/dangoslen/changelog-enforcer.
 
 - [#2331](https://github.com/NibiruChain/nibiru/pull/2331) - test(evm-e2e): WNIBI tests for deposit, transfer and total supply
 - [#2334](https://gittub.com/NibiruChain/nibiru/pull/2334) - feat(evm-embeds): Publish new version for `@nibiruchain/solidity@0.0.6`, which updates `NibiruOracleChainLinkLike.sol` to have additional methods used by Aave.
+- [#2344](https://gittub.com/NibiruChain/nibiru/pull/23344) - feat(evm): Add some evm messages into the evm codec.
 
 ## [v2.5.0](https://github.com/NibiruChain/nibiru/releases/tag/v2.5.0) - 2025-06-09
 

--- a/x/evm/codec.go
+++ b/x/evm/codec.go
@@ -35,7 +35,7 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		&MsgEthereumTx{},
 		&MsgUpdateParams{},
 		&MsgCreateFunToken{},
-		&MsgConvertCoinToEvm{},    
+		&MsgConvertCoinToEvm{},
 	)
 	registry.RegisterInterface(
 		"eth.evm.v1.TxData",

--- a/x/evm/codec.go
+++ b/x/evm/codec.go
@@ -34,6 +34,8 @@ func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 		(*sdk.Msg)(nil),
 		&MsgEthereumTx{},
 		&MsgUpdateParams{},
+		&MsgCreateFunToken{},
+		&MsgConvertCoinToEvm{},    
 	)
 	registry.RegisterInterface(
 		"eth.evm.v1.TxData",

--- a/x/evm/msg.go
+++ b/x/evm/msg.go
@@ -34,7 +34,7 @@ var (
 	_ ante.GasTx = &MsgEthereumTx{}
 	_ sdk.Msg    = &MsgUpdateParams{}
 	_ sdk.Msg    = &MsgCreateFunToken{}
-	_ sdk.Msg    = &MsgConvertCoinToEvm{}  
+	_ sdk.Msg    = &MsgConvertCoinToEvm{}
 
 	_ codectypes.UnpackInterfacesMessage = MsgEthereumTx{}
 )

--- a/x/evm/msg.go
+++ b/x/evm/msg.go
@@ -34,6 +34,7 @@ var (
 	_ ante.GasTx = &MsgEthereumTx{}
 	_ sdk.Msg    = &MsgUpdateParams{}
 	_ sdk.Msg    = &MsgCreateFunToken{}
+	_ sdk.Msg    = &MsgConvertCoinToEvm{}  
 
 	_ codectypes.UnpackInterfacesMessage = MsgEthereumTx{}
 )


### PR DESCRIPTION
This pull request introduces two new message types, `MsgCreateFunToken` and `MsgConvertCoinToEvm`, to the `x/evm` module. These changes extend the functionality of the module by registering and supporting these new message types.

### Additions to message types:

* [`x/evm/codec.go`](diffhunk://#diff-52330b4824d2ae4d46412bc9b98dff8c2aa32877f2c663934c307f29288c591bR37-R38): Registered `MsgCreateFunToken` and `MsgConvertCoinToEvm` with the codec interface registry to enable their usage in transactions.
* [`x/evm/msg.go`](diffhunk://#diff-5ca9fbc3c4d517a8a59ba037f2a9fcda7b26c969c199a56a7701c9d850c650cdR37): Added `MsgConvertCoinToEvm` to the list of supported `sdk.Msg` types, ensuring compatibility with the `sdk.Msg` interface.