### PR TITLE
fix(simapp): sim tests with empty validator set panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ See https://github.com/dangoslen/changelog-enforcer.
 - [#2344](https://gittub.com/NibiruChain/nibiru/pull/23344) - feat(evm): Add some evm messages into the evm codec.
 - [#2346](https://gittub.com/NibiruChain/nibiru/pull/2346) - fix(buf-gen-rs): improve Rust proto binding generation script robustness and get it to work with a forked Cosmos-SDK dependency and exit correctly on failure
 - [#2348](https://github.com/NibiruChain/nibiru/pull/2348) - fix(oracle): max expiration a label rather than an invalidation for additional query liveness
+- [#2350](https://github.com/NibiruChain/nibiru/pull/2350) - fix(simapp): sim tests with empty validator set panic
 
 ### Dependencies
 - Bump `form-data` from 4.0.1 to 4.0.4 ([#2347](https://github.com/NibiruChain/nibiru/pull/2347))

--- a/app/simapp/state_test.go
+++ b/app/simapp/state_test.go
@@ -35,6 +35,15 @@ func AppStateFn(cdc codec.JSONCodec, simManager *module.SimulationManager) simty
 			genesisTimestamp = time.Unix(appsim.FlagGenesisTimeValue, 0)
 		}
 
+		if len(accs) == 0 {
+			// Fallback to generated accounts if none were passed in
+			// We do this because staking will fail if there are 0 accounts to be
+			// eligible validators, causing a panic during InitChain.
+			//
+			// See https://github.com/NibiruChain/nibiru/issues/2349
+			accs = simtypes.RandomAccounts(r, 3)
+		}
+
 		chainID = config.ChainID
 		switch {
 		case config.ParamsFile != "" && config.GenesisFile != "":
@@ -156,7 +165,11 @@ func AppStateRandomizedFn(
 	)
 	appParams.GetOrGenerate(
 		cdc, sims.InitiallyBondedValidators, &numInitiallyBonded, r,
-		func(r *rand.Rand) { numInitiallyBonded = int64(r.Intn(300)) },
+		func(r *rand.Rand) {
+			// Note that we set numInitiallyBonded to be at least 1, because a chain
+			// with 0 validators is invalid an will panic in InitChain.
+			numInitiallyBonded = max(int64(r.Intn(300)), 1)
+		},
 	)
 
 	if numInitiallyBonded > numAccs {


### PR DESCRIPTION
# Purpose / Abstract

- Closes #2349. This PR fixes a panic in simulation tests caused by an empty validator set during `InitChain`.

## Problem

When the simulation framework generates zero accounts (`accs`), and/or when the number of initially bonded validators is set to zero (or exceeds the number of accounts), the staking module cannot initialize a validator set, causing the app to panic with:

```
validator set is empty after InitGenesis
```

## Testing this PR 
 
```bash
make test-sim-nondeterminism
```

## Fixes

* Ensure at least 1 account is generated in `AppStateFn` if none were passed in.
* Clamp `numInitiallyBonded` to a minimum of 1 in `AppStateRandomizedFn`.

These changes guarantee that:

* The simulation has a non-empty account pool.
* The validator set always includes at least one bonded validator, avoiding invalid genesis states.
