### PR TITLE
chore(token-registry): Add bank coin versions of USDC and USDT from Stargate and LayerZero, and update ErisEvm.sol to fix redeem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ See https://github.com/dangoslen/changelog-enforcer.
 - [#2346](https://gittub.com/NibiruChain/nibiru/pull/2346) - fix(buf-gen-rs): improve Rust proto binding generation script robustness and get it to work with a forked Cosmos-SDK dependency and exit correctly on failure
 - [#2348](https://github.com/NibiruChain/nibiru/pull/2348) - fix(oracle): max expiration a label rather than an invalidation for additional query liveness
 - [#2350](https://github.com/NibiruChain/nibiru/pull/2350) - fix(simapp): sim tests with empty validator set panic
+- [#2352](https://github.com/NibiruChain/nibiru/pull/2352) - chore(token-registry): Add bank coin versions of USDC and USDT from Stargate and LayerZero, and update ErisEvm.sol to fix redeem
 
 ### Dependencies
 - Bump `form-data` from 4.0.1 to 4.0.4 ([#2347](https://github.com/NibiruChain/nibiru/pull/2347))

--- a/token-registry/CHANGELOG.md
+++ b/token-registry/CHANGELOG.md
@@ -15,3 +15,4 @@
   executing the script, resolving issues caused by `os.WriteFile` truncating the
   embedded JSON files on error.
 - [#2341](https://github.com/NibiruChain/nibiru/pull/2341) - chore(token-registry): Add the USDa and sUSDa ERC20 from Avalon Finance
+- [#2352](https://github.com/NibiruChain/nibiru/pull/2352) - chore(token-registry): Add bank coin versions of USDC and USDT from Stargate and LayerZero, and update ErisEvm.sol to fix redeem.

--- a/token-registry/official_bank_coins.json
+++ b/token-registry/official_bank_coins.json
@@ -30,5 +30,25 @@
       "source": "bybit",
       "priceId": "USDCUSDT"
     }
+  },
+  {
+    "contractAddr": "erc20/0x0829F361A05D993d5CEb035cA6DF3446b060970b",
+    "displayName": "USDC (Stargate, Bank)",
+    "symbol": "USDC.e",
+    "logoSrc": "https://raw.githubusercontent.com/NibiruChain/nibiru/main/token-registry/img/002_usdc.png",
+    "priceInfo": {
+      "source": "bybit",
+      "priceId": "USDCUSDT"
+    }
+  },
+  {
+    "contractAddr": "erc20/0x43F2376D5D03553aE72F4A8093bbe9de4336EB08",
+    "displayName": "USDT (Stargate, Bank)",
+    "symbol": "USDT",
+    "logoSrc": "https://raw.githubusercontent.com/NibiruChain/nibiru/main/token-registry/img/006_usdt.svg",
+    "priceInfo": {
+      "source": "bybit",
+      "priceId": "USDCUSDT"
+    }
   }
 ]

--- a/token-registry/official_erc20s.json
+++ b/token-registry/official_erc20s.json
@@ -69,13 +69,13 @@
   },
   {
     "contractAddr": "0xf4e097E36d2064E2bDCA96e60439f3A369522003",
-    "displayName": "USDa (Avalon Finance)",
+    "displayName": "USDa (Avalon)",
     "symbol": "USDa",
     "logoSrc": "https://raw.githubusercontent.com/NibiruChain/nibiru/main/token-registry/img/007_usda-avalon.png"
   },
   {
     "contractAddr": "0x84f682626302EA7BCA2A7c338b84863292131319",
-    "displayName": "sUSDa (Avalon Finance)",
+    "displayName": "sUSDa (Avalon)",
     "symbol": "sUSDa",
     "logoSrc": "https://raw.githubusercontent.com/NibiruChain/nibiru/main/token-registry/img/007_susda-avalon.png"
   }

--- a/x/evm/embeds/contracts/ErisEvm.sol
+++ b/x/evm/embeds/contracts/ErisEvm.sol
@@ -142,22 +142,11 @@ contract ErisEvm {
     }
 
     /// @notice Redeem any stNIBI that has finished unstaking to receive the NIBI
-    /// principal and any accrued rewards from liquid staking. NIBI received is
-    /// converted to WNIBI.
+    /// principal and any accrued rewards from liquid staking.
     function redeem() external {
-        uint256 nibiBalBefore = address(msg.sender).balance;
-
         bytes memory wasmMsg = bytes('{"withdraw_unbonded":{}}');
         INibiruEvm.BankCoin[] memory funds = new INibiruEvm.BankCoin[](0);
         _doWasmExecute(ERIS_WASM_CONTRACT, wasmMsg, funds);
-
-        uint256 nibiBalAfter = address(msg.sender).balance;
-        uint256 nibiReceived = nibiBalAfter > nibiBalBefore
-            ? nibiBalAfter - nibiBalBefore
-            : 0;
-        if (nibiReceived > 0) {
-            WNIBI(WNIBI_ADDRESS).deposit{value: nibiBalAfter - nibiBalBefore}();
-        }
     }
 
     /// @notice Queue to unstake stNIBI to later redeem it for the principal and


### PR DESCRIPTION
# Purpose / Abstract

- Closes https://github.com/NibiruChain/sai-website/issues/172
- Related to https://github.com/NibiruChain/web-app/pull/1469#issuecomment-3123250087
