### PR TITLE
feat(eth): enhance EIP55Addr Unmarshal to support ASCII hex strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ See https://github.com/dangoslen/changelog-enforcer.
 -->
 
 - [#2353](https://github.com/NibiruChain/nibiru/pull/2353) - refactor(oracle): remove dead code from asset registry 
+- [#2371](https://github.com/NibiruChain/nibiru/pull/2371) - feat(evm): fix UnmarshalJSON to accept ASCII hex strings
 
 ### Dependencies
 - Bump `base-x` from 3.0.10 to 3.0.11 ([#2355](https://github.com/NibiruChain/nibiru/pull/2355))

--- a/eth/eip55.go
+++ b/eth/eip55.go
@@ -1,12 +1,12 @@
 package eth
 
 import (
-    "encoding/json"
-    "fmt"
-    "strings"
+	"encoding/json"
+	"fmt"
+	"strings"
 
-    sdk "github.com/cosmos/cosmos-sdk/types"
-    gethcommon "github.com/ethereum/go-ethereum/common"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 var _ sdk.CustomProtobufType = (*EIP55Addr)(nil)
@@ -59,34 +59,34 @@ func (h *EIP55Addr) MarshalTo(data []byte) (n int, err error) {
 // Unmarshal implements the gogo proto custom type interface.
 // Ref: https://github.com/cosmos/gogoproto/blob/v1.5.0/custom_types.md
 func (h *EIP55Addr) Unmarshal(data []byte) error {
-    // Fast path: raw 20-byte address (H160)
-    if len(data) == gethcommon.AddressLength {
-        addr := gethcommon.BytesToAddress(data)
-        *h = EIP55Addr{Address: addr}
-        return nil
-    }
+	// Fast path: raw 20-byte address (H160)
+	if len(data) == gethcommon.AddressLength {
+		addr := gethcommon.BytesToAddress(data)
+		*h = EIP55Addr{Address: addr}
+		return nil
+	}
 
-    // If the wire payload looks like an ASCII hex string (with or without 0x),
-    // parse it as a hex-encoded Ethereum address for robustness across clients
-    // that accidentally pass a string's UTF-8 bytes (e.g., CosmWasm/Rust SDKs).
-    s := string(data)
-    sTrim := strings.TrimSpace(s)
-    // Normalize 0x prefix handling and length
-    sNo0x := strings.TrimPrefix(strings.TrimPrefix(sTrim, "0x"), "0X")
-    if len(sNo0x) == 40 {
-        // Accept if it is a valid hex address form. geth's IsHexAddress accepts
-        // both with and without 0x; use the original (possibly 0x-prefixed) string.
-        if gethcommon.IsHexAddress(sTrim) || gethcommon.IsHexAddress("0x"+sNo0x) {
-            addr := gethcommon.HexToAddress(sTrim)
-            *h = EIP55Addr{Address: addr}
-            return nil
-        }
-    }
+	// If the wire payload looks like an ASCII hex string (with or without 0x),
+	// parse it as a hex-encoded Ethereum address for robustness across clients
+	// that accidentally pass a string's UTF-8 bytes (e.g., CosmWasm/Rust SDKs).
+	s := string(data)
+	sTrim := strings.TrimSpace(s)
+	// Normalize 0x prefix handling and length
+	sNo0x := strings.TrimPrefix(strings.TrimPrefix(sTrim, "0x"), "0X")
+	if len(sNo0x) == 40 {
+		// Accept if it is a valid hex address form. geth's IsHexAddress accepts
+		// both with and without 0x; use the original (possibly 0x-prefixed) string.
+		if gethcommon.IsHexAddress(sTrim) || gethcommon.IsHexAddress("0x"+sNo0x) {
+			addr := gethcommon.HexToAddress(sTrim)
+			*h = EIP55Addr{Address: addr}
+			return nil
+		}
+	}
 
-    // Fallback: interpret the bytes directly (uses last 20 bytes if longer).
-    addr := gethcommon.BytesToAddress(data)
-    *h = EIP55Addr{Address: addr}
-    return nil
+	// Fallback: interpret the bytes directly (uses last 20 bytes if longer).
+	addr := gethcommon.BytesToAddress(data)
+	*h = EIP55Addr{Address: addr}
+	return nil
 }
 
 // UnmarshalJSON implements the gogo proto custom type interface.

--- a/eth/eip55.go
+++ b/eth/eip55.go
@@ -1,11 +1,12 @@
 package eth
 
 import (
-	"encoding/json"
-	"fmt"
+    "encoding/json"
+    "fmt"
+    "strings"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	gethcommon "github.com/ethereum/go-ethereum/common"
+    sdk "github.com/cosmos/cosmos-sdk/types"
+    gethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 var _ sdk.CustomProtobufType = (*EIP55Addr)(nil)
@@ -58,9 +59,34 @@ func (h *EIP55Addr) MarshalTo(data []byte) (n int, err error) {
 // Unmarshal implements the gogo proto custom type interface.
 // Ref: https://github.com/cosmos/gogoproto/blob/v1.5.0/custom_types.md
 func (h *EIP55Addr) Unmarshal(data []byte) error {
-	addr := gethcommon.BytesToAddress(data)
-	*h = EIP55Addr{Address: addr}
-	return nil
+    // Fast path: raw 20-byte address (H160)
+    if len(data) == gethcommon.AddressLength {
+        addr := gethcommon.BytesToAddress(data)
+        *h = EIP55Addr{Address: addr}
+        return nil
+    }
+
+    // If the wire payload looks like an ASCII hex string (with or without 0x),
+    // parse it as a hex-encoded Ethereum address for robustness across clients
+    // that accidentally pass a string's UTF-8 bytes (e.g., CosmWasm/Rust SDKs).
+    s := string(data)
+    sTrim := strings.TrimSpace(s)
+    // Normalize 0x prefix handling and length
+    sNo0x := strings.TrimPrefix(strings.TrimPrefix(sTrim, "0x"), "0X")
+    if len(sNo0x) == 40 {
+        // Accept if it is a valid hex address form. geth's IsHexAddress accepts
+        // both with and without 0x; use the original (possibly 0x-prefixed) string.
+        if gethcommon.IsHexAddress(sTrim) || gethcommon.IsHexAddress("0x"+sNo0x) {
+            addr := gethcommon.HexToAddress(sTrim)
+            *h = EIP55Addr{Address: addr}
+            return nil
+        }
+    }
+
+    // Fallback: interpret the bytes directly (uses last 20 bytes if longer).
+    addr := gethcommon.BytesToAddress(data)
+    *h = EIP55Addr{Address: addr}
+    return nil
 }
 
 // UnmarshalJSON implements the gogo proto custom type interface.

--- a/eth/eip55_test.go
+++ b/eth/eip55_test.go
@@ -234,37 +234,37 @@ func (s *EIP55AddrSuite) TestStringEncoding() {
 
 // Ensure Unmarshal accepts ASCII hex strings (with/without 0x) in addition to raw 20 bytes.
 func (s *EIP55AddrSuite) TestUnmarshalAcceptsASCIIHexStrings() {
-    expected := gethcommon.HexToAddress("0xb45ad9d1cf36cb1a55cf5f781a791415846465d3")
+	expected := gethcommon.HexToAddress("0xb45ad9d1cf36cb1a55cf5f781a791415846465d3")
 
-    for idx, input := range []string{
-        "0xb45ad9d1cf36cb1a55cf5f781a791415846465d3", // lower, with 0x
-        "b45ad9d1cf36cb1a55cf5f781a791415846465d3",   // lower, without 0x
-        "0xB45AD9D1CF36CB1A55CF5F781A791415846465D3", // upper, with 0x
-    } {
-        s.Run("ascii-hex-"+strconv.Itoa(idx), func() {
-            var got eth.EIP55Addr
-            // Pass the ASCII hex string bytes to Unmarshal, simulating a client
-            // that encoded the hex string directly in protobuf bytes.
-            err := got.Unmarshal([]byte(input))
-            s.Require().NoError(err)
+	for idx, input := range []string{
+		"0xb45ad9d1cf36cb1a55cf5f781a791415846465d3", // lower, with 0x
+		"b45ad9d1cf36cb1a55cf5f781a791415846465d3",   // lower, without 0x
+		"0xB45AD9D1CF36CB1A55CF5F781A791415846465D3", // upper, with 0x
+	} {
+		s.Run("ascii-hex-"+strconv.Itoa(idx), func() {
+			var got eth.EIP55Addr
+			// Pass the ASCII hex string bytes to Unmarshal, simulating a client
+			// that encoded the hex string directly in protobuf bytes.
+			err := got.Unmarshal([]byte(input))
+			s.Require().NoError(err)
 
-            s.Equal(expected, got.Address)
+			s.Equal(expected, got.Address)
 
-            // Round-trip back to bytes should equal the raw 20 bytes
-            bz, err := got.Marshal()
-            s.Require().NoError(err)
-            s.Equal(expected.Bytes(), bz)
+			// Round-trip back to bytes should equal the raw 20 bytes
+			bz, err := got.Marshal()
+			s.Require().NoError(err)
+			s.Equal(expected.Bytes(), bz)
 
-            // Size should be exactly 20 bytes
-            s.Equal(20, got.Size())
-        })
-    }
+			// Size should be exactly 20 bytes
+			s.Equal(20, got.Size())
+		})
+	}
 
-    // Raw 20-byte input still works (baseline behavior)
-    s.Run("raw-20-bytes", func() {
-        var got eth.EIP55Addr
-        err := got.Unmarshal(expected.Bytes())
-        s.Require().NoError(err)
-        s.Equal(expected, got.Address)
-    })
+	// Raw 20-byte input still works (baseline behavior)
+	s.Run("raw-20-bytes", func() {
+		var got eth.EIP55Addr
+		err := got.Unmarshal(expected.Bytes())
+		s.Require().NoError(err)
+		s.Equal(expected, got.Address)
+	})
 }

--- a/eth/eip55_test.go
+++ b/eth/eip55_test.go
@@ -231,3 +231,40 @@ func (s *EIP55AddrSuite) TestStringEncoding() {
 	s.Require().NoError(err)
 	s.Require().EqualValues(addrHex, newAddr.Hex())
 }
+
+// Ensure Unmarshal accepts ASCII hex strings (with/without 0x) in addition to raw 20 bytes.
+func (s *EIP55AddrSuite) TestUnmarshalAcceptsASCIIHexStrings() {
+    expected := gethcommon.HexToAddress("0xb45ad9d1cf36cb1a55cf5f781a791415846465d3")
+
+    for idx, input := range []string{
+        "0xb45ad9d1cf36cb1a55cf5f781a791415846465d3", // lower, with 0x
+        "b45ad9d1cf36cb1a55cf5f781a791415846465d3",   // lower, without 0x
+        "0xB45AD9D1CF36CB1A55CF5F781A791415846465D3", // upper, with 0x
+    } {
+        s.Run("ascii-hex-"+strconv.Itoa(idx), func() {
+            var got eth.EIP55Addr
+            // Pass the ASCII hex string bytes to Unmarshal, simulating a client
+            // that encoded the hex string directly in protobuf bytes.
+            err := got.Unmarshal([]byte(input))
+            s.Require().NoError(err)
+
+            s.Equal(expected, got.Address)
+
+            // Round-trip back to bytes should equal the raw 20 bytes
+            bz, err := got.Marshal()
+            s.Require().NoError(err)
+            s.Equal(expected.Bytes(), bz)
+
+            // Size should be exactly 20 bytes
+            s.Equal(20, got.Size())
+        })
+    }
+
+    // Raw 20-byte input still works (baseline behavior)
+    s.Run("raw-20-bytes", func() {
+        var got eth.EIP55Addr
+        err := got.Unmarshal(expected.Bytes())
+        s.Require().NoError(err)
+        s.Equal(expected, got.Address)
+    })
+}


### PR DESCRIPTION
Added functionality to the Unmarshal method of EIP55Addr to accept ASCII hex strings (with and without 0x prefix) in addition to raw 20-byte addresses. This improves robustness for clients that may pass hex strings directly. Added corresponding unit tests to validate the new behavior.