### PR TITLE
feat(tokenfactory-cli): add CLI commands for set denom functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ See https://github.com/dangoslen/changelog-enforcer.
 -->
 
 - [#2353](https://github.com/NibiruChain/nibiru/pull/2353) - refactor(oracle): remove dead code from asset registry 
+- [#2372](https://github.com/NibiruChain/nibiru/pull/2372) - feat(tokenfactory-cli): add CLI commands for set denom functions
 
 ### Dependencies
 - Bump `base-x` from 3.0.10 to 3.0.11 ([#2355](https://github.com/NibiruChain/nibiru/pull/2355))

--- a/cmd/nibid/cmd/base64.go
+++ b/cmd/nibid/cmd/base64.go
@@ -14,8 +14,8 @@ func GetBuildWasmMsg() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build-stargate-wasm [message data]",
 		Short: "Build wasm Stargate message in Base64",
-		Long: `This message is used to build a Cosmos SDK,
-	in the format used to be sent as a Stargate message in a CosmWasm transaction.`,
+		Long: `This message is used to build an sdk.Msg as a protobuf Any 
+	type for use as a Stargate message in a CosmWasm transaction.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)

--- a/x/evm/cli/cli_setup_test.go
+++ b/x/evm/cli/cli_setup_test.go
@@ -23,10 +23,8 @@ import (
 type Suite struct {
 	suite.Suite
 
-	keyring   keyring.Keyring
-	encCfg    testutilmod.TestEncodingConfig
-	baseCtx   sdkclient.Context
-	clientCtx sdkclient.Context
+	keyring keyring.Keyring
+	encCfg  testutilmod.TestEncodingConfig
 
 	testAcc sdktestutil.TestAccount
 }
@@ -34,17 +32,6 @@ type Suite struct {
 func (s *Suite) SetupSuite() {
 	s.encCfg = testutilmod.MakeTestEncodingConfig(evmmodule.AppModuleBasic{})
 	s.keyring = keyring.NewInMemory(s.encCfg.Codec)
-	s.baseCtx = sdkclient.Context{}.
-		WithKeyring(s.keyring).
-		WithTxConfig(s.encCfg.TxConfig).
-		WithCodec(s.encCfg.Codec).
-		WithClient(sdktestutilcli.MockTendermintRPC{Client: rpcclientmock.Client{}}).
-		WithAccountRetriever(sdkclient.MockAccountRetriever{}).
-		WithOutput(io.Discard).
-		WithChainID("test-chain")
-
-	s.clientCtx = s.baseCtx
-
 	testAccs := sdktestutil.CreateKeyringAccounts(s.T(), s.keyring, 1)
 	s.testAcc = testAccs[0]
 }
@@ -71,7 +58,14 @@ type TestCase struct {
 }
 
 func (tc TestCase) NewCtx(s *Suite) sdkclient.Context {
-	return s.baseCtx
+	return sdkclient.Context{}.
+		WithKeyring(s.keyring).
+		WithTxConfig(s.encCfg.TxConfig).
+		WithCodec(s.encCfg.Codec).
+		WithClient(sdktestutilcli.MockTendermintRPC{Client: rpcclientmock.Client{}}).
+		WithAccountRetriever(sdkclient.MockAccountRetriever{}).
+		WithOutput(io.Discard).
+		WithChainID("test-chain")
 }
 
 func (tc TestCase) RunTxCmd(s *Suite) {

--- a/x/tokenfactory/cli/tx.go
+++ b/x/tokenfactory/cli/tx.go
@@ -359,12 +359,35 @@ Examples:
 			if err != nil {
 				return err
 			}
+			isTemplate, _ := cmd.Flags().GetBool("template")
+			if isTemplate {
+				metadata := bank.Metadata{
+					Description: "A short description of the token",
+					Base:        "foodenom",
+					Name:        "Foo Token (template)",
+					Display:     "FOO",
+					Symbol:      "FOO",
+					DenomUnits: []*bank.DenomUnit{
+						{
+							Denom:    "foodenom",
+							Exponent: 0,
+						},
+						{
+							Denom:    "FOO - This exponent determines ERC20 decimals",
+							Exponent: 6,
+							Aliases:  []string{},
+						},
+					},
+				}
+				jsonBz, _ := json.MarshalIndent(metadata, "", "  ")
+				fmt.Println(string(jsonBz))
+				return nil
+			}
 
 			fileContents, err := parseMetadataFromFile(args[0])
 			if err != nil {
 				return err
 			}
-
 			msg := &types.MsgSudoSetDenomMetadata{
 				Sender:   clientCtx.GetFromAddress().String(),
 				Metadata: fileContents,

--- a/x/tokenfactory/cli/tx.go
+++ b/x/tokenfactory/cli/tx.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -9,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/spf13/cobra"
 
 	"github.com/NibiruChain/nibiru/v2/x/tokenfactory/types"
@@ -31,7 +34,8 @@ func NewTxCmd() *cobra.Command {
 		CmdMint(),
 		CmdBurn(),
 		CmdBurnNative(),
-		// CmdModifyDenomMetadata(), // CosmWasm only
+		CmdSetDenomMetadata(),
+		CmdSudoSetDenomMetadata(),
 	)
 
 	return cmd
@@ -250,4 +254,142 @@ $ nibid tx tokenfactory burn-native 100unibi
 	flags.AddTxFlagsToCmd(cmd)
 
 	return cmd
+}
+
+func CmdSetDenomMetadata() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: strings.TrimSpace(
+			`set-denom-metadata FILE [--template]
+		Arguments:
+		  FILE
+		         Name of a file containing new JSON metadata for the bank coin.
+		  [--template]
+		         Add this optional flag to create a template JSON file for new metadata.
+		Examples:
+		  nibid tx tokenfactory set-denom-metadata metadata.json
+		  nibid tx tokenfactory set-denom-metadata metadata.json --template
+		`),
+		Short: `Set bank coin metadata for a "tf/"-prefixed token as its admin`,
+		Long: strings.TrimSpace(`
+					Set bank coin metadata for a  Token Factory token ("tf/{creator}/{subdenom}") as its admin.
+		`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+			isTemplate, _ := cmd.Flags().GetBool("template")
+			if isTemplate {
+				metadata := bank.Metadata{
+					Description: "A short description of the token",
+					Base:        "foodenom",
+					Name:        "Foo Token (template)",
+					Display:     "FOO",
+					Symbol:      "FOO",
+					DenomUnits: []*bank.DenomUnit{
+						{
+							Denom:    "foodenom",
+							Exponent: 0,
+						},
+						{
+							Denom:    "FOO - This exponent determines ERC20 decimals",
+							Exponent: 6,
+							Aliases:  []string{},
+						},
+					},
+				}
+				jsonBz, _ := json.MarshalIndent(metadata, "", "  ")
+				fmt.Println(string(jsonBz))
+				return nil
+			}
+			fileContents, err := parseMetadataFromFile(args[0])
+			if err != nil {
+				return err
+			}
+			msg := &types.MsgSetDenomMetadata{
+				Sender:   clientCtx.GetFromAddress().String(),
+				Metadata: fileContents,
+			}
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	cmd.Flags().Bool("template", false, "Optional flag to create a template JSON file for new metadata")
+
+	return cmd
+}
+
+func CmdSudoSetDenomMetadata() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: strings.TrimSpace(
+			`sudo-set-denom-metadata FILE [--template]
+
+Arguments:
+  FILE
+         Name of a file containing new JSON metadata for the bank coin.
+  [--template]
+         Add this optional flag to create a template JSON file for new metadata.
+
+Examples:
+  nibid tx tokenfactory sudo-set-denom-metadata metadata.json
+  nibid tx tokenfactory sudo-set-denom-metadata metadata.json --template
+`),
+		Short: `Set bank coin metadata with x/sudo permissions. Usable for ICS20, ERC20, and "tf" tokens`,
+		Long: strings.TrimSpace(`
+Set bank coin metadata with x/sudo permissions.
+
+Arguments:
+  FILE
+         Name of a file containing new JSON metadata for the bank coin.
+  [--template]
+         Add this optional flag to create a template JSON file for new metadata.
+
+Examples:
+  nibid tx tokenfactory sudo-set-denom-metadata metadata.json
+  nibid tx tokenfactory sudo-set-denom-metadata metadata.json --template
+`),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			fileContents, err := parseMetadataFromFile(args[0])
+			if err != nil {
+				return err
+			}
+
+			msg := &types.MsgSudoSetDenomMetadata{
+				Sender:   clientCtx.GetFromAddress().String(),
+				Metadata: fileContents,
+			}
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	cmd.Flags().Bool("template", false, "Optional flag to create a template JSON file for new metadata")
+
+	return cmd
+}
+
+func parseMetadataFromFile(path string) (bank.Metadata, error) {
+	var md bank.Metadata
+	bz, err := os.ReadFile(path)
+	if err != nil {
+		return md, fmt.Errorf("read file %q: %w", path, err)
+	}
+	if err := json.Unmarshal(bz, &md); err != nil {
+		return md, fmt.Errorf("unmarshal %q as bank.Metadata: %w", path, err)
+	}
+	return md, nil
 }


### PR DESCRIPTION
# Purpose / Abstract

This change implements CLI commands for:
- "nibiru.tokenfactory.v1.MsgSetDenomMetadata"
- "nibiru.tokenfactory.v1.MsgSudoSetDenomMetadata"
- Related https://github.com/NibiruChain/nibiru/pull/2242

These are used with `nibid build-stargate-wasm` to get base64-encoded transaction
messages that can be used with a CW3 multisig as a "Stargate" message. By
Stargate, we're referring to the `CosmosMsg::Stargate` variant that is now called
`CosmosMsg::Any`, as of `cosmwasm_std` v2.

```rust
pub enum CosmosMsg<T = Empty> {
    // ...
    #[deprecated = "Use `CosmosMsg::Any` instead (if you only target CosmWasm 2+ chains)"]
    Stargate {
        type_url: String,
        value: Binary,
    },
    /// `CosmosMsg::Any` is the replaces the "stargate message" ΓÇô a message wrapped
    /// in a [protobuf Any](https://protobuf.dev/programming-guides/proto3/#any)
    /// that is suppored by the chain. It behaves the same as
    /// `CosmosMsg::Stargate` but has a better name and slightly improved syntax.
    ///
    /// This is feature-gated at compile time with `cosmwasm_2_0` because
    /// a chain running CosmWasm < 2.0 cannot process this.
    #[cfg(feature = "cosmwasm_2_0")]
    Any(AnyMsg),
    // ... 
}
```
