### PR TITLE
ci: fix high docker build disk space usage

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 permissions:
   contents: write
@@ -51,7 +52,6 @@ jobs:
           path: |
             go-build
             go-pkg
-            nibiru-temp
           key: ${{ runner.os }}-${{ runner.arch }}-nibid-docker-${{ hashFiles('go.sum') }}
 
       - name: Inject cache
@@ -60,8 +60,7 @@ jobs:
           cache-map: |
             {
               "go-build": "/root/.cache/go-build",
-              "go-pkg": "/go/pkg",
-              "nibiru-temp": "/nibiru/temp"
+              "go-pkg": "/go/pkg"
             }
           skip-extraction: ${{ steps.cache.outputs.cache-hit }}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds PR trigger to the Docker workflow and removes the `nibiru-temp` cache to reduce build cache footprint.
> 
> - **CI / GitHub Actions**
>   - **`/.github/workflows/docker-latest.yml`**:
>     - Add `pull_request` trigger alongside `push` to `main`.
>     - Streamline BuildKit cache: remove `nibiru-temp` from `actions/cache` paths and `cache-map`, keeping only `go-build` and `go-pkg`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f26d956ea04d43108d192a7c9caabda19b0a77f2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->