### PR TITLE
feat: upgrade v2.10

### DIFF
--- a/app/upgrades/all_upgrades.go
+++ b/app/upgrades/all_upgrades.go
@@ -44,6 +44,7 @@ var AllUpgrades = []Upgrade{
 	Upgrade2_7_0,
 	Upgrade2_8_0,
 	Upgrade2_9_0,
+	Upgrade2_10_0,
 }
 
 // DefaultUpgradeHandler runs module manager migrations without running any other

--- a/app/upgrades/v2.go
+++ b/app/upgrades/v2.go
@@ -135,4 +135,10 @@ var (
 		CreateUpgradeHandler: DefaultUpgradeHandler,
 		StoreUpgrades:        store.StoreUpgrades{},
 	}
+
+	Upgrade2_10_0 = Upgrade{
+		UpgradeName:          "v2.10.0",
+		CreateUpgradeHandler: DefaultUpgradeHandler,
+		StoreUpgrades:        store.StoreUpgrades{},
+	}
 )


### PR DESCRIPTION
This pull request adds support for a new upgrade version, v2.10.0, to the upgrade system. The main changes are the definition of the new upgrade and its inclusion in the list of all upgrades.

**Upgrade system updates:**

* Added a new `Upgrade2_10_0` definition for version "v2.10.0" in `app/upgrades/v2.go`
* Included `Upgrade2_10_0` in the `AllUpgrades` list in `app/upgrades/all_upgrades.go`