### PR TITLE
fix(internal/cosmos-sdk): resolve ledger error in tests using build tags

### DIFF
--- a/internal/cosmos-sdk/justfile
+++ b/internal/cosmos-sdk/justfile
@@ -13,10 +13,14 @@ gen-proto-go:
   fi
   echo "✅ SUCCESS: just gen-proto-go"
 
+# Run cosmos-sdk tests relevant to Nibiru
 test:
   #!/usr/bin/env bash
+  printf "\n\nRun tests - cosmos-sdk/types:\n"
+  go test ./types/... -tags='ledger test_ledger_mock'
+
+  printf "\n\nRun tests - cosmos-sdk/x:\n"
   go test ./x/...
+
+  printf "\n\nRun tests - cosmos-sdk/baseapp:\n"
   go test ./baseapp/...
-  # FIXME: Fails due to ledger error. This was not fixed in t# cosmos-sdk.
-  # We'll need to do it here in order to run the tests for the entire repo.
-  # go test ./types/... 

--- a/internal/cosmos-sdk/types/bech32/legacybech32/pk_test.go
+++ b/internal/cosmos-sdk/types/bech32/legacybech32/pk_test.go
@@ -11,6 +11,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// NOTE: This test requires the build tags for ledger devices.
+// In other words, you'd run something like
+// ```
+// go test ./types/... -tags='ledger test_ledger_mock'
+// ```
 func TestBeach32ifPbKey(t *testing.T) {
 	require := require.New(t)
 	path := *hd.NewFundraiserParams(0, sdk.CoinType, 0)


### PR DESCRIPTION
- Fixes https://github.com/NibiruChain/nibiru/issues/2450

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Test execution improvements**
> 
> - Adds `test` recipe in `internal/cosmos-sdk/justfile` to run `./types/...` with `-tags='ledger test_ledger_mock'`, then `./x/...` and `./baseapp/...`
> - Documents required build tags in `types/bech32/legacybech32/pk_test.go` so ledger-dependent tests run reliably
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b3b12706e045563f7c00396c028495907e736dc. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->