### PR TITLE
perf(justfile): Use default `-covermode` in Go tests for > 2x speedup

### DIFF
--- a/justfile
+++ b/justfile
@@ -208,7 +208,6 @@ test-cover:
   go test ./... \
     -tags=pebbledb \
     -coverprofile=coverage.out \
-    -covermode=atomic \
     -count=1
   go tool cover -func=coverage.out
 


### PR DESCRIPTION
Removed `-covermode=atomic` from `just test-cover`; `-count=1` was already there and is still there.

Speed test results with the existing localnet:

- Before: `371.80s` with `-covermode=atomic`
- After: `165.56s` with no explicit `-covermode`
- Improvement: about `206s` faster, roughly `2.25x` speedup

The generated `coverage.out` now starts with:

```text
mode: set
```

Go defaults to `-covermode=set` when the flag is not specified.
