### PR TITLE
chore: remove stale pricefeeder references (#2587)

### DIFF
--- a/api/nibiru/oracle/v1/tx_grpc.pb.go
+++ b/api/nibiru/oracle/v1/tx_grpc.pb.go
@@ -30,7 +30,7 @@ type MsgClient interface {
 	AggregateExchangeRateVote(ctx context.Context, in *MsgAggregateExchangeRateVote, opts ...grpc.CallOption) (*MsgAggregateExchangeRateVoteResponse, error)
 	// DelegateFeedConsent defines a method for delegating oracle voting rights
 	// to another address known as a price feeder.
-	// See https://github.com/NibiruChain/pricefeeder.
+	// Deprecated: x/oracle Msg RPCs are disabled on-chain (ErrOracleDeprecated).
 	DelegateFeedConsent(ctx context.Context, in *MsgDelegateFeedConsent, opts ...grpc.CallOption) (*MsgDelegateFeedConsentResponse, error)
 	EditOracleParams(ctx context.Context, in *MsgEditOracleParams, opts ...grpc.CallOption) (*MsgEditOracleParamsResponse, error)
 }
@@ -91,7 +91,7 @@ type MsgServer interface {
 	AggregateExchangeRateVote(context.Context, *MsgAggregateExchangeRateVote) (*MsgAggregateExchangeRateVoteResponse, error)
 	// DelegateFeedConsent defines a method for delegating oracle voting rights
 	// to another address known as a price feeder.
-	// See https://github.com/NibiruChain/pricefeeder.
+	// Deprecated: x/oracle Msg RPCs are disabled on-chain (ErrOracleDeprecated).
 	DelegateFeedConsent(context.Context, *MsgDelegateFeedConsent) (*MsgDelegateFeedConsentResponse, error)
 	EditOracleParams(context.Context, *MsgEditOracleParams) (*MsgEditOracleParamsResponse, error)
 	mustEmbedUnimplementedMsgServer()

--- a/contrib/docker-compose/README.md
+++ b/contrib/docker-compose/README.md
@@ -3,13 +3,12 @@
 - [contrib/docker-compose](#contribdocker-compose)
   - [docker-compose-chaosnet](#docker-compose-chaosnet)
   - [Usage](#usage)
-    - [Single validator node + pricefeeder](#single-validator-node--pricefeeder)
-    - [Two validator nodes + pricefeeder + IBC relayer](#two-validator-nodes--pricefeeder--ibc-relayer)
+    - [Single validator node](#single-validator-node)
+    - [Two validator nodes + IBC relayer](#two-validator-nodes--ibc-relayer)
     - [Single validator node + heartmonitor](#single-validator-node--heartmonitor)
     - [Other Commands](#other-commands)
   - [Services Overview](#services-overview)
     - [Nibiru node services](#nibiru-node-services)
-    - [Pricefeeder services](#pricefeeder-services)
     - [Hermes IBC relayer services](#hermes-ibc-relayer-services)
     - [Heart Monitor Services](#heart-monitor-services)
   - [Reference Materials](#reference-materials)
@@ -28,13 +27,13 @@ Features:
 
 ## Usage
 
-### Single validator node + pricefeeder
+### Single validator node
 
 ```sh
 docker compose -f docker-compose-chaosnet.yml up
 ```
 
-### Two validator nodes + pricefeeder + IBC relayer
+### Two validator nodes + IBC relayer
 
 ```sh
 docker compose -f docker-compose-chaosnet.yml --profile ibc up 
@@ -61,11 +60,6 @@ docker compose -f docker-compose-chaosnet.yml --profile heartmonitor up
 - `nibiru-0` and `nibiru-1` (Service): Represents two distinct Nibiru Chain nodes (nibiru-0 and nibiru-1)
   running on different ports, using unique mnemonics and chain IDs, imitating two
   independent blockchain networks.
-
-### Pricefeeder services
-
-- `pricefeeder-0` and `pricefeeder-1` (Service): Two price feeder services that push price
-  data to the respective Nibiru nodes.
 
 ### Hermes IBC relayer services
 

--- a/contrib/make/chaosnet.mk
+++ b/contrib/make/chaosnet.mk
@@ -37,10 +37,6 @@ chaosnet-down:
 chaosnet-logs:
 	docker compose -f ./contrib/docker-compose/docker-compose-chaosnet.yml logs
 
-.PHONY: chaosnet-logs-pricefeeder
-chaosnet-logs-pricefeeder:
-	docker compose -f ./contrib/docker-compose/docker-compose-chaosnet.yml logs pricefeeder --follow
-
 .PHONY: chaosnet-logs-go-heartmonitor
 chaosnet-logs-go-heartmonitor:
 	docker compose -f ./contrib/docker-compose/docker-compose-chaosnet.yml logs go-heartmonitor

--- a/contrib/scripts/localnet.sh
+++ b/contrib/scripts/localnet.sh
@@ -286,7 +286,7 @@ cat >"$WNIBI_EVM_GENESIS_JSON" <<'EOF'
 EOF
 add_genesis_param_slurpfile '.app_state.evm.accounts += $wnibi_evm' "wnibi_evm" "$WNIBI_EVM_GENESIS_JSON"
 
-# hack for localnet since we don't have a pricefeeder yet
+# Static oracle exchange rates in genesis for local development and tests.
 price_btc="50000"
 price_eth="2000"
 add_genesis_param '.app_state.oracle.exchange_rates[0].pair = "ubtc:uusd"'

--- a/proto/nibiru/oracle/v1/tx.proto
+++ b/proto/nibiru/oracle/v1/tx.proto
@@ -25,7 +25,7 @@ service Msg {
 
   // DelegateFeedConsent defines a method for delegating oracle voting rights
   // to another address known as a price feeder.
-  // See https://github.com/NibiruChain/pricefeeder.
+  // Deprecated: x/oracle Msg RPCs are disabled on-chain (ErrOracleDeprecated).
   rpc DelegateFeedConsent(MsgDelegateFeedConsent) returns (MsgDelegateFeedConsentResponse) {
     option (google.api.http).post = "/nibiru/oracle/feeder-delegate";
   }

--- a/x/nutil/denoms/denoms.go
+++ b/x/nutil/denoms/denoms.go
@@ -5,7 +5,6 @@ const (
 	// NOTE: US dollars. Use `denoms.USD` instead of `denoms.UUSD` going forward.
 	USD = "usd"
 	// Avalon Finance overcollateralized stablecoin.
-	// https://github.com/NibiruChain/pricefeeder/pull/64
 	USDA  = "usda"
 	SUSDA = "susda"
 )

--- a/x/oracle/types/tx.pb.go
+++ b/x/oracle/types/tx.pb.go
@@ -658,7 +658,7 @@ type MsgClient interface {
 	AggregateExchangeRateVote(ctx context.Context, in *MsgAggregateExchangeRateVote, opts ...grpc.CallOption) (*MsgAggregateExchangeRateVoteResponse, error)
 	// DelegateFeedConsent defines a method for delegating oracle voting rights
 	// to another address known as a price feeder.
-	// See https://github.com/NibiruChain/pricefeeder.
+	// Deprecated: x/oracle Msg RPCs are disabled on-chain (ErrOracleDeprecated).
 	DelegateFeedConsent(ctx context.Context, in *MsgDelegateFeedConsent, opts ...grpc.CallOption) (*MsgDelegateFeedConsentResponse, error)
 	EditOracleParams(ctx context.Context, in *MsgEditOracleParams, opts ...grpc.CallOption) (*MsgEditOracleParamsResponse, error)
 }
@@ -717,7 +717,7 @@ type MsgServer interface {
 	AggregateExchangeRateVote(context.Context, *MsgAggregateExchangeRateVote) (*MsgAggregateExchangeRateVoteResponse, error)
 	// DelegateFeedConsent defines a method for delegating oracle voting rights
 	// to another address known as a price feeder.
-	// See https://github.com/NibiruChain/pricefeeder.
+	// Deprecated: x/oracle Msg RPCs are disabled on-chain (ErrOracleDeprecated).
 	DelegateFeedConsent(context.Context, *MsgDelegateFeedConsent) (*MsgDelegateFeedConsentResponse, error)
 	EditOracleParams(context.Context, *MsgEditOracleParams) (*MsgEditOracleParamsResponse, error)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleans up dead links and tooling left over from the retired standalone pricefeeder repository, as requested in #2587. On-chain oracle Msg handlers are already disabled; this change is documentation and operator-facing cleanup only.

## Changes

- **Proto / generated Go:** Replaced the dead `github.com/NibiruChain/pricefeeder` link on `DelegateFeedConsent` with a short deprecation note aligned with `ErrOracleDeprecated`. Regenerated bindings with `just gen-proto` (covers `x/oracle/types` and `api/nibiru/oracle/v1/tx_grpc.pb.go`).

- **`x/nutil/denoms/denoms.go`:** Removed the obsolete pricefeeder PR link; kept the USDA description.

- **`contrib/scripts/localnet.sh`:** Reworded the genesis oracle rate comment to describe static seeding for local dev instead of referencing pricefeeder.

- **`contrib/make/chaosnet.mk`:** Removed `chaosnet-logs-pricefeeder` (no `pricefeeder` service in `docker-compose-chaosnet.yml`).

- **`contrib/docker-compose/README.md`:** Dropped TOC and sections for non-existent pricefeeder services; usage headings now match the compose file.

## Verification

- `just gen-proto` and `just fmt` were run successfully after installing Docker (`dockerd` with `--iptables=false --storage-driver=vfs` in this nested environment) and `just` from apt; `gofumpt` installed via `go install`.

Closes #2587
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nibiruchain.slack.com/archives/D0AVA20J2K0/p1778968031195179?thread_ts=1778968031.195179&cid=D0AVA20J2K0)

<div><a href="https://cursor.com/agents/bc-f38fcaa9-5b9c-5c1c-8d42-8ce4673b9345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f38fcaa9-5b9c-5c1c-8d42-8ce4673b9345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

