### PR TITLE
fix(collections): return errors for invalid Int key encoding (#2491)

### DIFF
--- a/eth/state_encoder.go
+++ b/eth/state_encoder.go
@@ -33,24 +33,24 @@ var (
 // collections ValueEncoder[[]byte]
 type veBytes struct{}
 
-func (veBytes) Encode(value []byte) []byte    { return value }
-func (veBytes) Decode(bz []byte) []byte       { return bz }
-func (veBytes) Stringify(value []byte) string { return BytesToHex(value) }
-func (veBytes) Name() string                  { return "[]byte" }
+func (veBytes) Encode(value []byte) ([]byte, error) { return value, nil }
+func (veBytes) Decode(bz []byte) []byte             { return bz }
+func (veBytes) Stringify(value []byte) string       { return BytesToHex(value) }
+func (veBytes) Name() string                        { return "[]byte" }
 
 // veEthAddr: Implements a `collections.ValueEncoder` for an Ethereum address.
 type veEthAddr struct{}
 
-func (veEthAddr) Encode(value gethcommon.Address) []byte    { return value.Bytes() }
-func (veEthAddr) Decode(bz []byte) gethcommon.Address       { return gethcommon.BytesToAddress(bz) }
-func (veEthAddr) Stringify(value gethcommon.Address) string { return value.Hex() }
-func (veEthAddr) Name() string                              { return "gethcommon.Address" }
+func (veEthAddr) Encode(value gethcommon.Address) ([]byte, error) { return value.Bytes(), nil }
+func (veEthAddr) Decode(bz []byte) gethcommon.Address             { return gethcommon.BytesToAddress(bz) }
+func (veEthAddr) Stringify(value gethcommon.Address) string       { return value.Hex() }
+func (veEthAddr) Name() string                                    { return "gethcommon.Address" }
 
 // keBytes: Implements a `collections.KeyEncoder` for raw bytes.
 type keBytes struct{}
 
 // Encode encodes the type T into bytes.
-func (keBytes) Encode(key []byte) []byte { return key }
+func (keBytes) Encode(key []byte) ([]byte, error) { return key, nil }
 
 // Decode decodes the given bytes back into T.
 // And it also must return the bytes of the buffer which were read.
@@ -62,7 +62,7 @@ func (keBytes) Stringify(key []byte) string { return BytesToHex(key) }
 // keEthAddr: Implements a `collections.KeyEncoder` for an Ethereum address.
 type keEthAddr struct{}
 
-func (keEthAddr) Encode(value gethcommon.Address) []byte { return value.Bytes() }
+func (keEthAddr) Encode(value gethcommon.Address) ([]byte, error) { return value.Bytes(), nil }
 func (keEthAddr) Decode(bz []byte) (int, gethcommon.Address) {
 	return gethcommon.AddressLength, gethcommon.BytesToAddress(bz[:gethcommon.AddressLength])
 }
@@ -71,7 +71,7 @@ func (keEthAddr) Stringify(value gethcommon.Address) string { return value.Hex()
 // keEthHash: Implements a `collections.KeyEncoder` for an Ethereum hash.
 type keEthHash struct{}
 
-func (keEthHash) Encode(value gethcommon.Hash) []byte { return value.Bytes() }
+func (keEthHash) Encode(value gethcommon.Hash) ([]byte, error) { return value.Bytes(), nil }
 func (keEthHash) Decode(bz []byte) (int, gethcommon.Hash) {
 	return gethcommon.HashLength, gethcommon.BytesToHash(bz)
 }
@@ -85,12 +85,12 @@ type veSignedInt struct{}
 
 // Encode encodes the value T into bytes.
 // Encode(value T) []byte
-func (veSignedInt) Encode(v sdkmath.Int) []byte {
+func (veSignedInt) Encode(v sdkmath.Int) ([]byte, error) {
 	bz, err := v.Marshal()
 	if err != nil {
-		panic(fmt.Errorf("invalid math.Int %s: %w", v, err))
+		return nil, fmt.Errorf("invalid math.Int %s: %w", v, err)
 	}
-	return bz
+	return bz, nil
 }
 
 // Decode returns the type T given its bytes representation.

--- a/eth/state_encoder_test.go
+++ b/eth/state_encoder_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func assertBijectiveKey[T any](t *testing.T, encoder collections.KeyEncoder[T], key T) {
-	encodedKey := encoder.Encode(key)
+	encodedKey, err := encoder.Encode(key)
+	require.NoError(t, err)
 	readLen, decodedKey := encoder.Decode(encodedKey)
 	require.Equal(t, len(encodedKey), readLen, "encoded key and read bytes must have same size")
 	require.Equal(t, key, decodedKey, "encoding and decoding produces different keys")
@@ -23,7 +24,8 @@ func assertBijectiveKey[T any](t *testing.T, encoder collections.KeyEncoder[T], 
 }
 
 func assertBijectiveValue[T any](t *testing.T, encoder collections.ValueEncoder[T], value T) {
-	encodedValue := encoder.Encode(value)
+	encodedValue, err := encoder.Encode(value)
+	require.NoError(t, err)
 	decodedValue := encoder.Decode(encodedValue)
 	require.Equal(t, value, decodedValue, "encoding and decoding produces different values")
 

--- a/x/collections/collections.go
+++ b/x/collections/collections.go
@@ -7,6 +7,16 @@ import (
 // ErrNotFound is returned when an object is not found.
 var ErrNotFound = errors.New("collections: not found")
 
+// ErrNilIntKey is returned when encoding a nil [cosmossdk.io/math.Int] as a key or value.
+var ErrNilIntKey = errors.New("collections: cannot encode nil math.Int")
+
+// ErrNegativeIntKey is returned when encoding a negative [cosmossdk.io/math.Int] as a
+// lexicographic collection key (unsigned padded encoding).
+var ErrNegativeIntKey = errors.New("collections: cannot encode negative math.Int")
+
+// ErrEmptyPairKey is returned when encoding an empty Pair (both sides nil).
+var ErrEmptyPairKey = errors.New("collections: empty Pair key")
+
 // Namespace defines a storage namespace which must be unique in a single module
 // for all the different storage layer types: Map, Sequence, KeySet, Item, MultiIndex, IndexedMap
 type Namespace uint8
@@ -17,7 +27,7 @@ func (n Namespace) Prefix() []byte { return []byte{uint8(n)} }
 // by types that are capable of encoding and decoding collections keys.
 type KeyEncoder[T any] interface {
 	// Encode encodes the type T into bytes.
-	Encode(key T) []byte
+	Encode(key T) ([]byte, error)
 	// Decode decodes the given bytes back into T.
 	// And it also must return the bytes of the buffer which were read.
 	Decode(b []byte) (int, T)
@@ -29,7 +39,7 @@ type KeyEncoder[T any] interface {
 // by types that are capable of encoding and decoding collection values.
 type ValueEncoder[T any] interface {
 	// Encode encodes the value T into bytes.
-	Encode(value T) []byte
+	Encode(value T) ([]byte, error)
 	// Decode returns the type T given its bytes representation.
 	Decode(b []byte) T
 	// Stringify returns a string representation of T.

--- a/x/collections/indexed_map.go
+++ b/x/collections/indexed_map.go
@@ -1,6 +1,8 @@
 package collections
 
 import (
+	"errors"
+
 	"github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -22,11 +24,11 @@ type Indexer[PK any, V any] interface {
 	// an object into its state, so the Indexer here
 	// creates the relationship between primary key
 	// and the fields of the object V.
-	Insert(ctx sdk.Context, primaryKey PK, v V)
+	Insert(ctx sdk.Context, primaryKey PK, v V) error
 	// Delete is called when the IndexedMap is removing
 	// the object V and hence the relationship between
 	// V and its primary keys need to be removed too.
-	Delete(ctx sdk.Context, primaryKey PK, v V)
+	Delete(ctx sdk.Context, primaryKey PK, v V) error
 }
 
 // NewIndexedMap instantiates a new IndexedMap instance.
@@ -64,16 +66,21 @@ func (i IndexedMap[PK, V, I]) GetOr(ctx sdk.Context, key PK, def V) V {
 // Insert inserts the object v into the Map using the primary key, then
 // iterates over every registered Indexer and instructs them to create
 // the relationship between the primary key PK and the object v.
-func (i IndexedMap[PK, V, I]) Insert(ctx sdk.Context, key PK, v V) {
+func (i IndexedMap[PK, V, I]) Insert(ctx sdk.Context, key PK, v V) error {
 	// before inserting we need to assert if another instance of this
 	// primary key exist in order to remove old relationships from indexes.
 	old, err := i.m.Get(ctx, key)
 	if err == nil {
-		i.unindex(ctx, key, old)
+		if err := i.unindex(ctx, key, old); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, ErrNotFound) {
+		return err
 	}
-	// insert and index
-	i.m.Insert(ctx, key, v)
-	i.index(ctx, key, v)
+	if err := i.m.Insert(ctx, key, v); err != nil {
+		return err
+	}
+	return i.index(ctx, key, v)
 }
 
 // Delete fetches the object from the Map removes it from the Map
@@ -90,7 +97,9 @@ func (i IndexedMap[PK, V, I]) Delete(ctx sdk.Context, key PK) error {
 		// this must never happen
 		panic(err)
 	}
-	i.unindex(ctx, key, v)
+	if err := i.unindex(ctx, key, v); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -115,14 +124,20 @@ func (i IndexedMap[PK, V, I]) Collect(ctx sdk.Context, iter interface{ PrimaryKe
 	return vs
 }
 
-func (i IndexedMap[PK, V, I]) index(ctx sdk.Context, key PK, v V) {
+func (i IndexedMap[PK, V, I]) index(ctx sdk.Context, key PK, v V) error {
 	for _, indexer := range i.Indexes.IndexerList() {
-		indexer.Insert(ctx, key, v)
+		if err := indexer.Insert(ctx, key, v); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-func (i IndexedMap[PK, V, I]) unindex(ctx sdk.Context, key PK, v V) {
+func (i IndexedMap[PK, V, I]) unindex(ctx sdk.Context, key PK, v V) error {
 	for _, indexer := range i.Indexes.IndexerList() {
-		indexer.Delete(ctx, key, v)
+		if err := indexer.Delete(ctx, key, v); err != nil {
+			return err
+		}
 	}
+	return nil
 }

--- a/x/collections/indexed_map_test.go
+++ b/x/collections/indexed_map_test.go
@@ -33,9 +33,9 @@ func TestIndexedMap(t *testing.T) {
 		},
 	)
 
-	m.Insert(ctx, 0, person{ID: 0, City: "milan"})
-	m.Insert(ctx, 1, person{ID: 1, City: "new york"})
-	m.Insert(ctx, 2, person{ID: 2, City: "milan"})
+	require.NoError(t, m.Insert(ctx, 0, person{ID: 0, City: "milan"}))
+	require.NoError(t, m.Insert(ctx, 1, person{ID: 1, City: "new york"}))
+	require.NoError(t, m.Insert(ctx, 2, person{ID: 2, City: "milan"}))
 
 	// correct insertion
 	res := m.Indexes.City.ExactMatch(ctx, "milan").PrimaryKeys()
@@ -55,7 +55,7 @@ func TestIndexedMap(t *testing.T) {
 	// insertion on an already existing primary key
 	// clears the old indexes, hence PK 2 => city "milan"
 	// is now converted to PK 2 => city "new york"
-	m.Insert(ctx, 2, person{ID: 2, City: "new york"})
+	require.NoError(t, m.Insert(ctx, 2, person{ID: 2, City: "new york"}))
 	require.Empty(t, m.Indexes.City.ExactMatch(ctx, "milan").PrimaryKeys())
 	res = m.Indexes.City.ExactMatch(ctx, "new york").PrimaryKeys()
 	require.Equal(t, []uint64{1, 2}, res)

--- a/x/collections/indexers.go
+++ b/x/collections/indexers.go
@@ -72,15 +72,15 @@ type MultiIndex[IK, PK, V any] struct {
 }
 
 // Insert implements the Indexer interface.
-func (i MultiIndex[IK, PK, V]) Insert(ctx sdk.Context, pk PK, v V) {
+func (i MultiIndex[IK, PK, V]) Insert(ctx sdk.Context, pk PK, v V) error {
 	indexingKey := i.getIndexingKey(v)
-	i.jointKeys.Insert(ctx, Join(indexingKey, pk))
+	return i.jointKeys.Insert(ctx, Join(indexingKey, pk))
 }
 
 // Delete implements the Indexer interface.
-func (i MultiIndex[IK, PK, V]) Delete(ctx sdk.Context, pk PK, v V) {
+func (i MultiIndex[IK, PK, V]) Delete(ctx sdk.Context, pk PK, v V) error {
 	indexingKey := i.getIndexingKey(v)
-	i.jointKeys.Delete(ctx, Join(indexingKey, pk))
+	return i.jointKeys.Delete(ctx, Join(indexingKey, pk))
 }
 
 // Iterate iterates over the provided range.

--- a/x/collections/indexers_test.go
+++ b/x/collections/indexers_test.go
@@ -31,7 +31,7 @@ func TestMultiIndex(t *testing.T) {
 	}
 
 	for _, p := range persons {
-		im.Insert(ctx, p.ID, p)
+		require.NoError(t, im.Insert(ctx, p.ID, p))
 	}
 
 	// test iterations and matches alongside PrimaryKeys ( and indirectly FullKeys )
@@ -42,7 +42,7 @@ func TestMultiIndex(t *testing.T) {
 	ks = im.ReverseExactMatch(ctx, "milan").PrimaryKeys()
 	require.Equal(t, []uint64{1, 0}, ks)
 	// test after removal it is not present
-	im.Delete(ctx, persons[0].ID, persons[0])
+	require.NoError(t, im.Delete(ctx, persons[0].ID, persons[0]))
 	ks = im.ExactMatch(ctx, "milan").PrimaryKeys()
 	require.Equal(t, []uint64{1}, ks)
 
@@ -62,8 +62,8 @@ func TestIndexerIterator(t *testing.T) {
 		func(v person) string { return v.City },
 	)
 
-	im.Insert(ctx, 0, person{ID: 0, City: "milan"})
-	im.Insert(ctx, 1, person{ID: 1, City: "milan"})
+	require.NoError(t, im.Insert(ctx, 0, person{ID: 0, City: "milan"}))
+	require.NoError(t, im.Insert(ctx, 1, person{ID: 1, City: "milan"}))
 
 	iter := im.Iterate(ctx, PairRange[string, uint64]{})
 	defer iter.Close()

--- a/x/collections/item.go
+++ b/x/collections/item.go
@@ -31,7 +31,9 @@ func (i Item[V]) Get(ctx sdk.Context) (V, error) { return (Map[uint64, V])(i).Ge
 func (i Item[V]) GetOr(ctx sdk.Context, def V) V { return (Map[uint64, V])(i).GetOr(ctx, itemKey, def) }
 
 // Set sets the item value to v.
-func (i Item[V]) Set(ctx sdk.Context, v V) { (Map[uint64, V])(i).Insert(ctx, itemKey, v) }
+func (i Item[V]) Set(ctx sdk.Context, v V) error {
+	return (Map[uint64, V])(i).Insert(ctx, itemKey, v)
+}
 
 // NewItem instantiates a new Item instance.
 func NewItemTransient[V any](
@@ -64,6 +66,6 @@ func (i ItemTransient[V]) GetOr(ctx sdk.Context, def V) V {
 }
 
 // Set sets the item value to v.
-func (i ItemTransient[V]) Set(ctx sdk.Context, v V) {
-	(MapTransient[uint64, V])(i).Insert(ctx, itemKey, v)
+func (i ItemTransient[V]) Set(ctx sdk.Context, v V) error {
+	return (MapTransient[uint64, V])(i).Insert(ctx, itemKey, v)
 }

--- a/x/collections/iter.go
+++ b/x/collections/iter.go
@@ -105,15 +105,31 @@ func (r Range[K]) RangeValues() (prefix *K, start *Bound[K], end *Bound[K], orde
 
 // iteratorFromRange generates an Iterator instance, with the proper prefixing and ranging.
 func iteratorFromRange[K, V any](s sdk.KVStore, r Ranger[K], kc KeyEncoder[K], vc ValueEncoder[V]) Iterator[K, V] {
+	iter, err := tryIteratorFromRange(s, r, kc, vc)
+	if err != nil {
+		panic(err)
+	}
+	return iter
+}
+
+func tryIteratorFromRange[K, V any](s sdk.KVStore, r Ranger[K], kc KeyEncoder[K], vc ValueEncoder[V]) (Iterator[K, V], error) {
 	pfx, start, end, order := r.RangeValues()
 	var prefixBytes []byte
 	if pfx != nil {
-		prefixBytes = kc.Encode(*pfx)
+		var err error
+		prefixBytes, err = kc.Encode(*pfx)
+		if err != nil {
+			return Iterator[K, V]{}, err
+		}
 		s = prefix.NewStore(s, prefixBytes)
 	}
 	var startBytes []byte // default is nil
 	if start != nil {
-		startBytes = kc.Encode(start.value)
+		sb, err := kc.Encode(start.value)
+		if err != nil {
+			return Iterator[K, V]{}, err
+		}
+		startBytes = sb
 		// iterators are inclusive at start by default
 		// so if we want to make the iteration exclusive
 		// we extend by one byte.
@@ -123,7 +139,11 @@ func iteratorFromRange[K, V any](s sdk.KVStore, r Ranger[K], kc KeyEncoder[K], v
 	}
 	var endBytes []byte // default is nil
 	if end != nil {
-		endBytes = kc.Encode(end.value)
+		eb, err := kc.Encode(end.value)
+		if err != nil {
+			return Iterator[K, V]{}, err
+		}
+		endBytes = eb
 		// iterators are exclusive at end by default
 		// so if we want to make the iteration
 		// inclusive we need to extend by one byte.
@@ -139,7 +159,7 @@ func iteratorFromRange[K, V any](s sdk.KVStore, r Ranger[K], kc KeyEncoder[K], v
 	case OrderDescending:
 		iter = s.ReverseIterator(startBytes, endBytes)
 	default:
-		panic(fmt.Errorf("unrecognized Order: %v", order))
+		return Iterator[K, V]{}, fmt.Errorf("unrecognized Order: %v", order)
 	}
 
 	return Iterator[K, V]{
@@ -147,7 +167,7 @@ func iteratorFromRange[K, V any](s sdk.KVStore, r Ranger[K], kc KeyEncoder[K], v
 		vc:          vc,
 		iter:        iter,
 		prefixBytes: prefixBytes,
-	}
+	}, nil
 }
 
 // Iterator defines a generic wrapper around an sdk.Iterator.

--- a/x/collections/iter_test.go
+++ b/x/collections/iter_test.go
@@ -11,12 +11,12 @@ func TestRangeBounds(t *testing.T) {
 
 	ks := NewKeySet[uint64](sk, 0, Uint64KeyEncoder)
 
-	ks.Insert(ctx, 1)
-	ks.Insert(ctx, 2)
-	ks.Insert(ctx, 3)
-	ks.Insert(ctx, 4)
-	ks.Insert(ctx, 5)
-	ks.Insert(ctx, 6)
+	require.NoError(t, ks.Insert(ctx, 1))
+	require.NoError(t, ks.Insert(ctx, 2))
+	require.NoError(t, ks.Insert(ctx, 3))
+	require.NoError(t, ks.Insert(ctx, 4))
+	require.NoError(t, ks.Insert(ctx, 5))
+	require.NoError(t, ks.Insert(ctx, 6))
 
 	// let's range (1-5]; expected: 2..5
 	result := ks.Iterate(ctx, Range[uint64]{}.StartExclusive(1).EndInclusive(5)).Keys()

--- a/x/collections/keys.go
+++ b/x/collections/keys.go
@@ -27,11 +27,11 @@ var (
 
 type stringKey struct{}
 
-func (stringKey) Encode(s string) []byte {
+func (stringKey) Encode(s string) ([]byte, error) {
 	if err := validString(s); err != nil {
-		panic(fmt.Errorf("invalid StringKey: %w", err))
+		return nil, fmt.Errorf("collections: invalid StringKey: %w", err)
 	}
-	return append([]byte(s), 0) // null terminate it for safe prefixing
+	return append([]byte(s), 0), nil // null terminate it for safe prefixing
 }
 
 func (stringKey) Decode(b []byte) (int, string) {
@@ -51,14 +51,14 @@ func (stringKey) Decode(b []byte) (int, string) {
 
 type uint64Key struct{}
 
-func (uint64Key) Stringify(u uint64) string     { return strconv.FormatUint(u, 10) }
-func (uint64Key) Encode(u uint64) []byte        { return sdk.Uint64ToBigEndian(u) }
-func (uint64Key) Decode(b []byte) (int, uint64) { return 8, sdk.BigEndianToUint64(b) }
+func (uint64Key) Stringify(u uint64) string       { return strconv.FormatUint(u, 10) }
+func (uint64Key) Encode(u uint64) ([]byte, error) { return sdk.Uint64ToBigEndian(u), nil }
+func (uint64Key) Decode(b []byte) (int, uint64)   { return 8, sdk.BigEndianToUint64(b) }
 
 type timeKey struct{}
 
-func (timeKey) Stringify(t time.Time) string { return t.String() }
-func (timeKey) Encode(t time.Time) []byte    { return sdk.FormatTimeBytes(t) }
+func (timeKey) Stringify(t time.Time) string       { return t.String() }
+func (timeKey) Encode(t time.Time) ([]byte, error) { return sdk.FormatTimeBytes(t), nil }
 func (timeKey) Decode(b []byte) (int, time.Time) {
 	t, err := sdk.ParseTimeBytes(b)
 	if err != nil {
@@ -70,7 +70,7 @@ func (timeKey) Decode(b []byte) (int, time.Time) {
 type accAddressKey struct{}
 
 func (accAddressKey) Stringify(addr sdk.AccAddress) string { return addr.String() }
-func (accAddressKey) Encode(addr sdk.AccAddress) []byte {
+func (accAddressKey) Encode(addr sdk.AccAddress) ([]byte, error) {
 	return StringKeyEncoder.Encode(addr.String())
 }
 
@@ -81,7 +81,7 @@ func (accAddressKey) Decode(b []byte) (int, sdk.AccAddress) {
 
 type valAddressKeyEncoder struct{}
 
-func (v valAddressKeyEncoder) Encode(key sdk.ValAddress) []byte {
+func (v valAddressKeyEncoder) Encode(key sdk.ValAddress) ([]byte, error) {
 	return StringKeyEncoder.Encode(key.String())
 }
 
@@ -110,7 +110,7 @@ func validString(s string) error {
 
 type consAddressKeyEncoder struct{}
 
-func (consAddressKeyEncoder) Encode(key sdk.ConsAddress) []byte {
+func (consAddressKeyEncoder) Encode(key sdk.ConsAddress) ([]byte, error) {
 	return StringKeyEncoder.Encode(key.String())
 }
 
@@ -128,12 +128,12 @@ type sdkDecKeyEncoder struct{}
 
 func (sdkDecKeyEncoder) Stringify(key sdk.Dec) string { return key.String() }
 
-func (sdkDecKeyEncoder) Encode(key sdk.Dec) []byte {
+func (sdkDecKeyEncoder) Encode(key sdk.Dec) ([]byte, error) {
 	bz, err := key.Marshal()
 	if err != nil {
-		panic(fmt.Errorf("invalid DecKey: %w %s", err, HumanizeBytes(bz)))
+		return nil, fmt.Errorf("collections: invalid DecKey: %w%s", err, HumanizeBytes(bz))
 	}
-	return bz
+	return bz, nil
 }
 
 func (sdkDecKeyEncoder) Decode(b []byte) (int, sdk.Dec) {

--- a/x/collections/keys_pair.go
+++ b/x/collections/keys_pair.go
@@ -42,16 +42,23 @@ func (p pairKeyEncoder[K1, K2]) Stringify(key Pair[K1, K2]) string {
 // Encode encodes the Pair.
 // If both parts of the keys are present, then the byte version of K1 and K2 are joined together.
 // If only the first part is present then
-func (p pairKeyEncoder[K1, K2]) Encode(key Pair[K1, K2]) []byte {
+func (p pairKeyEncoder[K1, K2]) Encode(key Pair[K1, K2]) ([]byte, error) {
 	if key.k1 != nil && key.k2 != nil {
-		return append(p.kc1.Encode(*key.k1), p.kc2.Encode(*key.k2)...)
+		b1, err := p.kc1.Encode(*key.k1)
+		if err != nil {
+			return nil, err
+		}
+		b2, err := p.kc2.Encode(*key.k2)
+		if err != nil {
+			return nil, err
+		}
+		return append(b1, b2...), nil
 	} else if key.k1 != nil && key.k2 == nil {
 		return p.kc1.Encode(*key.k1)
 	} else if key.k1 == nil && key.k2 != nil {
 		return p.kc2.Encode(*key.k2)
-	} else {
-		panic("empty Pair key")
 	}
+	return nil, ErrEmptyPairKey
 }
 
 // Decode decodes the Pair. It assumes that the provided bytes contain both the K1 and K2 part.

--- a/x/collections/keys_pair_test.go
+++ b/x/collections/keys_pair_test.go
@@ -14,7 +14,8 @@ func TestPairKeyEncoder(t *testing.T) {
 
 	t.Run("encode both - bijectivity", func(t *testing.T) {
 		key := Join("k1", "k2")
-		b := enc.Encode(key)
+		b, err := enc.Encode(key)
+		require.NoError(t, err)
 		read, got := enc.Decode(b)
 		require.Equal(t, key, got)
 		require.Equal(t, len(b), read)
@@ -22,18 +23,25 @@ func TestPairKeyEncoder(t *testing.T) {
 
 	t.Run("encode partial - k1", func(t *testing.T) {
 		key := PairPrefix[string, string]("k1")
-		require.Equal(t, StringKeyEncoder.Encode("k1"), enc.Encode(key))
+		want, err := StringKeyEncoder.Encode("k1")
+		require.NoError(t, err)
+		got, err := enc.Encode(key)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
 	})
 
 	t.Run("encode partial - k2", func(t *testing.T) {
 		key := PairSuffix[string, string]("k2")
-		require.Equal(t, StringKeyEncoder.Encode("k2"), enc.Encode(key))
+		want, err := StringKeyEncoder.Encode("k2")
+		require.NoError(t, err)
+		got, err := enc.Encode(key)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
 	})
 
-	t.Run("empty panics", func(t *testing.T) {
-		require.Panics(t, func() {
-			enc.Encode(Pair[string, string]{})
-		})
+	t.Run("empty returns ErrEmptyPairKey", func(t *testing.T) {
+		_, err := enc.Encode(Pair[string, string]{})
+		require.ErrorIs(t, err, ErrEmptyPairKey)
 	})
 
 	t.Run("stringify both", func(t *testing.T) {
@@ -67,7 +75,7 @@ func TestPairRange(t *testing.T) {
 	}
 
 	for _, i := range items {
-		ks.Insert(ctx, i)
+		require.NoError(t, ks.Insert(ctx, i))
 	}
 
 	// prefix test

--- a/x/collections/keys_test.go
+++ b/x/collections/keys_test.go
@@ -19,7 +19,9 @@ func TestUint64(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		var k uint64
-		require.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 0}, Uint64KeyEncoder.Encode(k))
+		b, err := Uint64KeyEncoder.Encode(k)
+		require.NoError(t, err)
+		require.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 0}, b)
 	})
 }
 
@@ -28,12 +30,13 @@ func TestStringKey(t *testing.T) {
 		assertBijective[string](t, StringKeyEncoder, "test")
 	})
 
-	t.Run("panics", func(t *testing.T) {
-		// invalid string key
-		require.Panics(t, func() {
-			invalid := []byte{0x1, 0x0, 0x3}
-			StringKeyEncoder.Encode(string(invalid))
-		})
+	t.Run("invalid string key", func(t *testing.T) {
+		invalid := []byte{0x1, 0x0, 0x3}
+		_, err := StringKeyEncoder.Encode(string(invalid))
+		require.Error(t, err)
+	})
+
+	t.Run("decode panics", func(t *testing.T) {
 		// invalid bytes do not end with 0x0
 		require.Panics(t, func() {
 			StringKeyEncoder.Decode([]byte{0x1, 0x2})
@@ -45,7 +48,8 @@ func TestStringKey(t *testing.T) {
 	})
 
 	t.Run("empty string", func(t *testing.T) {
-		b := StringKeyEncoder.Encode("")
+		b, err := StringKeyEncoder.Encode("")
+		require.NoError(t, err)
 		i, r := StringKeyEncoder.Decode(b)
 		require.Equal(t, 1, i)
 		require.Equal(t, "", r)
@@ -61,7 +65,9 @@ func TestStringKey(t *testing.T) {
 		bytesStringKeys := make([][]byte, len(stringKeys))
 		for i, sk := range stringKeys {
 			strings[i] = sk
-			bytesStringKeys[i] = StringKeyEncoder.Encode(sk)
+			enc, err := StringKeyEncoder.Encode(sk)
+			require.NoError(t, err)
+			bytesStringKeys[i] = enc
 		}
 
 		sort.Strings(strings)

--- a/x/collections/keyset.go
+++ b/x/collections/keyset.go
@@ -29,14 +29,14 @@ func (s KeySet[K]) Has(ctx sdk.Context, k K) bool {
 }
 
 // Insert inserts the key K in the set.
-func (s KeySet[K]) Insert(ctx sdk.Context, k K) {
-	(Map[K, setObject])(s).Insert(ctx, k, setObject{})
+func (s KeySet[K]) Insert(ctx sdk.Context, k K) error {
+	return (Map[K, setObject])(s).Insert(ctx, k, setObject{})
 }
 
 // Delete deletes the key from the set.
 // Does not check if the key exists or not.
-func (s KeySet[K]) Delete(ctx sdk.Context, k K) {
-	_ = (Map[K, setObject])(s).Delete(ctx, k)
+func (s KeySet[K]) Delete(ctx sdk.Context, k K) error {
+	return (Map[K, setObject])(s).Delete(ctx, k)
 }
 
 // Iterate returns a KeySetIterator over the provided keys.Range of keys.
@@ -66,7 +66,7 @@ func (s KeySetIterator[K]) Keys() []K { return (Iterator[K, setObject])(s).Keys(
 // it also implements the ValueEncoder interface for itself.
 type setObject struct{}
 
-func (s setObject) Encode(_ setObject) []byte { return []byte{} }
+func (s setObject) Encode(_ setObject) ([]byte, error) { return []byte{}, nil }
 
 func (s setObject) Decode(b []byte) setObject {
 	if !bytes.Equal(b, []byte{}) {

--- a/x/collections/keyset_test.go
+++ b/x/collections/keyset_test.go
@@ -13,21 +13,21 @@ func TestKeySet(t *testing.T) {
 
 	// test insert and get
 	key := "hi"
-	keyset.Insert(ctx, key)
+	require.NoError(t, keyset.Insert(ctx, key))
 	require.True(t, keyset.Has(ctx, key))
 
 	// test delete and get error
-	keyset.Delete(ctx, key)
+	require.NoError(t, keyset.Delete(ctx, key))
 	require.False(t, keyset.Has(ctx, key))
 }
 
 func TestKeySet_Iterate(t *testing.T) {
 	sk, ctx, _ := deps()
 	keyset := NewKeySet[string](sk, 0, StringKeyEncoder)
-	keyset.Insert(ctx, "a")
-	keyset.Insert(ctx, "aa")
-	keyset.Insert(ctx, "b")
-	keyset.Insert(ctx, "bb")
+	require.NoError(t, keyset.Insert(ctx, "a"))
+	require.NoError(t, keyset.Insert(ctx, "aa"))
+	require.NoError(t, keyset.Insert(ctx, "b"))
+	require.NoError(t, keyset.Insert(ctx, "bb"))
 
 	expectedKeys := []string{"a", "aa", "b", "bb"}
 
@@ -42,7 +42,7 @@ func TestKeysetIterator(t *testing.T) {
 	sk, ctx, _ := deps()
 
 	keyset := NewKeySet[string](sk, 0, StringKeyEncoder)
-	keyset.Insert(ctx, "a")
+	require.NoError(t, keyset.Insert(ctx, "a"))
 
 	iter := keyset.Iterate(ctx, Range[string]{})
 	defer iter.Close()

--- a/x/collections/map.go
+++ b/x/collections/map.go
@@ -38,13 +38,25 @@ func NewMap[K, V any](
 	}
 }
 
-func (m Map[K, V]) Insert(ctx sdk.Context, k K, v V) {
-	m.GetStore(ctx).
-		Set(m.kc.Encode(k), m.vc.Encode(v))
+func (m Map[K, V]) Insert(ctx sdk.Context, k K, v V) error {
+	kBytes, err := m.kc.Encode(k)
+	if err != nil {
+		return err
+	}
+	vBytes, err := m.vc.Encode(v)
+	if err != nil {
+		return err
+	}
+	m.GetStore(ctx).Set(kBytes, vBytes)
+	return nil
 }
 
 func (m Map[K, V]) Get(ctx sdk.Context, k K) (v V, err error) {
-	vBytes := m.GetStore(ctx).Get(m.kc.Encode(k))
+	kBytes, encErr := m.kc.Encode(k)
+	if encErr != nil {
+		return v, encErr
+	}
+	vBytes := m.GetStore(ctx).Get(kBytes)
 	if vBytes == nil {
 		return v, fmt.Errorf("%w: '%s' with key %s", ErrNotFound, m.typeName, m.kc.Stringify(k))
 	}
@@ -64,7 +76,10 @@ func (m Map[K, V]) GetOr(ctx sdk.Context, key K, def V) (v V) {
 // Delete removes the key-value pair associated with the key from the map.
 // Returns an error if the key does not exist.
 func (m Map[K, V]) Delete(ctx sdk.Context, k K) error {
-	kBytes := m.kc.Encode(k)
+	kBytes, err := m.kc.Encode(k)
+	if err != nil {
+		return err
+	}
 	store := m.GetStore(ctx)
 	if !store.Has(kBytes) {
 		return fmt.Errorf("%w: '%s' with key %s", ErrNotFound, m.typeName, m.kc.Stringify(k))

--- a/x/collections/map_test.go
+++ b/x/collections/map_test.go
@@ -24,7 +24,7 @@ type MapImpl[K, V any] interface {
 	Get(ctx sdk.Context, k K) (v V, err error)
 	GetOr(ctx sdk.Context, key K, def V) (v V)
 	GetStore(ctx sdk.Context) sdk.KVStore
-	Insert(ctx sdk.Context, k K, v V)
+	Insert(ctx sdk.Context, k K, v V) error
 	Iterate(ctx sdk.Context, rng Ranger[K]) Iterator[K, V]
 }
 
@@ -52,7 +52,7 @@ func RunTestMap(t *testing.T, ctx sdk.Context, m MapImpl[string, string]) {
 	expected := "test"
 
 	// test insert and get
-	m.Insert(ctx, key, expected)
+	require.NoError(t, m.Insert(ctx, key, expected))
 	got, err := m.Get(ctx, key)
 	require.NoError(t, err)
 	require.Equal(t, expected, got)
@@ -75,7 +75,7 @@ func RunTestMap(t *testing.T, ctx sdk.Context, m MapImpl[string, string]) {
 func RunTestMapGetOrDefault(t *testing.T, ctx sdk.Context, m MapImpl[string, string]) {
 	assert.EqualValues(t, "default", m.GetOr(ctx, "foo", "default"))
 
-	m.Insert(ctx, "foo", "not-default")
+	require.NoError(t, m.Insert(ctx, "foo", "not-default"))
 	assert.EqualValues(t, "not-default", m.GetOr(ctx, "foo", "default"))
 }
 
@@ -91,10 +91,10 @@ func RunTestMapIterate(t *testing.T, ctx sdk.Context, m MapImpl[string, string])
 		kv("a"), kv("aa"), kv("b"), kv("bb"),
 	}
 
-	m.Insert(ctx, "a", "a")
-	m.Insert(ctx, "aa", "aa")
-	m.Insert(ctx, "b", "b")
-	m.Insert(ctx, "bb", "bb")
+	require.NoError(t, m.Insert(ctx, "a", "a"))
+	require.NoError(t, m.Insert(ctx, "aa", "aa"))
+	require.NoError(t, m.Insert(ctx, "b", "b"))
+	require.NoError(t, m.Insert(ctx, "bb", "bb"))
 
 	// test iteration ascending
 	iter := m.Iterate(ctx, Range[string]{})

--- a/x/collections/sequence.go
+++ b/x/collections/sequence.go
@@ -29,8 +29,9 @@ func NewSequence(sk types.StoreKey, namespace Namespace) Sequence {
 func (s Sequence) Next(ctx sdk.Context) uint64 {
 	// get current
 	seq := s.Peek(ctx)
-	// increase
-	s.sequence.Set(ctx, seq+1)
+	if err := s.sequence.Set(ctx, seq+1); err != nil {
+		panic(err)
+	}
 	// return current
 	return seq
 }
@@ -50,13 +51,15 @@ func (s Sequence) IncreaseBy(ctx sdk.Context, by uint64) (nextVal uint64) {
 
 // Set hard resets the sequence to the provided number.
 func (s Sequence) Set(ctx sdk.Context, u uint64) {
-	s.sequence.Set(ctx, u)
+	if err := s.sequence.Set(ctx, u); err != nil {
+		panic(err)
+	}
 }
 
 // uint64Value implements a ValueEncoder for uint64
 type uint64Value struct{}
 
-func (u uint64Value) Encode(value uint64) []byte    { return sdk.Uint64ToBigEndian(value) }
-func (u uint64Value) Decode(b []byte) uint64        { return sdk.BigEndianToUint64(b) }
-func (u uint64Value) Stringify(value uint64) string { return strconv.FormatUint(value, 10) }
-func (u uint64Value) Name() string                  { return "uint64" }
+func (u uint64Value) Encode(value uint64) ([]byte, error) { return sdk.Uint64ToBigEndian(value), nil }
+func (u uint64Value) Decode(b []byte) uint64              { return sdk.BigEndianToUint64(b) }
+func (u uint64Value) Stringify(value uint64) string       { return strconv.FormatUint(value, 10) }
+func (u uint64Value) Name() string                        { return "uint64" }

--- a/x/collections/utils_test.go
+++ b/x/collections/utils_test.go
@@ -9,14 +9,16 @@ import (
 )
 
 func assertBijective[T any](t *testing.T, encoder KeyEncoder[T], key T) {
-	encodedKey := encoder.Encode(key)
+	encodedKey, err := encoder.Encode(key)
+	require.NoError(t, err)
 	read, decodedKey := encoder.Decode(encodedKey)
 	require.Equal(t, len(encodedKey), read, "encoded key and read bytes must have same size")
 	require.Equal(t, key, decodedKey, "encoding and decoding produces different keys")
 }
 
 func assertValueBijective[T any](t *testing.T, encoder ValueEncoder[T], value T) {
-	encodedValue := encoder.Encode(value)
+	encodedValue, err := encoder.Encode(value)
+	require.NoError(t, err)
 	decodedValue := encoder.Decode(encodedValue)
 	require.Equal(t, value, decodedValue, "encoding and decoding produces different values")
 }
@@ -24,18 +26,21 @@ func assertValueBijective[T any](t *testing.T, encoder ValueEncoder[T], value T)
 // stringValue is a ValueEncoder for string, used for testing.
 type stringValue struct{}
 
-func (s stringValue) Encode(value string) []byte    { return []byte(value) }
-func (s stringValue) Decode(b []byte) string        { return string(b) }
-func (s stringValue) Stringify(value string) string { return value }
-func (s stringValue) Name() string                  { return "test string" }
+func (s stringValue) Encode(value string) ([]byte, error) { return []byte(value), nil }
+func (s stringValue) Decode(b []byte) string              { return string(b) }
+func (s stringValue) Stringify(value string) string       { return value }
+func (s stringValue) Name() string                        { return "test string" }
 
 // jsonValue is a ValueEncoder for objects to be turned into json.
 // used for testing.
 type jsonValue[T any] struct{}
 
-func (jsonValue[T]) Encode(value T) []byte {
-	b, _ := json.Marshal(value)
-	return b
+func (jsonValue[T]) Encode(value T) ([]byte, error) {
+	b, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
 }
 
 func (jsonValue[T]) Decode(b []byte) T {

--- a/x/collections/value_encoder.go
+++ b/x/collections/value_encoder.go
@@ -36,9 +36,15 @@ type protoValueEncoder[V any, PV interface {
 	cdc codec.BinaryCodec
 }
 
-func (p protoValueEncoder[V, PV]) Name() string          { return proto.MessageName(PV(new(V))) }
-func (p protoValueEncoder[V, PV]) Encode(value V) []byte { return p.cdc.MustMarshal(PV(&value)) }
-func (p protoValueEncoder[V, PV]) Stringify(v V) string  { return PV(&v).String() }
+func (p protoValueEncoder[V, PV]) Name() string { return proto.MessageName(PV(new(V))) }
+func (p protoValueEncoder[V, PV]) Encode(value V) ([]byte, error) {
+	bz, err := p.cdc.Marshal(PV(&value))
+	if err != nil {
+		return nil, fmt.Errorf("collections: proto marshal: %w", err)
+	}
+	return bz, nil
+}
+func (p protoValueEncoder[V, PV]) Stringify(v V) string { return PV(&v).String() }
 func (p protoValueEncoder[V, PV]) Decode(b []byte) V {
 	v := PV(new(V))
 	p.cdc.MustUnmarshal(b, v)
@@ -49,12 +55,12 @@ func (p protoValueEncoder[V, PV]) Decode(b []byte) V {
 
 type decValueEncoder struct{}
 
-func (d decValueEncoder) Encode(value sdk.Dec) []byte {
+func (d decValueEncoder) Encode(value sdk.Dec) ([]byte, error) {
 	b, err := value.Marshal()
 	if err != nil {
-		panic(fmt.Errorf("%w %s", err, HumanizeBytes(b)))
+		return nil, fmt.Errorf("%w %s", err, HumanizeBytes(b))
 	}
-	return b
+	return b, nil
 }
 
 func (d decValueEncoder) Decode(b []byte) sdk.Dec {
@@ -78,16 +84,16 @@ func (d decValueEncoder) Name() string {
 
 type accAddressValueEncoder struct{}
 
-func (a accAddressValueEncoder) Encode(value sdk.AccAddress) []byte    { return value }
-func (a accAddressValueEncoder) Decode(b []byte) sdk.AccAddress        { return b }
-func (a accAddressValueEncoder) Stringify(value sdk.AccAddress) string { return value.String() }
-func (a accAddressValueEncoder) Name() string                          { return "sdk.AccAddress" }
+func (a accAddressValueEncoder) Encode(value sdk.AccAddress) ([]byte, error) { return value, nil }
+func (a accAddressValueEncoder) Decode(b []byte) sdk.AccAddress              { return b }
+func (a accAddressValueEncoder) Stringify(value sdk.AccAddress) string       { return value.String() }
+func (a accAddressValueEncoder) Name() string                                { return "sdk.AccAddress" }
 
 // IntValueEncoder ValueEncoder[sdk.Int]
 
 type intValueEncoder struct{}
 
-func (intValueEncoder) Encode(value sdkmath.Int) []byte {
+func (intValueEncoder) Encode(value sdkmath.Int) ([]byte, error) {
 	return IntKeyEncoder.Encode(value)
 }
 
@@ -104,27 +110,28 @@ func (intValueEncoder) Name() string {
 	return "math.Int"
 }
 
-// IntKeyEncoder
-
+// IntKeyEncoder encodes non-negative [cosmossdk.io/math.Int] values into a fixed-width
+// big-endian byte slice for lexicographic ordering. Nil or negative inputs return
+// [ErrNilIntKey] or [ErrNegativeIntKey] from Encode.
 var IntKeyEncoder KeyEncoder[sdkmath.Int] = intKeyEncoder{}
 
 type intKeyEncoder struct{}
 
 const maxIntKeyLen = sdkmath.MaxBitLen / 8
 
-func (intKeyEncoder) Encode(key sdkmath.Int) []byte {
+func (intKeyEncoder) Encode(key sdkmath.Int) ([]byte, error) {
 	if key.IsNil() {
-		panic("cannot encode invalid math.Int")
+		return nil, ErrNilIntKey
 	}
 	if key.IsNegative() {
-		panic("cannot encode negative math.Int")
+		return nil, ErrNegativeIntKey
 	}
 	i := key.BigInt()
 
 	be := i.Bytes()
 	padded := make([]byte, maxIntKeyLen)
 	copy(padded[maxIntKeyLen-len(be):], be)
-	return padded
+	return padded, nil
 }
 
 func (intKeyEncoder) Decode(b []byte) (int, sdkmath.Int) {

--- a/x/collections/value_encoder_test.go
+++ b/x/collections/value_encoder_test.go
@@ -69,8 +69,10 @@ func (s *SuiteValueEncoder) TestIntEncoder() {
 	s.Require().Equal(maxIntKeyLen, len(maxBigInt.Bytes()))
 
 	// test encoding ordering
-	enc1 := IntKeyEncoder.Encode(sdk.NewInt(50_000))
-	enc2 := IntKeyEncoder.Encode(sdk.NewInt(100_000))
+	enc1, err := IntKeyEncoder.Encode(sdk.NewInt(50_000))
+	s.Require().NoError(err)
+	enc2, err := IntKeyEncoder.Encode(sdk.NewInt(100_000))
+	s.Require().NoError(err)
 	s.Less(enc1, enc2)
 
 	// test decoding
@@ -80,23 +82,19 @@ func (s *SuiteValueEncoder) TestIntEncoder() {
 	s.Equal(sdk.NewInt(50_000), got1)
 	s.Equal(sdk.NewInt(100_000), got2)
 
-	// require panics on negative values
-	s.Panics(func() {
-		IntKeyEncoder.Encode(sdk.NewInt(-1))
-	})
-	// require panics on invalid int
-	s.Panics(func() {
-		IntKeyEncoder.Encode(sdkmath.Int{})
-	})
+	_, err = IntKeyEncoder.Encode(sdk.NewInt(-1))
+	s.Require().ErrorIs(err, ErrNegativeIntKey)
+
+	_, err = IntKeyEncoder.Encode(sdkmath.Int{})
+	s.Require().ErrorIs(err, ErrNilIntKey)
 
 	// test value encoder
 	value := sdk.NewInt(50_000)
-	valueBytes := IntValueEncoder.Encode(value)
+	valueBytes, err := IntValueEncoder.Encode(value)
+	s.Require().NoError(err)
 	gotValue := IntValueEncoder.Decode(valueBytes)
 	s.Equal(value, gotValue)
 
-	// panics on invalid math.Int
-	s.Panics(func() {
-		IntValueEncoder.Encode(sdkmath.Int{})
-	})
+	_, err = IntValueEncoder.Encode(sdkmath.Int{})
+	s.Require().ErrorIs(err, ErrNilIntKey)
 }

--- a/x/nutil/address.go
+++ b/x/nutil/address.go
@@ -29,7 +29,7 @@ var StringValueEncoder collections.ValueEncoder[string] = stringValueEncoder{}
 
 type stringValueEncoder struct{}
 
-func (a stringValueEncoder) Encode(value string) []byte    { return []byte(value) }
-func (a stringValueEncoder) Decode(b []byte) string        { return string(b) }
-func (a stringValueEncoder) Stringify(value string) string { return value }
-func (a stringValueEncoder) Name() string                  { return "string" }
+func (a stringValueEncoder) Encode(value string) ([]byte, error) { return []byte(value), nil }
+func (a stringValueEncoder) Decode(b []byte) string              { return string(b) }
+func (a stringValueEncoder) Stringify(value string) string       { return value }
+func (a stringValueEncoder) Name() string                        { return "string" }

--- a/x/nutil/address_test.go
+++ b/x/nutil/address_test.go
@@ -33,7 +33,8 @@ func TestStringValueEncoder(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.given, func(t *testing.T) {
 			want := tc.given
-			encoded := encoder.Encode(tc.given)
+			encoded, err := encoder.Encode(tc.given)
+			require.NoError(t, err)
 			got := encoder.Decode(encoded)
 			assert.Equal(t, want, got)
 			assert.Equal(t, want, encoder.Stringify(got))

--- a/x/nutil/asset/pair.go
+++ b/x/nutil/asset/pair.go
@@ -144,7 +144,7 @@ var PairKeyEncoder collections.KeyEncoder[Pair] = pairKeyEncoder{}
 type pairKeyEncoder struct{}
 
 func (pairKeyEncoder) Stringify(a Pair) string { return a.String() }
-func (pairKeyEncoder) Encode(a Pair) []byte {
+func (pairKeyEncoder) Encode(a Pair) ([]byte, error) {
 	return collections.StringKeyEncoder.Encode(a.String())
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [issue #2491](https://github.com/NibiruChain/nibiru/issues/2491): `IntKeyEncoder` (and the shared unsigned `math.Int` encoding used by `IntValueEncoder`) no longer panics on nil or negative values. Callers receive stable sentinel errors and can propagate them through `collections.Map` / `KeySet` / `IndexedMap` / `MultiIndex` APIs.

## Key changes

- `KeyEncoder.Encode` and `ValueEncoder.Encode` now return `([]byte, error)`.
- New exported errors: `ErrNilIntKey`, `ErrNegativeIntKey`, `ErrEmptyPairKey`.
- `Map.Insert`, `Get`, `Delete`; `KeySet.Insert`, `Delete`; `Item.Set`; `IndexedMap.Insert`; `MultiIndex.Insert`/`Delete`; and related indexer hooks propagate encode errors.
- `StringKeyEncoder`, `SdkDecKeyEncoder`, `ProtoValueEncoder`, `PairKeyEncoder` (empty pair), and `eth` / `x/nutil` encoders updated to match the new signatures; `SignedIntValueEncoder` returns marshal errors instead of panicking.
- Iterator construction still returns `Iterator` directly; range key encoding errors surface as a panic inside `iteratorFromRange` (unchanged call sites for `Iterate` across the repo).

## Verification

- `go test ./...`

- Closes https://github.com/NibiruChain/nibiru/issues/2491
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nibiruchain.slack.com/archives/D0AVA20J2K0/p1778968031195179?thread_ts=1778968031.195179&cid=D0AVA20J2K0)

<div><a href="https://cursor.com/agents/bc-f38fcaa9-5b9c-5c1c-8d42-8ce4673b9345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f38fcaa9-5b9c-5c1c-8d42-8ce4673b9345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

