### PR TITLE
feat(evm): Allow zero-gas calls with native value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ consensus determinism.
 ### 1 - Main Highlights
 
 - **Fixed** - Successful EVM transactions were sometimes shown as failed due to Cosmos SDK gas-meter issues. No longer. ([#2521](https://github.com/NibiruChain/nibiru/pull/2521))
-- **New** - Governance-allowlisted "always zero gas" EVM contracts can be called by any sender with no gas balance, as long as value is 0. ([#2517](https://github.com/NibiruChain/nibiru/pull/2517))
+- **New** - Governance-allowlisted "always zero gas" EVM contracts can be called by any sender without paying native NIBI gas fees. Nonzero `msg.value` still requires sender balance. ([#2517](https://github.com/NibiruChain/nibiru/pull/2517))
 - **Improved** - Precompiles now report gas cleanly with dynamic handling, and SDK out-of-gas panics are recovered into normal errors instead of crashing the node. ([#2516](https://github.com/NibiruChain/nibiru/pull/2516))
 - **Security** - Upgraded CometBFT to patched v0.37.18 for CSA-2026-001 (Tachyon), a critical consensus-level issue affecting block time guarantees. ([#2512](https://github.com/NibiruChain/nibiru/pull/2512))
 - **Consensus safety** - Removed nondeterministic Go map iteration in consensus-critical paths (oracle + EVM state commit), addressing intermittent apphash mismatches. ([#2503](https://github.com/NibiruChain/nibiru/pull/2503))
@@ -91,8 +91,8 @@ Includes:
 **What it enables:** First-time onboarding and "no gas balance" execution for calls into governance-allowlisted contracts.
 
 **How it works:**
-- If a transaction calls a **governance-allowlisted contract** and `value == 0`, the chain marks it as "zero gas" early in the ante handler.
-- It then skips gas-related checks (fee deduction, balance-vs-cost checks, mempool min gas price checks, and `RefundGas`) while still enforcing account checks and `CanTransfer`.
+- If a transaction calls a **governance-allowlisted contract**, the chain marks it as "zero gas" early in the ante handler.
+- It then skips gas-related checks (fee deduction, balance-vs-cost checks, mempool min gas price checks, and `RefundGas`) while still enforcing account checks and `CanTransfer`, including native value solvency for `msg.value`.
 - A governance-managed list `ZeroGasActors.always_zero_gas_contracts` allows **any sender** to invoke specific EVM contracts with zero gas.
 
 **Governance:** This is controlled by a governance-managed allowlist. Manage via `sudo edit-zero-gas` and the `always_zero_gas_contracts` field.
@@ -134,7 +134,7 @@ This release upgrades CometBFT to **v0.37.18**, which includes the required fix 
 
 #### For Builders
 - **Tx status correctness** — Successful EVM calls should no longer be mislabeled as failed due to SDK gas-meter issues.
-- **Gasless calls** — If your contract is allowlisted under `always_zero_gas_contracts`, any sender can call it with `value == 0` and no gas balance.
+- **Gasless calls** — If your contract is allowlisted under `always_zero_gas_contracts`, any sender can call it without paying native NIBI gas fees. Nonzero `msg.value` still requires sender balance.
 - **Precompile behavior** — Expect cleaner out-of-gas error surfaces and more accurate gas reporting around dynamic precompiles.
 - **Passkeys / account abstraction** — New contracts and SDK exist for passkey-secured ERC-4337 flows; good time to prototype onboarding without seed phrases.
 - **CLI flags** — Transaction flags are more concise by default so developers can see command-specific flags more clearly. ([#2449](https://github.com/NibiruChain/nibiru/pull/2449))

--- a/app/app.go
+++ b/app/app.go
@@ -355,7 +355,7 @@ func NewNibiruApp(
 		genmsg.NewAppModule(app.MsgServiceRouter()),
 
 		// ibc
-		ibc.NewAppModule(app.ibcKeeper),
+		ibc.NewAppModule(app.IbcKeeper),
 		ibctransfer.NewAppModule(app.ibcTransferKeeper),
 		ibcfee.NewAppModule(app.ibcFeeKeeper),
 		ica.NewAppModule(&app.icaControllerKeeper, &app.icaHostKeeper),
@@ -430,7 +430,7 @@ func NewNibiruApp(
 			SigGasConsumer:         authante.DefaultSigVerificationGasConsumer,
 			ExtensionOptionChecker: func(*codectypes.Any) bool { return true },
 		},
-		IBCKeeper:         app.ibcKeeper,
+		IBCKeeper:         app.IbcKeeper,
 		TxCounterStoreKey: app.keys[wasmtypes.StoreKey],
 		WasmConfig:        &wasmConfig,
 		DevGasKeeper:      &app.DevGasKeeper,
@@ -620,7 +620,7 @@ func (app *NibiruApp) GetStakingKeeper() types.StakingKeeper {
 }
 
 func (app *NibiruApp) GetIBCKeeper() *ibckeeper.Keeper {
-	return app.ibcKeeper
+	return app.IbcKeeper
 }
 
 func (app *NibiruApp) GetScopedIBCKeeper() capabilitykeeper.ScopedKeeper {

--- a/app/keepers.go
+++ b/app/keepers.go
@@ -80,9 +80,6 @@ type AppKeepers struct {
 	   the IBC light client misbehavior evidence route. */
 	evidenceKeeper evidencekeeper.Keeper
 
-	/* ibcKeeper defines each ICS keeper for IBC. ibcKeeper must be a pointer in
-	   the app, so we can SetRouter on it correctly. */
-	ibcKeeper    *ibckeeper.Keeper
 	ibcFeeKeeper ibcfeekeeper.Keeper
 	/* ibcTransferKeeper is for cross-chain fungible token transfers. */
 	ibcTransferKeeper   ibctransferkeeper.Keeper
@@ -139,7 +136,7 @@ func (app *NibiruApp) initNonDepinjectKeepers(
 
 	// ---------------------------------- IBC keepers
 
-	app.ibcKeeper = ibckeeper.NewKeeper(
+	app.IbcKeeper = ibckeeper.NewKeeper(
 		app.appCodec,
 		app.keys[ibcexported.StoreKey],
 		app.getSubspace(ibcexported.ModuleName),
@@ -151,9 +148,9 @@ func (app *NibiruApp) initNonDepinjectKeepers(
 	// IBC Fee Module keeper
 	app.ibcFeeKeeper = ibcfeekeeper.NewKeeper(
 		app.appCodec, app.keys[ibcfeetypes.StoreKey],
-		app.ibcKeeper.ChannelKeeper, // may be replaced with IBC middleware
-		app.ibcKeeper.ChannelKeeper,
-		&app.ibcKeeper.PortKeeper,
+		app.IbcKeeper.ChannelKeeper, // may be replaced with IBC middleware
+		app.IbcKeeper.ChannelKeeper,
+		&app.IbcKeeper.PortKeeper,
 		app.AccountKeeper,
 		app.BankKeeper,
 	)
@@ -163,8 +160,8 @@ func (app *NibiruApp) initNonDepinjectKeepers(
 		app.keys[ibctransfertypes.StoreKey],
 		/* paramSubspace */ app.getSubspace(ibctransfertypes.ModuleName),
 		/* ibctransfertypes.ICS4Wrapper */ app.ibcFeeKeeper,
-		/* ibctransfertypes.ChannelKeeper */ app.ibcKeeper.ChannelKeeper,
-		/* ibctransfertypes.PortKeeper */ &app.ibcKeeper.PortKeeper,
+		/* ibctransfertypes.ChannelKeeper */ app.IbcKeeper.ChannelKeeper,
+		/* ibctransfertypes.PortKeeper */ &app.IbcKeeper.PortKeeper,
 		app.AccountKeeper,
 		app.BankKeeper,
 		app.ScopedTransferKeeper,
@@ -174,8 +171,8 @@ func (app *NibiruApp) initNonDepinjectKeepers(
 		app.appCodec, app.keys[icacontrollertypes.StoreKey],
 		app.getSubspace(icacontrollertypes.SubModuleName),
 		app.ibcFeeKeeper,
-		app.ibcKeeper.ChannelKeeper,
-		&app.ibcKeeper.PortKeeper,
+		app.IbcKeeper.ChannelKeeper,
+		&app.IbcKeeper.PortKeeper,
 		app.ScopedICAControllerKeeper,
 		app.MsgServiceRouter(),
 	)
@@ -185,8 +182,8 @@ func (app *NibiruApp) initNonDepinjectKeepers(
 		app.keys[icahosttypes.StoreKey],
 		app.getSubspace(icahosttypes.SubModuleName),
 		app.ibcFeeKeeper,
-		app.ibcKeeper.ChannelKeeper,
-		&app.ibcKeeper.PortKeeper,
+		app.IbcKeeper.ChannelKeeper,
+		&app.IbcKeeper.PortKeeper,
 		app.AccountKeeper,
 		app.ScopedICAHostKeeper,
 		app.MsgServiceRouter(),
@@ -236,7 +233,7 @@ func (app *NibiruApp) initNonDepinjectKeepers(
 	wmha := wasmext.MsgHandlerArgs{
 		Router:           app.MsgServiceRouter(),
 		Ics4Wrapper:      app.ibcFeeKeeper,
-		ChannelKeeper:    app.ibcKeeper.ChannelKeeper,
+		ChannelKeeper:    app.IbcKeeper.ChannelKeeper,
 		CapabilityKeeper: app.ScopedWasmKeeper,
 		BankKeeper:       app.BankKeeper,
 		Unpacker:         app.appCodec,
@@ -252,7 +249,7 @@ func (app *NibiruApp) initNonDepinjectKeepers(
 		distrkeeper.NewQuerier(app.DistrKeeper),
 		wmha.Ics4Wrapper, // ISC4 Wrapper: fee IBC middleware
 		wmha.ChannelKeeper,
-		&app.ibcKeeper.PortKeeper,
+		&app.IbcKeeper.PortKeeper,
 		wmha.CapabilityKeeper,
 		wmha.PortSource,
 		wmha.Router,
@@ -267,7 +264,7 @@ func (app *NibiruApp) initNonDepinjectKeepers(
 	app.WasmClientKeeper = ibcwasmkeeper.NewKeeperWithVM(
 		app.appCodec,
 		app.keys[ibcwasmtypes.StoreKey],
-		app.ibcKeeper.ClientKeeper,
+		app.IbcKeeper.ClientKeeper,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		wasmVM,
 		app.GRPCQueryRouter(),
@@ -323,7 +320,7 @@ func (app *NibiruApp) initNonDepinjectKeepers(
 	icaHostStack := icahost.NewIBCModule(app.icaHostKeeper)
 
 	var wasmStack porttypes.IBCModule
-	wasmStack = wasm.NewIBCHandler(app.WasmKeeper, app.ibcKeeper.ChannelKeeper, app.ibcFeeKeeper)
+	wasmStack = wasm.NewIBCHandler(app.WasmKeeper, app.IbcKeeper.ChannelKeeper, app.ibcFeeKeeper)
 	wasmStack = ibcfee.NewIBCMiddleware(wasmStack, app.ibcFeeKeeper)
 
 	// Add transfer stack to IBC Router
@@ -351,14 +348,14 @@ func (app *NibiruApp) initNonDepinjectKeepers(
 
 	/* SetRouter finalizes all routes by sealing the router.
 	   No more routes can be added. */
-	app.ibcKeeper.SetRouter(ibcRouter)
+	app.IbcKeeper.SetRouter(ibcRouter)
 
 	govRouter := govv1beta1types.NewRouter()
 	govRouter.
 		AddRoute(govtypes.RouterKey, govv1beta1types.ProposalHandler).
 		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.paramsKeeper)).
 		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.UpgradeKeeper)).
-		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.ibcKeeper.ClientKeeper))
+		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IbcKeeper.ClientKeeper))
 
 	app.GovKeeper.SetLegacyRouter(govRouter)
 

--- a/app/keepers/all_keepers.go
+++ b/app/keepers/all_keepers.go
@@ -14,7 +14,7 @@ import (
 
 	// ---------------------------------------------------------------
 	// IBC imports
-
+	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
 	ibcmock "github.com/cosmos/ibc-go/v7/testing/mock"
 
 	// ---------------------------------------------------------------
@@ -50,6 +50,10 @@ type PublicKeepers struct {
 	ScopedICAControllerKeeper capabilitykeeper.ScopedKeeper
 	ScopedICAHostKeeper       capabilitykeeper.ScopedKeeper
 	ScopedTransferKeeper      capabilitykeeper.ScopedKeeper
+
+	/* IbcKeeper defines each ICS keeper for IBC. IbcKeeper must be a pointer in
+	   the app, so we can SetRouter on it correctly. */
+	IbcKeeper *ibckeeper.Keeper
 
 	// make IBC modules public for test purposes
 	// these modules are never directly routed to by the IBC Router

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -47,12 +47,12 @@ func (app *NibiruApp) setupUpgrades() {
 func (app *NibiruApp) setUpgradeHandlers() {
 	for _, u := range Upgrades {
 		app.UpgradeKeeper.SetUpgradeHandler(u.UpgradeName,
-			u.CreateUpgradeHandler(
+			u.Handler.Handler(
 				app.ModuleManager,
 				app.Configurator(),
 				&app.PublicKeepers,
-				app.ibcKeeper.ClientKeeper,
-			))
+			),
+		)
 	}
 }
 

--- a/app/upgrades/all_upgrades.go
+++ b/app/upgrades/all_upgrades.go
@@ -7,18 +7,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 )
 
 type Upgrade struct {
 	UpgradeName string
 
-	CreateUpgradeHandler func(
-		mm *module.Manager,
-		cfg module.Configurator,
-		nibiru *keepers.PublicKeepers,
-		ibcKeeperClientKeeper clientkeeper.Keeper,
-	) upgradetypes.UpgradeHandler
+	Handler HandlerImpl
 
 	// StoreUpgrades defines a series of transformations to apply the multistore db
 	// upon load
@@ -50,16 +44,40 @@ var AllUpgrades = []Upgrade{
 	Upgrade2_14_0,
 }
 
-// DefaultUpgradeHandler runs module manager migrations without running any other
-// logic that uses the Nibiru keepers. This is the most common value for
-// the "CreateUpgradeHandler" field of an [Upgrade].
-func DefaultUpgradeHandler(
+// HandlerImpl is a struct wrapper
+type HandlerImpl interface {
+	Handler(
+		mm *module.Manager,
+		cfg module.Configurator,
+		nibiru *keepers.PublicKeepers,
+	) upgradetypes.UpgradeHandler
+}
+
+// DefaultUpgraderHandler runs module manager migrations without running any
+// other logic that uses the Nibiru keepers.
+type DefaultUpgraderHandler struct{}
+
+var _ HandlerImpl = (*DefaultUpgraderHandler)(nil)
+
+// Handler for [DefaultUpgraderHandler] runs module manager migrations without
+// running any other logic that uses the Nibiru keepers.
+func (h DefaultUpgraderHandler) Handler(
 	mm *module.Manager,
 	cfg module.Configurator,
 	nibiru *keepers.PublicKeepers,
-	clientKeeper clientkeeper.Keeper,
 ) upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		return mm.RunMigrations(ctx, cfg, fromVM)
 	}
+}
+
+// NewEventUpgradeFailure builds an [sdk.Event] to use when an upgrade fails and
+// exits. This is used to debug why an upgrade failed while allowing it to
+// proceed without panicking and halting the blockchain.
+func NewEventUpgradeFailure(upgradeName string, err error) sdk.Event {
+	return sdk.NewEvent(
+		"upgrade_failure",
+		sdk.NewAttribute("upgrade", upgradeName),
+		sdk.NewAttribute("error", err.Error()),
+	)
 }

--- a/app/upgrades/v1.go
+++ b/app/upgrades/v1.go
@@ -14,7 +14,6 @@ import (
 	icahosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
 	icatypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/keepers"
 	inflationtypes "github.com/NibiruChain/nibiru/v2/x/inflation/types"
@@ -23,98 +22,103 @@ import (
 var (
 	// Tests the upgrade process and move to newer version of rocksdb
 	Upgrade1_0_1 = Upgrade{
-		UpgradeName:          "v1.0.1",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v1.0.1",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	// Newer version of the Cosmos-SDK
 	Upgrade1_0_2 = Upgrade{
-		UpgradeName:          "v1.0.2",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v1.0.2",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	// Newer version of the Cosmos-SDK
 	Upgrade1_0_3 = Upgrade{
-		UpgradeName:          "v1.0.3",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v1.0.3",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade1_1_0 = Upgrade{
-		UpgradeName:          "v1.1.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
+		UpgradeName: "v1.1.0",
+		Handler:     DefaultUpgraderHandler{},
 		StoreUpgrades: store.StoreUpgrades{
 			Added: []string{inflationtypes.ModuleName},
 		},
 	}
 
 	Upgrade1_2_0 = Upgrade{
-		UpgradeName:          "v1.2.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v1.2.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade1_3_0 = Upgrade{
 		UpgradeName: "v1.3.0",
-		CreateUpgradeHandler: func(
-			mm *module.Manager,
-			cfg module.Configurator,
-			nibiru *keepers.PublicKeepers,
-			clientKeeper clientkeeper.Keeper,
-		) upgradetypes.UpgradeHandler {
-			return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-				// set the ICS27 consensus version so InitGenesis is not run
-				fromVM[icatypes.ModuleName] = mm.GetVersionMap()[icatypes.ModuleName]
-
-				// create ICS27 Controller submodule params, controller module not enabled.
-				controllerParams := icacontrollertypes.Params{
-					ControllerEnabled: true,
-				}
-
-				// create ICS27 Host submodule params
-				hostParams := icahosttypes.Params{
-					HostEnabled: true,
-					AllowMessages: []string{
-						sdk.MsgTypeURL(&banktypes.MsgSend{}),
-						sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}),
-						sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}),
-						sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),
-						sdk.MsgTypeURL(&distrtypes.MsgWithdrawDelegatorReward{}),
-						sdk.MsgTypeURL(&distrtypes.MsgSetWithdrawAddress{}),
-						sdk.MsgTypeURL(&distrtypes.MsgFundCommunityPool{}),
-						sdk.MsgTypeURL(&authz.MsgExec{}),
-						sdk.MsgTypeURL(&authz.MsgGrant{}),
-						sdk.MsgTypeURL(&authz.MsgRevoke{}),
-						sdk.MsgTypeURL(&ibctransfertypes.MsgTransfer{}),
-					},
-				}
-
-				// initialize ICS27 module
-				icamodule, correctTypecast := mm.Modules[icatypes.ModuleName].(ica.AppModule)
-				if !correctTypecast {
-					panic("mm.Modules[icatypes.ModuleName] is not of type ica.AppModule")
-				}
-				icamodule.InitModule(ctx, controllerParams, hostParams)
-
-				return mm.RunMigrations(ctx, cfg, fromVM)
-			}
-		},
+		Handler:     Handler_v1_3{},
 		StoreUpgrades: store.StoreUpgrades{
 			Added: []string{icacontrollertypes.StoreKey, icahosttypes.StoreKey},
 		},
 	}
 
 	Upgrade1_4_0 = Upgrade{
-		UpgradeName:          "v1.4.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v1.4.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade1_5_0 = Upgrade{
-		UpgradeName:          "v1.5.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v1.5.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 )
+
+var _ HandlerImpl = (*Handler_v1_3)(nil)
+
+type Handler_v1_3 struct{}
+
+func (h Handler_v1_3) Handler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	nibiru *keepers.PublicKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// set the ICS27 consensus version so InitGenesis is not run
+		fromVM[icatypes.ModuleName] = mm.GetVersionMap()[icatypes.ModuleName]
+
+		// create ICS27 Controller submodule params, controller module not enabled.
+		controllerParams := icacontrollertypes.Params{
+			ControllerEnabled: true,
+		}
+
+		// create ICS27 Host submodule params
+		hostParams := icahosttypes.Params{
+			HostEnabled: true,
+			AllowMessages: []string{
+				sdk.MsgTypeURL(&banktypes.MsgSend{}),
+				sdk.MsgTypeURL(&stakingtypes.MsgDelegate{}),
+				sdk.MsgTypeURL(&stakingtypes.MsgUndelegate{}),
+				sdk.MsgTypeURL(&stakingtypes.MsgBeginRedelegate{}),
+				sdk.MsgTypeURL(&distrtypes.MsgWithdrawDelegatorReward{}),
+				sdk.MsgTypeURL(&distrtypes.MsgSetWithdrawAddress{}),
+				sdk.MsgTypeURL(&distrtypes.MsgFundCommunityPool{}),
+				sdk.MsgTypeURL(&authz.MsgExec{}),
+				sdk.MsgTypeURL(&authz.MsgGrant{}),
+				sdk.MsgTypeURL(&authz.MsgRevoke{}),
+				sdk.MsgTypeURL(&ibctransfertypes.MsgTransfer{}),
+			},
+		}
+
+		// initialize ICS27 module
+		icamodule, correctTypecast := mm.Modules[icatypes.ModuleName].(ica.AppModule)
+		if !correctTypecast {
+			panic("mm.Modules[icatypes.ModuleName] is not of type ica.AppModule")
+		}
+		icamodule.InitModule(ctx, controllerParams, hostParams)
+
+		return mm.RunMigrations(ctx, cfg, fromVM)
+	}
+}

--- a/app/upgrades/v2.go
+++ b/app/upgrades/v2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	ibcwasmtypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/types"
-	clientkeeper "github.com/cosmos/ibc-go/v7/modules/core/02-client/keeper"
 
 	"github.com/NibiruChain/nibiru/v2/app/appconst"
 	"github.com/NibiruChain/nibiru/v2/app/keepers"
@@ -18,8 +17,8 @@ import (
 
 var (
 	Upgrade2_0_0 = Upgrade{
-		UpgradeName:          "v2.0.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
+		UpgradeName: "v2.0.0",
+		Handler:     DefaultUpgraderHandler{},
 		StoreUpgrades: store.StoreUpgrades{
 			Added: []string{evm.ModuleName},
 		},
@@ -27,148 +26,75 @@ var (
 
 	Upgrade2_1_0 = Upgrade{
 		UpgradeName: "v2.1.0",
-		CreateUpgradeHandler: func(
-			mm *module.Manager,
-			cfg module.Configurator,
-			nibiru *keepers.PublicKeepers,
-			clientKeeper clientkeeper.Keeper,
-		) upgradetypes.UpgradeHandler {
-			return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-				// explicitly update the IBC 02-client params, adding the wasm client type if it is not there
-				params := clientKeeper.GetParams(ctx)
-
-				hasWasmClient := slices.Contains(params.AllowedClients, ibcwasmtypes.Wasm)
-
-				if !hasWasmClient {
-					params.AllowedClients = append(params.AllowedClients, ibcwasmtypes.Wasm)
-					clientKeeper.SetParams(ctx, params)
-				}
-
-				return mm.RunMigrations(ctx, cfg, fromVM)
-			}
-		},
+		Handler:     Handler_v2_1{},
 		StoreUpgrades: store.StoreUpgrades{
 			Added: []string{ibcwasmtypes.ModuleName},
 		},
 	}
 
 	Upgrade2_2_0 = Upgrade{
-		UpgradeName:          "v2.2.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v2.2.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade2_3_0 = Upgrade{
-		UpgradeName:          "v2.3.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v2.3.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade2_4_0 = Upgrade{
-		UpgradeName:          "v2.4.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v2.4.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade2_5_0 = Upgrade{
-		UpgradeName: "v2.5.0",
-		CreateUpgradeHandler: func(
-			mm *module.Manager,
-			cfg module.Configurator,
-			nibiru *keepers.PublicKeepers,
-			clientKeeper clientkeeper.Keeper,
-		) upgradetypes.UpgradeHandler {
-			return func(
-				ctx sdk.Context,
-				plan upgradetypes.Plan,
-				fromVM module.VersionMap,
-			) (module.VersionMap, error) {
-				err := UpgradeStNibiEvmMetadata(nibiru, ctx, appconst.MAINNET_STNIBI_ADDR)
-				if err != nil {
-					return fromVM, fmt.Errorf("v2.5.0 upgrade failure: %w", err)
-				}
-
-				return mm.RunMigrations(ctx, cfg, fromVM)
-			}
-		},
+		UpgradeName:   "v2.5.0",
+		Handler:       Handler_v2_5{},
 		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade2_6_0 = Upgrade{
-		UpgradeName:          "v2.6.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v2.6.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade2_7_0 = Upgrade{
-		UpgradeName: "v2.7.0",
-		CreateUpgradeHandler: func(
-			mm *module.Manager,
-			cfg module.Configurator,
-			nibiru *keepers.PublicKeepers,
-			clientKeeper clientkeeper.Keeper,
-		) upgradetypes.UpgradeHandler {
-			return func(
-				ctx sdk.Context,
-				plan upgradetypes.Plan,
-				fromVM module.VersionMap,
-			) (module.VersionMap, error) {
-				err := runUpgrade2_7_0(nibiru, ctx)
-				if err != nil {
-					return fromVM, fmt.Errorf("v2.7.0 upgrade failure: %w", err)
-				}
-
-				return mm.RunMigrations(ctx, cfg, fromVM)
-			}
-		},
+		UpgradeName:   "v2.7.0",
+		Handler:       Handler_v2_7{},
 		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade2_8_0 = Upgrade{
-		UpgradeName:          "v2.8.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v2.8.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade2_9_0 = Upgrade{
-		UpgradeName:          "v2.9.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v2.9.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade2_10_0 = Upgrade{
-		UpgradeName:          "v2.10.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v2.10.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade2_11_0 = Upgrade{
-		UpgradeName:          "v2.11.0",
-		CreateUpgradeHandler: DefaultUpgradeHandler,
-		StoreUpgrades:        store.StoreUpgrades{},
+		UpgradeName:   "v2.11.0",
+		Handler:       DefaultUpgraderHandler{},
+		StoreUpgrades: store.StoreUpgrades{},
 	}
 
 	Upgrade2_12_0 = Upgrade{
-		UpgradeName: "v2.12.0",
-		CreateUpgradeHandler: func(
-			mm *module.Manager,
-			cfg module.Configurator,
-			nibiru *keepers.PublicKeepers,
-			clientKeeper clientkeeper.Keeper,
-		) upgradetypes.UpgradeHandler {
-			return func(
-				ctx sdk.Context,
-				plan upgradetypes.Plan,
-				fromVM module.VersionMap,
-			) (module.VersionMap, error) {
-				err := runUpgrade2_12_0(nibiru, ctx)
-				if err != nil {
-					return fromVM, fmt.Errorf("v2.12.0 upgrade failure: %w", err)
-				}
-
-				return mm.RunMigrations(ctx, cfg, fromVM)
-			}
-		},
+		UpgradeName:   "v2.12.0",
+		Handler:       Handler_v2_12{},
 		StoreUpgrades: store.StoreUpgrades{},
 	}
 
@@ -177,31 +103,102 @@ var (
 	//   - UpgradeName:        "v2.13.0",
 	//   - UpgradeName: "v2.13.1-test.3",
 	Upgrade2_14_0 = Upgrade{
-		UpgradeName: "v2.14.0",
-		CreateUpgradeHandler: func(
-			mm *module.Manager,
-			cfg module.Configurator,
-			nibiru *keepers.PublicKeepers,
-			clientKeeper clientkeeper.Keeper,
-		) upgradetypes.UpgradeHandler {
-			return func(
-				ctx sdk.Context,
-				plan upgradetypes.Plan,
-				fromVM module.VersionMap,
-			) (module.VersionMap, error) {
-				err := runUpgrade2_14_0(nibiru, ctx)
-				if err != nil {
-					ctx.Logger().Error("v2.14.0 upgrade failure", "err", err)
-					ctx.EventManager().EmitEvent(
-						sdk.NewEvent(
-							"v2_14_0_upgrade_failure",
-							sdk.NewAttribute("error", err.Error()),
-						),
-					)
-				}
-				return mm.RunMigrations(ctx, cfg, fromVM)
-			}
-		},
+		UpgradeName:   "v2.14.0",
+		Handler:       Handler_v2_14{},
 		StoreUpgrades: store.StoreUpgrades{},
 	}
 )
+
+var _ HandlerImpl = (*Handler_v2_1)(nil)
+
+type Handler_v2_1 struct{}
+
+func (h Handler_v2_1) Handler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	nibiru *keepers.PublicKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		clientKeeper := nibiru.IbcKeeper.ClientKeeper
+		// explicitly update the IBC 02-client params, adding the wasm client type if it is not there
+		params := clientKeeper.GetParams(ctx)
+
+		hasWasmClient := slices.Contains(params.AllowedClients, ibcwasmtypes.Wasm)
+
+		if !hasWasmClient {
+			params.AllowedClients = append(params.AllowedClients, ibcwasmtypes.Wasm)
+			clientKeeper.SetParams(ctx, params)
+		}
+
+		return mm.RunMigrations(ctx, cfg, fromVM)
+	}
+}
+
+var _ HandlerImpl = (*Handler_v2_5)(nil)
+
+type Handler_v2_5 struct{}
+
+func (h Handler_v2_5) Handler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	nibiru *keepers.PublicKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(
+		ctx sdk.Context,
+		plan upgradetypes.Plan,
+		fromVM module.VersionMap,
+	) (module.VersionMap, error) {
+		err := UpgradeStNibiEvmMetadata(nibiru, ctx, appconst.MAINNET_STNIBI_ADDR)
+		if err != nil {
+			return fromVM, fmt.Errorf("v2.5.0 upgrade failure: %w", err)
+		}
+
+		return mm.RunMigrations(ctx, cfg, fromVM)
+	}
+}
+
+var _ HandlerImpl = (*Handler_v2_7)(nil)
+
+type Handler_v2_7 struct{}
+
+func (h Handler_v2_7) Handler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	nibiru *keepers.PublicKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(
+		ctx sdk.Context,
+		plan upgradetypes.Plan,
+		fromVM module.VersionMap,
+	) (module.VersionMap, error) {
+		err := runUpgrade2_7_0(nibiru, ctx)
+		if err != nil {
+			return fromVM, fmt.Errorf("v2.7.0 upgrade failure: %w", err)
+		}
+
+		return mm.RunMigrations(ctx, cfg, fromVM)
+	}
+}
+
+var _ HandlerImpl = (*Handler_v2_12)(nil)
+
+type Handler_v2_12 struct{}
+
+func (h Handler_v2_12) Handler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	nibiru *keepers.PublicKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(
+		ctx sdk.Context,
+		plan upgradetypes.Plan,
+		fromVM module.VersionMap,
+	) (module.VersionMap, error) {
+		err := runUpgrade2_12_0(nibiru, ctx)
+		if err != nil {
+			return fromVM, fmt.Errorf("v2.12.0 upgrade failure: %w", err)
+		}
+
+		return mm.RunMigrations(ctx, cfg, fromVM)
+	}
+}

--- a/app/upgrades/v2_14_0.go
+++ b/app/upgrades/v2_14_0.go
@@ -6,11 +6,34 @@ import (
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/NibiruChain/nibiru/v2/app/appconst"
 	"github.com/NibiruChain/nibiru/v2/app/keepers"
 	"github.com/NibiruChain/nibiru/v2/x/sudo"
 )
+
+var _ HandlerImpl = (*Handler_v2_14)(nil)
+
+type Handler_v2_14 struct{}
+
+func (h Handler_v2_14) Handler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	nibiru *keepers.PublicKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		err := h.runUpgrade2_14_0(nibiru, ctx)
+		if err != nil {
+			ctx.Logger().Error("v2.14.0 upgrade failure", "err", err)
+			ctx.EventManager().EmitEvent(
+				NewEventUpgradeFailure("v2.14.0", err),
+			)
+		}
+		return mm.RunMigrations(ctx, cfg, fromVM)
+	}
+}
 
 // Upgrade2_14_AddrCfg contains the deployed contract addresses touched
 // by the v2.14 upgrade. Tests can override these values after instantiating
@@ -87,7 +110,7 @@ type cw4UpdateAdminMsg struct {
 	} `json:"update_admin"`
 }
 
-func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
+func (h Handler_v2_14) runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 	addrCfg := AddrCfg_v2_14
 
 	// -------------------------------------------------------------------------
@@ -103,7 +126,7 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 	// STEP 1: Mainnet-only zero-gas allowlist update for LayerZero OFT adapters.
 	// -------------------------------------------------------------------------
 	if ctx.ChainID() == addrCfg.MainnetChainID {
-		if err := addZeroGasContracts(ctx, nibiru, addrCfg.LayerZeroOFTAdapters); err != nil {
+		if err := h.addZeroGasContracts(ctx, nibiru, addrCfg.LayerZeroOFTAdapters); err != nil {
 			return err
 		}
 	}
@@ -275,7 +298,7 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 	return nil
 }
 
-func addZeroGasContracts(ctx sdk.Context, nibiru *keepers.PublicKeepers, addrs []string) error {
+func (h Handler_v2_14) addZeroGasContracts(ctx sdk.Context, nibiru *keepers.PublicKeepers, addrs []string) error {
 	actors := nibiru.SudoKeeper.GetZeroGasActors(ctx)
 
 	nextActors := sudo.ZeroGasActors{

--- a/app/upgrades/v2_14_0.go
+++ b/app/upgrades/v2_14_0.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/NibiruChain/nibiru/v2/app/appconst"
 	"github.com/NibiruChain/nibiru/v2/app/keepers"
+	"github.com/NibiruChain/nibiru/v2/x/sudo"
 )
 
 // Upgrade2_14_AddrCfg contains the deployed contract addresses touched
@@ -28,6 +29,8 @@ type Upgrade2_14_AddrCfg struct {
 
 	TreasuryAddSigner     sdk.AccAddress
 	TreasuryRemoveSigners []sdk.AccAddress
+
+	LayerZeroOFTAdapters []string
 }
 
 // AddrCfg_v2_14 is the deployed address configuration used by the v2.14
@@ -50,6 +53,11 @@ var AddrCfg_v2_14 = Upgrade2_14_AddrCfg{
 		mustAccAddress("nibi1wwhdx03msygelmm8tm5z6nzh4dklwkettwd5vj"), // Gimeno
 		mustAccAddress("nibi1aj6vgnj5hh0ehe5memz0f38z2lla2z5gdj5vst"), // JC
 		mustAccAddress("nibi1w3s6gdtt09ekhmwzfszc6qtxh298fstu895gn8"), // Kevin NanoS
+	},
+
+	LayerZeroOFTAdapters: []string{
+		"0x12a272A581feE5577A5dFa371afEB4b2F3a8C2F8", // USDC.e LayerZero OFT adapter
+		"0x4DF4eFa0a3707b6Cc964F62042E8a303A0376F54", // WNIBI LayerZero OFT adapter
 	},
 }
 
@@ -91,6 +99,15 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 		return nil
 	}
 
+	// -------------------------------------------------------------------------
+	// STEP 1: Mainnet-only zero-gas allowlist update for LayerZero OFT adapters.
+	// -------------------------------------------------------------------------
+	if ctx.ChainID() == addrCfg.MainnetChainID {
+		if err := addZeroGasContracts(ctx, nibiru, addrCfg.LayerZeroOFTAdapters); err != nil {
+			return err
+		}
+	}
+
 	permissionedWasmKeeper := wasmkeeper.NewDefaultPermissionKeeper(nibiru.WasmKeeper)
 	updateWasmAdmin := func(contract, currentAdmin, newAdmin sdk.AccAddress) error {
 		info := nibiru.WasmKeeper.GetContractInfo(ctx, contract)
@@ -117,7 +134,7 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 	}
 
 	// -------------------------------------------------------------------------
-	// STEP 1: Skip cleanup if the Treasury CW3 and CW4 contracts are absent.
+	// STEP 2: Skip cleanup if the Treasury CW3 and CW4 contracts are absent.
 	// -------------------------------------------------------------------------
 	if !nibiru.WasmKeeper.HasContractInfo(ctx, addrCfg.TreasuryCW4Group) {
 		return nil
@@ -127,7 +144,7 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 	}
 
 	// -------------------------------------------------------------------------
-	// STEP 2: Update Treasury CW4 membership with a query-first diff.
+	// STEP 3: Update Treasury CW4 membership with a query-first diff.
 	// -------------------------------------------------------------------------
 	respBz, err := nibiru.WasmKeeper.QuerySmart(ctx, addrCfg.TreasuryCW4Group, []byte(`{"list_members":{}}`))
 	if err != nil {
@@ -178,7 +195,7 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 	}
 
 	// -------------------------------------------------------------------------
-	// STEP 3: Hand Treasury CW4 group admin from nibimultisig to Treasury CW3.
+	// STEP 4: Hand Treasury CW4 group admin from nibimultisig to Treasury CW3.
 	// -------------------------------------------------------------------------
 	respBz, err = nibiru.WasmKeeper.QuerySmart(ctx, addrCfg.TreasuryCW4Group, []byte(`{"admin":{}}`))
 	if err != nil {
@@ -212,7 +229,7 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 	}
 
 	// -------------------------------------------------------------------------
-	// STEP 4: Move Treasury CW4 and CW3 wasm admin metadata to Treasury CW3.
+	// STEP 5: Move Treasury CW4 and CW3 wasm admin metadata to Treasury CW3.
 	// -------------------------------------------------------------------------
 	if err := updateWasmAdmin(addrCfg.TreasuryCW4Group, addrCfg.LegacyMultisig, addrCfg.TreasuryCW3); err != nil {
 		return err
@@ -222,7 +239,7 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 	}
 
 	// -------------------------------------------------------------------------
-	// STEP 5: Mainnet-only guard for dormant Hot Wallet cleanup.
+	// STEP 6: Mainnet-only guard for dormant Hot Wallet cleanup.
 	// -------------------------------------------------------------------------
 	if ctx.ChainID() != addrCfg.MainnetChainID {
 		return nil
@@ -232,7 +249,7 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 	}
 
 	// -------------------------------------------------------------------------
-	// STEP 6: Sweep the Hot Wallet CW3 bank balance into Treasury CW3.
+	// STEP 7: Sweep the Hot Wallet CW3 bank balance into Treasury CW3.
 	// -------------------------------------------------------------------------
 	balances := nibiru.BankKeeper.GetAllBalances(ctx, addrCfg.HotWalletCW3)
 	if !balances.IsZero() {
@@ -243,7 +260,7 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 	}
 
 	// -------------------------------------------------------------------------
-	// STEP 7: Move Hot Wallet CW3 and CW4 wasm admin metadata to Treasury CW3.
+	// STEP 8: Move Hot Wallet CW3 and CW4 wasm admin metadata to Treasury CW3.
 	// -------------------------------------------------------------------------
 	if err := updateWasmAdmin(addrCfg.HotWalletCW3, addrCfg.KevinNanoS, addrCfg.TreasuryCW3); err != nil {
 		return err
@@ -255,6 +272,37 @@ func runUpgrade2_14_0(nibiru *keepers.PublicKeepers, ctx sdk.Context) error {
 		}
 	}
 
+	return nil
+}
+
+func addZeroGasContracts(ctx sdk.Context, nibiru *keepers.PublicKeepers, addrs []string) error {
+	actors := nibiru.SudoKeeper.GetZeroGasActors(ctx)
+
+	nextActors := sudo.ZeroGasActors{
+		Senders:                append([]string(nil), actors.Senders...),
+		Contracts:              append([]string(nil), actors.Contracts...),
+		AlwaysZeroGasContracts: make([]string, 0, len(actors.AlwaysZeroGasContracts)+len(addrs)),
+	}
+	seenAlwaysZeroGas := make(map[string]bool, len(actors.AlwaysZeroGasContracts)+len(addrs))
+	for _, addr := range actors.AlwaysZeroGasContracts {
+		if seenAlwaysZeroGas[addr] {
+			continue
+		}
+		nextActors.AlwaysZeroGasContracts = append(nextActors.AlwaysZeroGasContracts, addr)
+		seenAlwaysZeroGas[addr] = true
+	}
+	for _, addr := range addrs {
+		if seenAlwaysZeroGas[addr] {
+			continue
+		}
+		nextActors.AlwaysZeroGasContracts = append(nextActors.AlwaysZeroGasContracts, addr)
+		seenAlwaysZeroGas[addr] = true
+	}
+
+	if err := nextActors.Validate(); err != nil {
+		return fmt.Errorf("failed to validate zero-gas LayerZero OFT adapter state: %w", err)
+	}
+	nibiru.SudoKeeper.ZeroGasActors.Set(ctx, nextActors)
 	return nil
 }
 

--- a/app/upgrades/v2_14_0_test.go
+++ b/app/upgrades/v2_14_0_test.go
@@ -429,7 +429,7 @@ func executeCW4UpdateAdmin(
 // runUpgradeForTest invokes a registered upgrade handler with the same app
 // wiring used by other upgrade tests.
 func runUpgradeForTest(deps evmtest.TestDeps, upgrade upgrades.Upgrade) error {
-	upgradeHandler := upgrade.CreateUpgradeHandler(
+	upgradeHandler := upgrade.Handler.Handler(
 		deps.App.ModuleManager,
 		module.NewConfigurator(
 			deps.App.AppCodec(),
@@ -437,7 +437,6 @@ func runUpgradeForTest(deps evmtest.TestDeps, upgrade upgrades.Upgrade) error {
 			deps.App.GRPCQueryRouter(),
 		),
 		&deps.App.PublicKeepers,
-		deps.App.GetIBCKeeper().ClientKeeper,
 	)
 
 	plan := upgradetypes.Plan{

--- a/app/upgrades/v2_14_0_test.go
+++ b/app/upgrades/v2_14_0_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/NibiruChain/nibiru/v2/x/nutil/denoms"
 	nutiltestutil "github.com/NibiruChain/nibiru/v2/x/nutil/testutil"
 	"github.com/NibiruChain/nibiru/v2/x/nutil/testutil/testapp"
+	"github.com/NibiruChain/nibiru/v2/x/sudo"
 )
 
 const (
@@ -39,6 +40,9 @@ const (
 	addrTreasuryAddSigner = "nibi1cj6edencz3tetxuwkxcdrlfwpg8cr02ef3uvz2"
 	addrGimeno            = "nibi1wwhdx03msygelmm8tm5z6nzh4dklwkettwd5vj"
 	addrJC                = "nibi1aj6vgnj5hh0ehe5memz0f38z2lla2z5gdj5vst"
+
+	addrLayerZeroUSDCeAdapter = "0x12a272A581feE5577A5dFa371afEB4b2F3a8C2F8"
+	addrLayerZeroWNIBIAdapter = "0x4DF4eFa0a3707b6Cc964F62042E8a303A0376F54"
 )
 
 // TestUpgrade2_14_0_HappyPath stores and instantiates real CW4 group and CW3
@@ -144,6 +148,66 @@ func TestUpgrade2_14_0_HappyPath(t *testing.T) {
 	require.Equal(t, treasuryCW3.String(), contractAdmin(t, deps, hotWalletCW4))
 	require.True(t, deps.App.BankKeeper.GetAllBalances(ctx, hotWalletCW3).IsZero())
 	require.Equal(t, hotWalletBalance, deps.App.BankKeeper.GetAllBalances(ctx, treasuryCW3))
+}
+
+func TestUpgrade2_14_0_AddsLayerZeroAdaptersToZeroGasActorsMainnet(t *testing.T) {
+	deps := evmtest.NewTestDeps()
+	deps.SetCtx(deps.Ctx().WithChainID(chainIDMainnet))
+
+	existingAlwaysZeroGas := "0x0000000000000000000000000000000000000005"
+	deps.App.SudoKeeper.ZeroGasActors.Set(deps.Ctx(), sudo.ZeroGasActors{
+		Senders:                []string{addrTreasuryAddSigner},
+		Contracts:              []string{addrLegacyMultisig},
+		AlwaysZeroGasContracts: []string{existingAlwaysZeroGas},
+	})
+
+	require.NoError(t, runUpgradeForTest(deps, upgrades.Upgrade2_14_0))
+
+	actors := deps.App.SudoKeeper.GetZeroGasActors(deps.Ctx())
+	require.Equal(t, []string{addrTreasuryAddSigner}, actors.Senders)
+	require.Equal(t, []string{addrLegacyMultisig}, actors.Contracts)
+	require.Equal(t, []string{
+		existingAlwaysZeroGas,
+		addrLayerZeroUSDCeAdapter,
+		addrLayerZeroWNIBIAdapter,
+	}, actors.AlwaysZeroGasContracts)
+}
+
+func TestUpgrade2_14_0_DoesNotDuplicateLayerZeroAdapters(t *testing.T) {
+	deps := evmtest.NewTestDeps()
+	deps.SetCtx(deps.Ctx().WithChainID(chainIDMainnet))
+
+	existingAlwaysZeroGas := "0x0000000000000000000000000000000000000005"
+	deps.App.SudoKeeper.ZeroGasActors.Set(deps.Ctx(), sudo.ZeroGasActors{
+		AlwaysZeroGasContracts: []string{
+			existingAlwaysZeroGas,
+			addrLayerZeroUSDCeAdapter,
+			addrLayerZeroWNIBIAdapter,
+		},
+	})
+
+	require.NoError(t, runUpgradeForTest(deps, upgrades.Upgrade2_14_0))
+
+	actors := deps.App.SudoKeeper.GetZeroGasActors(deps.Ctx())
+	require.Equal(t, []string{
+		existingAlwaysZeroGas,
+		addrLayerZeroUSDCeAdapter,
+		addrLayerZeroWNIBIAdapter,
+	}, actors.AlwaysZeroGasContracts)
+}
+
+func TestUpgrade2_14_0_DoesNotAddLayerZeroAdaptersOffMainnet(t *testing.T) {
+	deps := evmtest.NewTestDeps()
+	deps.SetCtx(deps.Ctx().WithChainID(upgrades.AddrCfg_v2_14.Testnet2ChainID))
+
+	existingActors := sudo.ZeroGasActors{
+		AlwaysZeroGasContracts: []string{"0x0000000000000000000000000000000000000005"},
+	}
+	deps.App.SudoKeeper.ZeroGasActors.Set(deps.Ctx(), existingActors)
+
+	require.NoError(t, runUpgradeForTest(deps, upgrades.Upgrade2_14_0))
+
+	require.Equal(t, existingActors, deps.App.SudoKeeper.GetZeroGasActors(deps.Ctx()))
 }
 
 // assertUpgrade2_14_0Events checks the observable event footprint of the happy

--- a/docs/ecosystem/updates/nan-003.md
+++ b/docs/ecosystem/updates/nan-003.md
@@ -19,8 +19,7 @@ description: >-
 longer label some successful EVM transactions as "failed" due to a Cosmos SDK
 gas-meter edge case.
 * **Expanded "Zero Gas" onboarding**: governance can allowlist specific contracts
-that anyone can call with **zero gas balance**, as long as the call sends **no
-value** (`value == 0`).
+that anyone can call without paying native NIBI gas fees.
 * **Passkeys for smart accounts (developer foundation)**: contracts, SDK, and
 bundler tooling for ERC-4337-style flows secured by P-256 passkey signatures.
 * **Cleaner precompile gas behavior**: more predictable gas reporting and safer
@@ -100,8 +99,9 @@ Nibiru supports a controlled "gasless" path for specific contract calls. In plai
 language:
 
 If governance approves a contract as "always zero gas," then **any user can call
-that contract even if their wallet has no gas token**, as long as the call sends
-**no value** (`value == 0`).
+that contract without paying native NIBI gas fees**. If the call sends native
+value through `msg.value`, the sender must still have enough balance to cover
+that value.
 
 So users can perform certain onboarding actions without first acquiring gas.
 
@@ -116,7 +116,8 @@ Once a contract is on that list:
 
 * any sender can call it
 * the sender can have **no gas balance**
-* the call must send **zero value**
+* attached native value is allowed, but the sender must have enough balance to
+  cover that value
 * normal safety checks still apply (this is not a bypass for everything)
 
 ### Why this matters

--- a/eth/rpc/rpcapi/call_tx.go
+++ b/eth/rpc/rpcapi/call_tx.go
@@ -355,7 +355,7 @@ func (b *Backend) GasPrice() (*hexutil.Big, error) {
 	//
 	// Chain execution still uses the real base fee. This method is only a
 	// wallet-facing fee hint.
-	var result = evm.WalletZeroBaseFeeWei()
+	result := evm.WalletZeroBaseFeeWei()
 
 	return (*hexutil.Big)(result), nil
 }

--- a/eth/rpc/rpcapi/call_tx.go
+++ b/eth/rpc/rpcapi/call_tx.go
@@ -214,9 +214,6 @@ func (b *Backend) isZeroGasJsonTxArgsLatest(args evm.JsonTxArgs) bool {
 	if args.To == nil {
 		return false
 	}
-	if args.Value != nil && args.Value.ToInt().Sign() != 0 {
-		return false
-	}
 
 	res, err := sudo.NewQueryClient(b.clientCtx).QueryZeroGasActors(
 		context.Background(),

--- a/justfile
+++ b/justfile
@@ -94,14 +94,44 @@ gen-proto-openapi:
 
 lint: 
   #!/usr/bin/env bash
-  echo "Running golangci-lint with docker!"
+  set -euo pipefail
+  source contrib/bashlib.sh
+
   image_version="v2.6.1"
+  lint_cmd=(golangci-lint run -v --fix)
+
+  if which_ok golangci-lint >/dev/null 2>&1; then
+    local_version="$(golangci-lint version --short 2>/dev/null || true)"
+    image_major="${image_version#v}"
+    image_major="${image_major%%.*}"
+    local_major="${local_version#v}"
+    local_major="${local_major%%.*}"
+
+    if [ "$local_version" = "$image_version" ] || [ "v$local_version" = "$image_version" ]; then
+      log_info "Running local golangci-lint $local_version"
+      GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE:-/tmp/nibi-golangci-lint-cache}" "${lint_cmd[@]}"
+      exit 0
+    fi
+
+    if [ -n "$local_major" ] && [ "$local_major" = "$image_major" ]; then
+      log_warning "Running local golangci-lint ${local_version:-unknown}; repo pins $image_version"
+      GOLANGCI_LINT_CACHE="${GOLANGCI_LINT_CACHE:-/tmp/nibi-golangci-lint-cache}" "${lint_cmd[@]}"
+      exit 0
+    fi
+
+    log_warning "Local golangci-lint version ${local_version:-unknown} does not match major version $image_major; using Docker"
+  else
+    log_info "golangci-lint not found locally; using Docker"
+  fi
+
+  which_ok docker
+  log_info "Running golangci-lint with Docker image golangci/golangci-lint:$image_version"
   docker run --rm \
     -v "$(pwd)":/app \
     -v ~/.cache/golangci-lint/$image_version:/root/.cache \
     -w /app \
     golangci/golangci-lint:$image_version \
-    golangci-lint run -v --fix 2>&1
+    "${lint_cmd[@]}" 2>&1
 
 # Runs a Nibiru local network. Ex: "just localnet --run --help". Optional flags: --no-build --log-level [debug|info]
 localnet *PASS_FLAGS:

--- a/x/evm/README.md
+++ b/x/evm/README.md
@@ -17,11 +17,13 @@ This project was created using `bun init` in bun v1.0.28. [Bun](https://bun.sh) 
 ## Zero-Gas EVM Fee Exemption
 
 EVM transactions whose `to` address is listed in `always_zero_gas_contracts` and
-whose `value` is zero are treated as fee-exempt. The raw signed Ethereum
-transaction is preserved for signature checks, transaction hashes, RPC
-transaction views, tracing, and debugging. After classification, the derived EVM
-execution message uses zero fee-price fields, and native NIBI gas fees are not
-required, deducted, burned, tipped, or refunded.
+whose transaction data passes normal non-fee validation are treated as
+fee-exempt. The raw signed Ethereum transaction is preserved for signature
+checks, transaction hashes, RPC transaction views, tracing, and debugging. After
+classification, the derived EVM execution message uses zero fee-price fields,
+and native NIBI gas fees are not required, deducted, burned, tipped, or
+refunded. If the transaction attaches native value through `msg.value`, the
+sender must still have enough EVM native balance to cover that value.
 
 Operators can recompute eligibility from recorded chain data:
 
@@ -30,8 +32,9 @@ nibid q sudo zero-gas-actors --height <height>
 nibid q tx <tx-hash> --height <height>
 ```
 
-Decode the `MsgEthereumTx`, compare its signed `to` and `value` fields against
-the allowlist at the transaction height, and confirm that the sender's native
-NIBI balance did not decrease by an EVM gas payment. Fee-exempt EVM txs still
-meter execution gas and count against block gas limits; `EventEthereumTx.gas_used`
-may be nonzero, while the usual `tx.fee` event from EVM gas deduction is absent.
+Decode the `MsgEthereumTx`, compare its signed `to` field against the allowlist
+at the transaction height, and confirm that the sender's native NIBI balance did
+not decrease by an EVM gas payment. A nonzero `value` may still move native NIBI
+as part of EVM execution. Fee-exempt EVM txs still meter execution gas and count
+against block gas limits; `EventEthereumTx.gas_used` may be nonzero, while the
+usual `tx.fee` event from EVM gas deduction is absent.

--- a/x/evm/evmante/all_evmante_test.go
+++ b/x/evm/evmante/all_evmante_test.go
@@ -166,6 +166,97 @@ func (s *Suite) TestAnteHandlerEVM() {
 				s.Require().True(evm.IsZeroGasEthTx(newCtx), "expected IsZeroGasEthTx to be true for zero-gas tx")
 			},
 		},
+		{
+			name: "zero-gas: nonzero value with exact value balance passes full ante",
+			beforeTxSetup: func(deps *evmtest.TestDeps, sdb *evmstate.SDB) {
+				targetAddr := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+				deps.App.SudoKeeper.ZeroGasActors.Set(deps.Ctx(), sudo.ZeroGasActors{
+					AlwaysZeroGasContracts: []string{targetAddr.Hex()},
+				})
+				AddBalanceSigned(sdb, deps.Sender.EthAddr, big.NewInt(123))
+			},
+			ctxSetup: func(deps *evmtest.TestDeps) {
+				gasPrice := sdk.NewInt64Coin("unibi", 1)
+				maxGasMicronibi := new(big.Int).Add(evmtest.GasLimitCreateContract(), big.NewInt(100))
+				cp := &tmproto.ConsensusParams{
+					Block: &tmproto.BlockParams{
+						MaxGas: evm.NativeToWei(maxGasMicronibi).Int64(),
+					},
+				}
+				deps.SetCtx(deps.Ctx().
+					WithMinGasPrices(sdk.NewDecCoins(sdk.NewDecCoinFromCoin(gasPrice))).
+					WithIsCheckTx(true).
+					WithConsensusParams(cp),
+				)
+			},
+			txSetup: func(deps *evmtest.TestDeps) sdk.FeeTx {
+				targetAddr := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+				txMsg := evm.NewTx(&evm.EvmTxArgs{
+					ChainID:  deps.App.EvmKeeper.EthChainID(deps.Ctx()),
+					Nonce:    0,
+					GasLimit: 50_000,
+					GasPrice: evm.NativeToWei(big.NewInt(1)),
+					To:       &targetAddr,
+					Amount:   big.NewInt(123),
+				})
+				txMsg.From = deps.Sender.EthAddr.Hex()
+				gethSigner := gethcore.LatestSignerForChainID(deps.App.EvmKeeper.EthChainID(deps.Ctx()))
+				err := txMsg.Sign(gethSigner, deps.Sender.KeyringSigner)
+				s.Require().NoError(err)
+				txBuilder := deps.App.GetTxConfig().NewTxBuilder()
+				tx, err := txMsg.BuildTx(txBuilder, eth.EthBaseDenom)
+				s.Require().NoError(err)
+				return tx
+			},
+			wantErr: "",
+			onSuccess: func(newCtx sdk.Context) {
+				s.Require().True(evm.IsZeroGasEthTx(newCtx), "expected IsZeroGasEthTx to be true for payable zero-gas tx")
+			},
+		},
+		{
+			name: "zero-gas: nonzero value with insufficient value balance fails full ante",
+			beforeTxSetup: func(deps *evmtest.TestDeps, sdb *evmstate.SDB) {
+				targetAddr := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+				deps.App.SudoKeeper.ZeroGasActors.Set(deps.Ctx(), sudo.ZeroGasActors{
+					AlwaysZeroGasContracts: []string{targetAddr.Hex()},
+				})
+				AddBalanceSigned(sdb, deps.Sender.EthAddr, big.NewInt(122))
+			},
+			ctxSetup: func(deps *evmtest.TestDeps) {
+				gasPrice := sdk.NewInt64Coin("unibi", 1)
+				maxGasMicronibi := new(big.Int).Add(evmtest.GasLimitCreateContract(), big.NewInt(100))
+				cp := &tmproto.ConsensusParams{
+					Block: &tmproto.BlockParams{
+						MaxGas: evm.NativeToWei(maxGasMicronibi).Int64(),
+					},
+				}
+				deps.SetCtx(deps.Ctx().
+					WithMinGasPrices(sdk.NewDecCoins(sdk.NewDecCoinFromCoin(gasPrice))).
+					WithIsCheckTx(true).
+					WithConsensusParams(cp),
+				)
+			},
+			txSetup: func(deps *evmtest.TestDeps) sdk.FeeTx {
+				targetAddr := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+				txMsg := evm.NewTx(&evm.EvmTxArgs{
+					ChainID:  deps.App.EvmKeeper.EthChainID(deps.Ctx()),
+					Nonce:    0,
+					GasLimit: 50_000,
+					GasPrice: big.NewInt(0),
+					To:       &targetAddr,
+					Amount:   big.NewInt(123),
+				})
+				txMsg.From = deps.Sender.EthAddr.Hex()
+				gethSigner := gethcore.LatestSignerForChainID(deps.App.EvmKeeper.EthChainID(deps.Ctx()))
+				err := txMsg.Sign(gethSigner, deps.Sender.KeyringSigner)
+				s.Require().NoError(err)
+				txBuilder := deps.App.GetTxConfig().NewTxBuilder()
+				tx, err := txMsg.BuildTx(txBuilder, eth.EthBaseDenom)
+				s.Require().NoError(err)
+				return tx
+			},
+			wantErr: "failed to transfer 123 wei",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/x/evm/evmante/evmante_can_transfer_test.go
+++ b/x/evm/evmante/evmante_can_transfer_test.go
@@ -201,9 +201,8 @@ func happyGasLimit() *big.Int {
 	)
 }
 
-// TestCanTransfer_ZeroGas_RunsAndPasses documents that CanTransfer runs (does not skip)
-// for zero-gas txs and passes. EffectiveGasFeeCapWei returns max(baseFee, txCap), so the
-// gas cap check passes; value is 0 by eligibility so the value check no-ops.
+// TestCanTransfer_ZeroGas_RunsAndPasses documents that CanTransfer runs (does
+// not skip) for zero-gas txs and passes. The zero value check no-ops.
 func TestCanTransfer_ZeroGas_RunsAndPasses(t *testing.T) {
 	targetAddr := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
 	deps := evmtest.NewTestDeps()
@@ -234,4 +233,68 @@ func TestCanTransfer_ZeroGas_RunsAndPasses(t *testing.T) {
 
 	err = evmante.AnteStepCanTransfer(sdb, sdb.Keeper(), tx, false, ANTE_OPTIONS_UNUSED)
 	require.NoError(t, err, "CanTransfer must run and pass for zero-gas tx")
+}
+
+func TestCanTransfer_ZeroGas_NonZeroValueExactBalancePasses(t *testing.T) {
+	targetAddr := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+	deps := evmtest.NewTestDeps()
+
+	deps.App.SudoKeeper.ZeroGasActors.Set(deps.Ctx(), sudo.ZeroGasActors{
+		AlwaysZeroGasContracts: []string{targetAddr.Hex()},
+	})
+
+	sdb := deps.NewStateDB()
+	valueWei := big.NewInt(123)
+	AddBalanceSigned(sdb, deps.Sender.EthAddr, valueWei)
+
+	tx := evm.NewTx(&evm.EvmTxArgs{
+		ChainID:   deps.App.EvmKeeper.EthChainID(deps.Ctx()),
+		Nonce:     0,
+		GasLimit:  50_000,
+		GasFeeCap: big.NewInt(1_200_000_000_000),
+		GasTipCap: big.NewInt(0),
+		To:        &targetAddr,
+		Amount:    valueWei,
+	})
+	tx.From = deps.Sender.EthAddr.Hex()
+
+	gethSigner := gethcore.LatestSignerForChainID(deps.App.EvmKeeper.EthChainID(deps.Ctx()))
+	require.NoError(t, tx.Sign(gethSigner, deps.Sender.KeyringSigner))
+
+	require.NoError(t, evmante.AnteStepDetectZeroGas(sdb, sdb.Keeper(), tx, false, ANTE_OPTIONS_UNUSED))
+	require.True(t, evm.IsZeroGasEthTx(sdb.Ctx()))
+
+	require.NoError(t, evmante.AnteStepCanTransfer(sdb, sdb.Keeper(), tx, false, ANTE_OPTIONS_UNUSED))
+}
+
+func TestCanTransfer_ZeroGas_NonZeroValueInsufficientBalanceFails(t *testing.T) {
+	targetAddr := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+	deps := evmtest.NewTestDeps()
+
+	deps.App.SudoKeeper.ZeroGasActors.Set(deps.Ctx(), sudo.ZeroGasActors{
+		AlwaysZeroGasContracts: []string{targetAddr.Hex()},
+	})
+
+	sdb := deps.NewStateDB()
+	valueWei := big.NewInt(123)
+	AddBalanceSigned(sdb, deps.Sender.EthAddr, big.NewInt(122))
+
+	tx := evm.NewTx(&evm.EvmTxArgs{
+		ChainID:  deps.App.EvmKeeper.EthChainID(deps.Ctx()),
+		Nonce:    0,
+		GasLimit: 50_000,
+		GasPrice: big.NewInt(0),
+		To:       &targetAddr,
+		Amount:   valueWei,
+	})
+	tx.From = deps.Sender.EthAddr.Hex()
+
+	gethSigner := gethcore.LatestSignerForChainID(deps.App.EvmKeeper.EthChainID(deps.Ctx()))
+	require.NoError(t, tx.Sign(gethSigner, deps.Sender.KeyringSigner))
+
+	require.NoError(t, evmante.AnteStepDetectZeroGas(sdb, sdb.Keeper(), tx, false, ANTE_OPTIONS_UNUSED))
+	require.True(t, evm.IsZeroGasEthTx(sdb.Ctx()))
+
+	err := evmante.AnteStepCanTransfer(sdb, sdb.Keeper(), tx, false, ANTE_OPTIONS_UNUSED)
+	require.ErrorContains(t, err, "failed to transfer 123 wei")
 }

--- a/x/evm/evmante/evmante_zero_gas.go
+++ b/x/evm/evmante/evmante_zero_gas.go
@@ -19,7 +19,6 @@ var _ AnteStep = AnteStepDetectZeroGas
 //
 // Eligibility:
 //   - tx.To is in ZeroGasActors.AlwaysZeroGasContracts (EVM hex address list)
-//   - tx.Value == 0
 //
 // No state mutations. Only sets ZeroGasMeta in context as a marker.
 func AnteStepDetectZeroGas(

--- a/x/evm/evmante/evmante_zero_gas_test.go
+++ b/x/evm/evmante/evmante_zero_gas_test.go
@@ -134,7 +134,7 @@ func TestAnteStepDetectZeroGas_Eligible_NonLegacyNonZeroFeeFields(t *testing.T) 
 	require.Equal(t, 0, balBefore.Cmp(sdb.GetBalance(from).ToBig()))
 }
 
-func TestAnteStepDetectZeroGas_Eligible_NonZeroValue_NoMeta(t *testing.T) {
+func TestAnteStepDetectZeroGas_Eligible_NonZeroValue_SetsMeta(t *testing.T) {
 	deps := evmtest.NewTestDeps()
 	// Configure ZeroGasActors with an always_zero_gas_contracts entry.
 	targetAddr := addr3
@@ -144,7 +144,7 @@ func TestAnteStepDetectZeroGas_Eligible_NonZeroValue_NoMeta(t *testing.T) {
 
 	sdb := deps.NewStateDB()
 
-	// Create a tx that targets the allowlisted contract but with non-zero value.
+	// Create a tx that targets the allowlisted contract with non-zero value.
 	to := targetAddr
 	tx := evm.NewTx(&evm.EvmTxArgs{
 		ChainID:  deps.App.EvmKeeper.EthChainID(deps.Ctx()),
@@ -152,7 +152,7 @@ func TestAnteStepDetectZeroGas_Eligible_NonZeroValue_NoMeta(t *testing.T) {
 		GasLimit: 50_000,
 		GasPrice: big.NewInt(1),
 		To:       &to,
-		Amount:   big.NewInt(1), // non-zero value should make tx ineligible
+		Amount:   big.NewInt(1),
 	})
 	tx.From = deps.Sender.EthAddr.Hex()
 
@@ -168,10 +168,9 @@ func TestAnteStepDetectZeroGas_Eligible_NonZeroValue_NoMeta(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// No meta should be set for non-zero value.
-	require.False(t, evm.IsZeroGasEthTx(sdb.Ctx()))
+	require.True(t, evm.IsZeroGasEthTx(sdb.Ctx()))
 
-	// Balance should be unchanged.
+	// Detection only sets metadata; value solvency is checked by later ante steps.
 	require.Equal(t, 0, initialBal.Cmp(sdb.GetBalance(from).ToBig()))
 }
 

--- a/x/evm/evmstate/msg_ethereum_tx_test.go
+++ b/x/evm/evmstate/msg_ethereum_tx_test.go
@@ -367,6 +367,48 @@ func (s *Suite) TestMsgEthereumTx_ZeroGas_ClassifiesAllowlistedType2Tx() {
 	s.Require().Equal(0, sdbAfter.GetBalance(ethAcc.EthAddr).Cmp(uint256.NewInt(0)))
 }
 
+func (s *Suite) TestMsgEthereumTx_ZeroGas_NonZeroValueTransfersWithoutGasPayment() {
+	deps := evmtest.NewTestDeps()
+	ethAcc := deps.Sender
+	to := gethcommon.HexToAddress("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed")
+	deps.App.SudoKeeper.ZeroGasActors.Set(deps.Ctx(), sudo.ZeroGasActors{
+		AlwaysZeroGasContracts: []string{to.Hex()},
+	})
+
+	valueWei := evm.NativeToWei(big.NewInt(1))
+	s.Require().NoError(testapp.FundAccount(
+		deps.App.BankKeeper,
+		deps.Ctx(),
+		deps.Sender.NibiruAddr,
+		sdk.NewCoins(sdk.NewInt64Coin("unibi", 1)),
+	))
+
+	ethTxMsg, err := evmtest.NewEthTxMsgFromTxData(
+		&deps,
+		gethcore.DynamicFeeTxType,
+		nil,
+		deps.EvmKeeper.GetAccNonce(deps.Ctx(), ethAcc.EthAddr),
+		&to,
+		valueWei,
+		100_000,
+		nil,
+	)
+	s.Require().NoError(err)
+	s.Require().NoError(ethTxMsg.ValidateBasic())
+
+	resp, err := deps.App.EvmKeeper.EthereumTx(sdk.WrapSDKContext(deps.Ctx()), ethTxMsg)
+	s.Require().NoError(err)
+	s.Require().Empty(resp.VmError)
+
+	sdbAfter := deps.EvmKeeper.NewSDB(
+		deps.Ctx(),
+		deps.EvmKeeper.TxConfig(deps.Ctx(), gethcommon.HexToHash(ethTxMsg.Hash)),
+	)
+	s.Require().Equal(0, sdbAfter.GetBalance(evm.FEE_COLLECTOR_ADDR).Cmp(uint256.NewInt(0)))
+	s.Require().Equal(0, sdbAfter.GetBalance(ethAcc.EthAddr).Cmp(uint256.NewInt(0)))
+	s.Require().Equal(0, sdbAfter.GetBalance(to).Cmp(uint256.MustFromBig(valueWei)))
+}
+
 // TestMsgEthereumTx_ZeroGas_WithRefund is like TestMsgEthereumTx_ZeroGas but uses a
 // higher gas limit. With bypass, RefundGas is skipped so no refund occurs. Balances stay at 0.
 // Same setup: msg_server only, zero-gas marker injected in context (ante not run).

--- a/x/evm/evmtest/upgrades.go
+++ b/x/evm/evmtest/upgrades.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (deps *TestDeps) RunUpgrade(upgrade upgrades.Upgrade) error {
-	upgradeHandler := upgrade.CreateUpgradeHandler(
+	upgradeHandler := upgrade.Handler.Handler(
 		deps.App.ModuleManager,
 		module.NewConfigurator(
 			deps.App.AppCodec(),
@@ -20,7 +20,6 @@ func (deps *TestDeps) RunUpgrade(upgrade upgrades.Upgrade) error {
 			deps.App.GRPCQueryRouter(),
 		),
 		&deps.App.PublicKeepers,
-		deps.App.GetIBCKeeper().ClientKeeper,
 	)
 
 	// ---- Run the upgrade handler. ----

--- a/x/evm/zero_gas.go
+++ b/x/evm/zero_gas.go
@@ -15,8 +15,8 @@ import (
 // must not buy priority.
 const DefaultZeroGasTxPriority int64 = 0
 
-// IsZeroGasTxData returns true when txData matches the contract-level zero-gas
-// policy: value == 0 and to is in the `always_zero_gas_contracts` set.
+// IsZeroGasTxData returns true when txData targets a contract in the
+// `always_zero_gas_contracts` set.
 func IsZeroGasTxData(
 	ctx sdk.Context,
 	sudoKeeper SudoKeeper,
@@ -28,10 +28,6 @@ func IsZeroGasTxData(
 
 	to := txData.GetTo()
 	if to == nil {
-		return false
-	}
-
-	if value := txData.GetValueWei(); value != nil && value.Sign() != 0 {
 		return false
 	}
 
@@ -63,7 +59,7 @@ func IsZeroGasMsgEthereumTx(
 	return IsZeroGasTxData(ctx, sudoKeeper, txData), txData, nil
 }
 
-// IsZeroGasJsonTxArgs classifies JSON-RPC call args using the same to/value
+// IsZeroGasJsonTxArgs classifies JSON-RPC call args using the same destination
 // policy as signed execution.
 func IsZeroGasJsonTxArgs(
 	ctx sdk.Context,
@@ -71,10 +67,6 @@ func IsZeroGasJsonTxArgs(
 	args JsonTxArgs,
 ) bool {
 	if sudoKeeper == nil || args.To == nil {
-		return false
-	}
-
-	if args.Value != nil && args.Value.ToInt().Sign() != 0 {
 		return false
 	}
 
@@ -106,9 +98,6 @@ func NormalizeZeroGasMessage(msg core.Message) core.Message {
 func ValidateZeroGasTxData(txData TxData) error {
 	if txData.GetTo() == nil {
 		return sdkioerrors.Wrap(sdkerrors.ErrInvalidRequest, "zero-gas tx must not be contract creation")
-	}
-	if value := txData.GetValueWei(); value != nil && value.Sign() != 0 {
-		return sdkioerrors.Wrapf(ErrInvalidAmount, "zero-gas tx value must be zero: %s", value)
 	}
 	for _, err := range []error{
 		ValidateTxDataAmount(txData),

--- a/x/evm/zero_gas_test.go
+++ b/x/evm/zero_gas_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/NibiruChain/nibiru/v2/x/sudo"
 )
 
-func TestZeroGasClassificationUsesAllowlistAndZeroValue(t *testing.T) {
+func TestZeroGasClassificationUsesAllowlist(t *testing.T) {
 	deps := evmtest.NewTestDeps()
 	allowlisted := gethcommon.HexToAddress("0x1111111111111111111111111111111111111111")
 	other := gethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
@@ -25,7 +25,7 @@ func TestZeroGasClassificationUsesAllowlistAndZeroValue(t *testing.T) {
 		AlwaysZeroGasContracts: []string{allowlisted.Hex()},
 	})
 
-	tx := newSignedDynamicFeeTx(t, &deps, &allowlisted, big.NewInt(0), big.NewInt(1), big.NewInt(2))
+	tx := newSignedDynamicFeeTx(t, &deps, &allowlisted, big.NewInt(1), big.NewInt(1), big.NewInt(2))
 	isZeroGas, txData, err := evm.IsZeroGasMsgEthereumTx(deps.Ctx(), deps.App.SudoKeeper, tx)
 	require.NoError(t, err)
 	require.True(t, isZeroGas)
@@ -38,7 +38,7 @@ func TestZeroGasClassificationUsesAllowlistAndZeroValue(t *testing.T) {
 	}))
 
 	nonzeroValue := (*hexutil.Big)(big.NewInt(1))
-	require.False(t, evm.IsZeroGasJsonTxArgs(deps.Ctx(), deps.App.SudoKeeper, evm.JsonTxArgs{
+	require.True(t, evm.IsZeroGasJsonTxArgs(deps.Ctx(), deps.App.SudoKeeper, evm.JsonTxArgs{
 		To:    &allowlisted,
 		Value: nonzeroValue,
 	}))
@@ -131,7 +131,35 @@ func TestValidateZeroGasTxDataSkipsFeeChecksAndKeepsNonFeeChecks(t *testing.T) {
 	valueTransfer := newSignedDynamicFeeTx(t, &deps, &to, big.NewInt(1), big.NewInt(1), big.NewInt(1))
 	valueTransferData, err := evm.UnpackTxData(valueTransfer.Data)
 	require.NoError(t, err)
-	require.ErrorContains(t, evm.ValidateZeroGasTxData(valueTransferData), "zero-gas tx value must be zero")
+	require.NoError(t, evm.ValidateZeroGasTxData(valueTransferData))
+
+	zeroValue := newSignedDynamicFeeTx(t, &deps, &to, big.NewInt(0), big.NewInt(1), big.NewInt(1))
+	zeroValueData, err := evm.UnpackTxData(zeroValue.Data)
+	require.NoError(t, err)
+	require.NoError(t, evm.ValidateZeroGasTxData(zeroValueData))
+
+	chainID := sdkmath.NewIntFromBigInt(deps.App.EvmKeeper.EthChainID(deps.Ctx()))
+	nilValue := &evm.DynamicFeeTx{
+		ChainID:   &chainID,
+		Nonce:     0,
+		GasLimit:  21_000,
+		GasFeeCap: nutil.Ptr(sdkmath.NewInt(1)),
+		GasTipCap: nutil.Ptr(sdkmath.NewInt(1)),
+		To:        to.Hex(),
+	}
+	require.NoError(t, evm.ValidateZeroGasTxData(nilValue))
+
+	negativeAmount := sdkmath.NewInt(-1)
+	negativeValue := &evm.DynamicFeeTx{
+		ChainID:   &chainID,
+		Nonce:     0,
+		GasLimit:  21_000,
+		GasFeeCap: nutil.Ptr(sdkmath.NewInt(1)),
+		GasTipCap: nutil.Ptr(sdkmath.NewInt(1)),
+		To:        to.Hex(),
+		Amount:    &negativeAmount,
+	}
+	require.ErrorContains(t, evm.ValidateZeroGasTxData(negativeValue), "amount cannot be negative")
 
 	missingChainID := &evm.DynamicFeeTx{
 		Nonce:     0,


### PR DESCRIPTION
# Allow Zero-Gas EVM Calls With Native Value

This updates EVM zero-gas handling so `always_zero_gas_contracts` waives native
NIBI gas payment without also requiring `tx.Value == 0`. Payable calls to
allowlisted contracts can now use zero-gas execution while still requiring the
sender to have enough EVM native balance for `msg.value`.

## Key Changes

- Removes the nonzero-value exclusion from signed transaction and JSON-RPC
  zero-gas classification, keeping `always_zero_gas_contracts` as the existing
  policy surface.
- Keeps native value solvency enforced through ante and EVM execution: zero-gas
  skips gas affordability, but `senderBalance >= tx.Value` is still required for
  payable calls.
- Adds focused regression coverage for nonzero-value classification, nil/zero/
  positive/negative value validation, full ante exact-balance pass/fail cases,
  and message-server value transfer without gas payment.
- Updates zero-gas docs and release notes so maintainers do not keep relying on
  the old `tx.Value == 0` eligibility rule.
