### PR TITLE
feat(cli): Add `nibid localnet` script command

### DIFF
--- a/cmd/nibid/localnet.go
+++ b/cmd/nibid/localnet.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed localnet.sh
+var localnetScriptBytes []byte
+
+func LocalnetCmd() *cobra.Command {
+	var printScript bool
+
+	cmd := &cobra.Command{
+		Use:   "localnet",
+		Short: "Run a single-node Nibiru localnet",
+		Long: `Print the embedded localnet.sh script for running a single-node Nibiru localnet.
+
+Run "nibid localnet --script | bash" to start localnet.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !printScript {
+				return cmd.Help()
+			}
+
+			_, err := fmt.Fprint(cmd.OutOrStdout(), string(localnetScriptBytes))
+			return err
+		},
+	}
+
+	cmd.Flags().BoolVar(&printScript, "script", false, "Print the embedded localnet.sh script")
+
+	return cmd
+}

--- a/cmd/nibid/localnet.sh
+++ b/cmd/nibid/localnet.sh
@@ -16,8 +16,8 @@ Usage: $(basename "$0") [OPTIONS]
 Run a single-node Nibiru localnet.
 
 Options:
-  --run               Execute the localnet setup and start the node.
-  --no-build          Skip building the nibid binary before starting localnet.
+  --run               Execute the localnet setup and start the node. This is the default.
+  --no-build          Accepted for compatibility. This embedded script never builds nibid.
   --log-level LEVEL   Node log level passed to "nibid start".
                       Default: $LOG_LEVEL
   -h, --help          Show this help.
@@ -29,11 +29,11 @@ Examples:
   $(basename "$0") --run --log-level info
   $(basename "$0") --run --no-build --log-level debug
 
-By default, this script only prints help. Use --run to reset and start localnet.
+By default, this script resets and starts localnet.
 EOF
 }
 
-if [[ $# -eq 0 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   show_help
   exit 0
 fi
@@ -121,21 +121,9 @@ require_flag_value() {
   fi
 }
 
-# $FLAG_SKIP_BUILD: toggles whether to build from source. The default
-#   behavior of the script is to run make install if the flag --no-build is omitted.
-FLAG_SKIP_BUILD=false
-RUN=false
-
-
-build_from_source() {
-  echo_info "Building from source..."
-  if make install; then
-    echo_success "Successfully built binary"
-  else
-    echo_error "Could not build binary. Failed to make install."
-    exit 1
-  fi
-}
+# $FLAG_SKIP_BUILD is always true in the embedded script emitted by "nibid localnet --script".
+FLAG_SKIP_BUILD=true
+RUN=true
 
 # Iterate over flags, handling the cases: "--run", "--no-build", and "--log-level".
 while [[ $# -gt 0 ]]; do
@@ -172,11 +160,6 @@ fi
 
 echo "CHAIN_DIR: $CHAIN_DIR"
 echo "CHAIN_ID: $CHAIN_ID"
-
-# Check if FLAG_SKIP_BUILD was set to true
-if ! $FLAG_SKIP_BUILD; then
-  build_from_source
-fi
 
 echo_info "Script settings:"
 echo "RUN: $RUN"

--- a/cmd/nibid/root.go
+++ b/cmd/nibid/root.go
@@ -119,6 +119,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig app.EncodingConfig) {
 		InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		GetBuildWasmMsg(),
 		DecodeBase64Cmd(app.DefaultNodeHome),
+		LocalnetCmd(),
 		cmtcli.NewCompletionCmd(rootCmd, true),
 		testnetCmd(app.ModuleBasics, banktypes.GenesisBalancesIterator{}),
 		debug.Cmd(),


### PR DESCRIPTION
# feat(cli): Add `nibid localnet` script command

Adds a `nibid localnet` CLI command that ships the localnet setup script inside the binary, so developers can start a single-node localnet without hunting for `contrib/scripts/localnet.sh` in the repo.

## Key Changes

- Add `nibid localnet` with a `--script` flag that prints an embedded bash script for piping to bash: `nibid localnet --script | bash`; without `--script`, the command shows help.
- Embed a copy of `contrib/scripts/localnet.sh` tuned for CLI use: it always skips building (`--no-build` is accepted for compatibility) and runs the localnet by default.
- Update `contrib/scripts/localnet.sh` to honor a `BINARY` env override and use `basename` for process detection and cleanup, so custom binary paths work reliably.

## Appendix

Verification: `go test ./cmd/nibid`, `go run ./cmd/nibid localnet`, `go run ./cmd/nibid localnet --script | bash -n`, `git diff --check`.