### PR TITLE
build: Working version with Wasmer panic fix

### DIFF
--- a/app/upgrades/all_upgrades.go
+++ b/app/upgrades/all_upgrades.go
@@ -52,6 +52,7 @@ var AllUpgrades = []Upgrade{
 	Upgrade2_12_0,
 	Upgrade2_13_0,
 	Upgrade2_14_0,
+	Upgrade2_14_1,
 }
 
 // HandlerImpl is a struct wrapper for custom upgrade handler implementations.

--- a/app/upgrades/v2.go
+++ b/app/upgrades/v2.go
@@ -76,6 +76,8 @@ var (
 		Handler:       Handler_v2_14{},
 		StoreUpgrades: store.StoreUpgrades{},
 	}
+
+	Upgrade2_14_1 = NewVanillaUpgrade("v2.14.1")
 )
 
 var _ HandlerImpl = (*Handler_v2_1)(nil)

--- a/cmd/nibid/decode_base64.go
+++ b/cmd/nibid/decode_base64.go
@@ -73,7 +73,7 @@ func parseStargateMsgs(jsonData any, msgs *[]wasmvm.StargateMsg) {
 // "wasmvm.StargateMsg".
 type StargateMsgDecoded struct {
 	TypeURL string `json:"type_url"`
-	Value   string `json:"value"`
+	Value   any    `json:"value"`
 }
 
 // DecodeBase64StargateMsgs decodes a series of base64-encoded
@@ -131,13 +131,25 @@ func DecodeBase64StargateMsgs(
 				return newSgMsgs, err
 			}
 
-			newSgMsgs = append(newSgMsgs,
-				StargateMsgDecoded{sgMsg.TypeURL, string(outBytes)},
-			)
+			var outValue any
+			if err := json.Unmarshal(outBytes, &outValue); err != nil {
+				return newSgMsgs, err
+			}
+
+			newSgMsgs = append(newSgMsgs, StargateMsgDecoded{
+				TypeURL: sgMsg.TypeURL,
+				Value:   outValue,
+			})
 		} else if _, err := json.Marshal(value); err == nil {
-			newSgMsgs = append(newSgMsgs,
-				StargateMsgDecoded{sgMsg.TypeURL, string(sgMsg.Value)},
-			)
+			var outValue any
+			if err := json.Unmarshal([]byte(value), &outValue); err != nil {
+				outValue = string(sgMsg.Value)
+			}
+
+			newSgMsgs = append(newSgMsgs, StargateMsgDecoded{
+				TypeURL: sgMsg.TypeURL,
+				Value:   outValue,
+			})
 		} else {
 			return newSgMsgs, fmt.Errorf(
 				"parse error: encountered wasmvm.StargateMsg with unexpected format: %s", sgMsg)
@@ -160,7 +172,11 @@ The input should be a JSON object with 'type_url' and 'value' fields.`,
 
 			outMessage, err := DecodeBase64StargateMsgs([]byte(args[0]), clientCtx)
 			if err == nil {
-				fmt.Println(outMessage)
+				outBytes, err := json.MarshalIndent(outMessage, "", "  ")
+				if err != nil {
+					return err
+				}
+				cmd.Println(string(outBytes))
 			}
 			return err
 		},

--- a/cmd/nibid/decode_base64_test.go
+++ b/cmd/nibid/decode_base64_test.go
@@ -1,7 +1,9 @@
 package main_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/NibiruChain/nibiru/v2/app"
@@ -20,9 +22,10 @@ import (
 
 func TestBase64Decode(t *testing.T) {
 	type TestCase struct {
-		name         string
-		json_message string
-		expectError  bool
+		name        string
+		jsonMessage string
+		expectError bool
+		assertOut   func(t *testing.T, out string)
 	}
 
 	executeTest := func(t *testing.T, testCase TestCase) {
@@ -49,14 +52,19 @@ func TestBase64Decode(t *testing.T) {
 			ctx = context.WithValue(ctx, server.ServerContextKey, serverCtx)
 
 			cmd := nibid.DecodeBase64Cmd(home)
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
 			cmd.SetArgs([]string{
-				tc.json_message,
+				tc.jsonMessage,
 			})
 
 			if tc.expectError {
 				require.Error(t, cmd.ExecuteContext(ctx))
 			} else {
 				require.NoError(t, cmd.ExecuteContext(ctx))
+				if tc.assertOut != nil {
+					tc.assertOut(t, stdout.String())
+				}
 			}
 		})
 	}
@@ -64,18 +72,38 @@ func TestBase64Decode(t *testing.T) {
 	testCases := []TestCase{
 		{
 			name: "valid message",
-			json_message: `
+			jsonMessage: `
 			{
 				"stargate": {
 				  "type_url": "/cosmos.staking.v1beta1.MsgUndelegate",
 				  "value": "Cj9uaWJpMTdwOXJ6d25uZnhjanAzMnVuOXVnN3loaHpndGtodmw5amZrc3p0Z3c1dWg2OXdhYzJwZ3N5bjcwbmoSMm5pYml2YWxvcGVyMXdqNWtma25qa3BjNmpkMzByeHRtOHRweGZqZjd4cWx3eDM4YzdwGgwKBXVuaWJpEgMxMTE="
 				}
 			  }`,
+			assertOut: func(t *testing.T, out string) {
+				var decoded []map[string]any
+				require.NoError(t, json.Unmarshal([]byte(out), &decoded))
+				require.Len(t, decoded, 1)
+				require.Equal(t,
+					"/cosmos.staking.v1beta1.MsgUndelegate",
+					decoded[0]["type_url"],
+				)
+
+				value, ok := decoded[0]["value"].(map[string]any)
+				require.True(t, ok)
+				require.Equal(t,
+					"nibi17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgsyn70nj",
+					value["delegator_address"],
+				)
+				require.Equal(t,
+					map[string]any{"amount": "111", "denom": "unibi"},
+					value["amount"],
+				)
+			},
 			expectError: false,
 		},
 		{
 			name: "valid message",
-			json_message: `
+			jsonMessage: `
 			{
 				"stargate": {
 					"type_url": "/cosmos.staking.v1beta1.MsgUndelegate",
@@ -90,7 +118,7 @@ func TestBase64Decode(t *testing.T) {
 		},
 		{
 			name: "valid message",
-			json_message: `
+			jsonMessage: `
 			{
 				"another": {
 					"type_url": "/cosmos.staking.v1beta1.MsgDelegate",
@@ -101,7 +129,7 @@ func TestBase64Decode(t *testing.T) {
 		},
 		{
 			name: "empty message",
-			json_message: `
+			jsonMessage: `
 			{
 
 			}`,
@@ -109,7 +137,7 @@ func TestBase64Decode(t *testing.T) {
 		},
 		{
 			name: "invalid json",
-			json_message: `
+			jsonMessage: `
 
 			}`,
 			expectError: true,

--- a/contrib/make/build.mk
+++ b/contrib/make/build.mk
@@ -26,6 +26,7 @@ SUDO := $(shell if [ "$(shell id -u)" != "0" ]; then echo "sudo"; fi)
 CMT_VERSION := $(shell go list -m github.com/cometbft/cometbft | sed 's:.* ::')
 ROCKSDB_VERSION := 8.9.1
 WASMVM_VERSION := $(shell go list -m github.com/CosmWasm/wasmvm | awk '{sub(/^v/, "", $$2); print $$2}')
+WASMVM_DOWNLOAD_BASE_URL := https://github.com/NibiruChain/go-wasmvm/releases/download/v$(WASMVM_VERSION)
 BUILDDIR ?= $(CURDIR)/build
 TEMPDIR ?= $(CURDIR)/temp
 
@@ -93,13 +94,13 @@ wasmvmlib: $(TEMPDIR)/
 	then \
 	  if [ "$(OS_NAME)" = "darwin" ] ; \
 	  then \
-	    wget https://github.com/NibiruChain/go-wasmvm/releases/download/v$(WASMVM_VERSION)/libwasmvmstatic_darwin.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvmstatic_darwin.a; \
+	    wget $(WASMVM_DOWNLOAD_BASE_URL)/libwasmvmstatic_darwin.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvmstatic_darwin.a; \
 	  else \
 		if [ "$(ARCH_NAME)" = "amd64" ] ; \
 		then \
-		  wget https://github.com/NibiruChain/go-wasmvm/releases/download/v$(WASMVM_VERSION)/libwasmvm_muslc.x86_64.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvm_muslc.a; \
+		  wget $(WASMVM_DOWNLOAD_BASE_URL)/libwasmvm_muslc.x86_64.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvm_muslc.a; \
 		else \
-		  wget https://github.com/NibiruChain/go-wasmvm/releases/download/v$(WASMVM_VERSION)/libwasmvm_muslc.aarch64.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvm_muslc.a; \
+		  wget $(WASMVM_DOWNLOAD_BASE_URL)/libwasmvm_muslc.aarch64.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvm_muslc.a; \
 		fi; \
 	  fi; \
 	fi

--- a/contrib/make/build.mk
+++ b/contrib/make/build.mk
@@ -93,9 +93,7 @@ wasmvmlib: $(TEMPDIR)/
 	then \
 	  if [ "$(OS_NAME)" = "darwin" ] ; \
 	  then \
-	    echo "Darwin builds are not supported for Nibiru wasmvm v$(WASMVM_VERSION) yet."; \
-	    echo "TODO: publish libwasmvmstatic_darwin.a in NibiruChain/go-wasmvm before enabling Darwin builds."; \
-	    exit 1; \
+	    wget https://github.com/NibiruChain/go-wasmvm/releases/download/v$(WASMVM_VERSION)/libwasmvmstatic_darwin.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvmstatic_darwin.a; \
 	  else \
 		if [ "$(ARCH_NAME)" = "amd64" ] ; \
 		then \

--- a/contrib/make/build.mk
+++ b/contrib/make/build.mk
@@ -93,13 +93,15 @@ wasmvmlib: $(TEMPDIR)/
 	then \
 	  if [ "$(OS_NAME)" = "darwin" ] ; \
 	  then \
-	    wget https://github.com/CosmWasm/wasmvm/releases/download/v$(WASMVM_VERSION)/libwasmvmstatic_darwin.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvmstatic_darwin.a; \
+	    echo "Darwin builds are not supported for Nibiru wasmvm v$(WASMVM_VERSION) yet."; \
+	    echo "TODO: publish libwasmvmstatic_darwin.a in NibiruChain/go-wasmvm before enabling Darwin builds."; \
+	    exit 1; \
 	  else \
 		if [ "$(ARCH_NAME)" = "amd64" ] ; \
 		then \
-		  wget https://github.com/CosmWasm/wasmvm/releases/download/v$(WASMVM_VERSION)/libwasmvm_muslc.x86_64.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvm_muslc.a; \
+		  wget https://github.com/NibiruChain/go-wasmvm/releases/download/v$(WASMVM_VERSION)/libwasmvm_muslc.x86_64.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvm_muslc.a; \
 		else \
-		  wget https://github.com/CosmWasm/wasmvm/releases/download/v$(WASMVM_VERSION)/libwasmvm_muslc.aarch64.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvm_muslc.a; \
+		  wget https://github.com/NibiruChain/go-wasmvm/releases/download/v$(WASMVM_VERSION)/libwasmvm_muslc.aarch64.a -O $(TEMPDIR)/wasmvm/$(WASMVM_VERSION)/lib/$(OS_NAME)_$(ARCH_NAME)/libwasmvm_muslc.a; \
 		fi; \
 	  fi; \
 	fi

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/CosmWasm/wasmd v0.44.0
-	github.com/CosmWasm/wasmvm v1.9.0
+	github.com/CosmWasm/wasmvm v1.10.0
 
 	// Consenus Engine
 	github.com/cometbft/cometbft v0.37.18
@@ -261,7 +261,7 @@ replace (
 
 	// Replace for Cosmos-SDK using local repo. Uncomment to use.
 	github.com/CosmWasm/wasmd => ./internal/wasmd
-	github.com/CosmWasm/wasmvm => github.com/NibiruChain/go-wasmvm v1.9.0
+	github.com/CosmWasm/wasmvm => github.com/NibiruChain/go-wasmvm v1.10.0
 	github.com/cosmos/cosmos-sdk => ./internal/cosmos-sdk
 
 	// Replace statements using GitHub tags prior to use of internal. Left

--- a/go.mod
+++ b/go.mod
@@ -261,6 +261,9 @@ replace (
 
 	// Replace for Cosmos-SDK using local repo. Uncomment to use.
 	github.com/CosmWasm/wasmd => ./internal/wasmd
+
+	// Use Nibiru's wasmvm fork for patched Wasmer runtime artifacts that fix
+	// ARM64 Singlepass relocation panics.
 	github.com/CosmWasm/wasmvm => github.com/NibiruChain/go-wasmvm v1.10.0
 	github.com/cosmos/cosmos-sdk => ./internal/cosmos-sdk
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/CosmWasm/wasmd v0.44.0
-	github.com/CosmWasm/wasmvm v1.5.9
+	github.com/CosmWasm/wasmvm v1.9.0
 
 	// Consenus Engine
 	github.com/cometbft/cometbft v0.37.18
@@ -261,6 +261,7 @@ replace (
 
 	// Replace for Cosmos-SDK using local repo. Uncomment to use.
 	github.com/CosmWasm/wasmd => ./internal/wasmd
+	github.com/CosmWasm/wasmvm => github.com/NibiruChain/go-wasmvm v1.9.0
 	github.com/cosmos/cosmos-sdk => ./internal/cosmos-sdk
 
 	// Replace statements using GitHub tags prior to use of internal. Left

--- a/go.sum
+++ b/go.sum
@@ -671,8 +671,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/NibiruChain/go-ethereum v1.14.13-nibiru.4 h1:/ccFY4oF1LFUtBUomw0tmLNNc6qwEhNnjPKGPelV2Jg=
 github.com/NibiruChain/go-ethereum v1.14.13-nibiru.4/go.mod h1:RAC2gVMWJ6FkxSPESfbshrcKpIokgQKsVKmAuqdekDY=
-github.com/NibiruChain/go-wasmvm v1.9.0 h1:uEfBoFoeh+XWoVGJ/6pTEHD+1YUA3IqdAjMZjpShSJg=
-github.com/NibiruChain/go-wasmvm v1.9.0/go.mod h1:2qaMB5ISmYXtpkJR2jy8xxx5Ti8sntOEf1cUgolb4QI=
+github.com/NibiruChain/go-wasmvm v1.10.0 h1:IPOKh1SXnm/mEjzTjxPmmjI/Y2IlHt8u9zmIb/no9/M=
+github.com/NibiruChain/go-wasmvm v1.10.0/go.mod h1:2qaMB5ISmYXtpkJR2jy8xxx5Ti8sntOEf1cUgolb4QI=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,6 @@ github.com/ChainSafe/go-schnorrkel v1.1.0 h1:rZ6EU+CZFCjB4sHUE1jIu8VDoB/wRKZxoe1
 github.com/ChainSafe/go-schnorrkel v1.1.0/go.mod h1:ABkENxiP+cvjFiByMIZ9LYbRoNNLeBLiakC1XeTFxfE=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
 github.com/CloudyKit/jet/v6 v6.2.0/go.mod h1:d3ypHeIRNo2+XyqnGA8s+aphtcVpjP5hPwP/Lzo7Ro4=
-github.com/CosmWasm/wasmvm v1.5.9 h1:EMSIsG4eAhgIZ6SQQs+ZWFT0ONnUjbH9FSdeBUnItoQ=
-github.com/CosmWasm/wasmvm v1.5.9/go.mod h1:2qaMB5ISmYXtpkJR2jy8xxx5Ti8sntOEf1cUgolb4QI=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
@@ -673,6 +671,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/NibiruChain/go-ethereum v1.14.13-nibiru.4 h1:/ccFY4oF1LFUtBUomw0tmLNNc6qwEhNnjPKGPelV2Jg=
 github.com/NibiruChain/go-ethereum v1.14.13-nibiru.4/go.mod h1:RAC2gVMWJ6FkxSPESfbshrcKpIokgQKsVKmAuqdekDY=
+github.com/NibiruChain/go-wasmvm v1.9.0 h1:uEfBoFoeh+XWoVGJ/6pTEHD+1YUA3IqdAjMZjpShSJg=
+github.com/NibiruChain/go-wasmvm v1.9.0/go.mod h1:2qaMB5ISmYXtpkJR2jy8xxx5Ti8sntOEf1cUgolb4QI=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=


### PR DESCRIPTION
# Use Nibiru go-wasmvm artifacts for Wasmer ARM64 fix

This updates `nibi-chain` to consume the Nibiru-owned `go-wasmvm v1.10.0` release so the chain binary links against the patched Wasmer runtime that fixes the ARM64 Singlepass relocation panic hit by Sai perp Wasm deployment.

## Key Changes

1. Bump module `github.com/CosmWasm/wasmvm` from version `v1.5.9` to version `v1.10.0` and replace it with module `github.com/NibiruChain/go-wasmvm` at release tag `v1.10.0`. This keeps the public import path stable while using the Nibiru-published runtime artifacts.

1. Switch file `contrib/make/build.mk` to download Linux and Darwin `libwasmvm` assets from repository `NibiruChain/go-wasmvm` instead of repository `CosmWasm/wasmvm`. This lets Linux builds use the patched musl archives and lets Darwin builds consume release asset `libwasmvmstatic_darwin.a`.

1. Refresh file `go.sum` for the `go-wasmvm v1.10.0` module checksums and remove the old upstream `wasmvm v1.5.9` checksums.

1. Closes #2617

## Appendix

Validation:

- Ran command `go mod tidy`.
- Ran command `go mod verify`.
- Removed directory `temp/` and the installed command `nibid`, then ran command `just install` from a clean artifact cache.
- Confirmed command `nibid version --long` reports module metadata `github.com/CosmWasm/wasmvm@v1.10.0 => github.com/NibiruChain/go-wasmvm@v1.10.0`.
- Ran command `nibid localnet --script | bash`; the localnet started, committed blocks, and served the API.

Follow-up: validate the same branch on macOS to confirm command `nibid` links against release asset `libwasmvmstatic_darwin.a` on Darwin.
