### PR TITLE
test(evm-e2e): Use descriptive wait timeouts instead of ethers tx.wait for easier test debugging and less hanging

### DIFF
--- a/evm-e2e/test/contract_infinite_loop_gas.test.ts
+++ b/evm-e2e/test/contract_infinite_loop_gas.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test"
 import { toBigInt } from "ethers"
 
 import { TEST_TIMEOUT } from "./testdeps"
-import { deployContractInfiniteLoopGas } from "./utils"
+import { deployContractInfiniteLoopGas, txWait } from "./utils"
 
 describe("Infinite loop gas contract", () => {
   it(
@@ -14,7 +14,7 @@ describe("Infinite loop gas contract", () => {
 
       try {
         const tx = await contract.forever({ gasLimit: 1e6 })
-        await tx.wait()
+        await txWait(tx, { label: "infinite_loop forever" })
         throw new Error("The transaction should have failed but did not.")
       } catch (error) {
         expect(error.message).toContain("transaction execution reverted")

--- a/evm-e2e/test/contract_send_nibi.test.ts
+++ b/evm-e2e/test/contract_send_nibi.test.ts
@@ -12,8 +12,8 @@
 import { describe, expect, it } from "bun:test"
 import { parseEther, toBigInt, Wallet } from "ethers"
 
-import { account, provider, TEST_TIMEOUT, TX_WAIT_TIMEOUT } from "./testdeps"
-import { deployContractSendNibi } from "./utils"
+import { account, provider, TEST_TIMEOUT } from "./testdeps"
+import { deployContractSendNibi, txWait } from "./utils"
 
 async function testSendNibi(
   method: "sendViaTransfer" | "sendViaSend" | "sendViaCall",
@@ -27,7 +27,7 @@ async function testSendNibi(
   expect(recipientBalanceBefore).toEqual(BigInt(0))
 
   const tx = await contract[method](recipient, { value: weiToSend })
-  const receipt = await tx.wait(1, TX_WAIT_TIMEOUT)
+  const receipt = await txWait(tx, { label: `send_nibi ${method}` })
 
   const tenPow12 = toBigInt(1e12)
   const txCostMicronibi = weiToSend / tenPow12 + receipt.gasUsed

--- a/evm-e2e/test/debug_queries.test.ts
+++ b/evm-e2e/test/debug_queries.test.ts
@@ -2,8 +2,8 @@ import { beforeAll, describe, expect, it } from "bun:test"
 import { parseEther, TransactionReceipt } from "ethers"
 
 import { TestERC20__factory } from "../types"
-import { provider, TEST_TIMEOUT, TX_WAIT_TIMEOUT } from "./testdeps"
-import { alice, deployContractTestERC20, hexify } from "./utils"
+import { provider, TEST_TIMEOUT } from "./testdeps"
+import { alice, deployContractTestERC20, hexify, txWait } from "./utils"
 
 describe("debug queries", () => {
   let contractAddress: string
@@ -19,7 +19,7 @@ describe("debug queries", () => {
 
     // Execute some contract TX
     const txResponse = await contract.transfer(alice, parseEther("0.01"))
-    await txResponse.wait(1, TX_WAIT_TIMEOUT)
+    await txWait(txResponse, { label: "debug_queries transfer" })
 
     const receipt: TransactionReceipt = await provider.getTransactionReceipt(
       txResponse.hash,

--- a/evm-e2e/test/erc20.test.ts
+++ b/evm-e2e/test/erc20.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test"
 import { parseUnits, toBigInt, Wallet } from "ethers"
 
 import { account, TEST_TIMEOUT } from "./testdeps"
-import { deployContractTestERC20 } from "./utils"
+import { deployContractTestERC20, txWait } from "./utils"
 
 describe("ERC-20 contract tests", () => {
   it(
@@ -20,7 +20,7 @@ describe("ERC-20 contract tests", () => {
       // send to alice
       const amountToSend = parseUnits("1000", 18) // contract tokens
       let tx = await contract.transfer(alice, amountToSend)
-      await tx.wait()
+      await txWait(tx, { label: "erc20 transfer" })
 
       expect(contract.balanceOf(account)).resolves.toEqual(
         ownerInitialBalance - amountToSend,

--- a/evm-e2e/test/eth_queries.test.ts
+++ b/evm-e2e/test/eth_queries.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { AbiCoder, ethers, keccak256, parseEther } from "ethers"
 
-import { account, provider, TEST_TIMEOUT, TX_WAIT_TIMEOUT } from "./testdeps"
+import { account, provider, TEST_TIMEOUT } from "./testdeps"
 import {
   alice,
   deployContractSendNibi,
@@ -10,6 +10,7 @@ import {
   INTRINSIC_TX_GAS,
   numberToHex,
   sendTestNibi,
+  txWait,
 } from "./utils"
 
 describe("eth queries", () => {
@@ -161,7 +162,9 @@ describe("eth queries", () => {
 
       // Execute some contract TX
       const tx = await contract.transfer(alice, parseEther("0.01"))
-      await tx.wait(1, TX_WAIT_TIMEOUT)
+      await txWait(tx.hash, {
+        label: "eth_getFilterChanges transfer",
+      })
 
       // The Go filter API appends logs from an async SubscribeLogs goroutine
       // into the filter's in-memory f.logs queue. tx.wait proves the tx mined,
@@ -184,7 +187,7 @@ describe("eth queries", () => {
       const success = await provider.send("eth_uninstallFilter", [filterId])
       expect(success).toBeTruthy()
     },
-    TEST_TIMEOUT,
+    TEST_TIMEOUT * 2,
   )
 
   it(
@@ -200,7 +203,9 @@ describe("eth queries", () => {
       }
       // Execute some contract TX
       const tx = await contract.transfer(alice, parseEther("0.01"))
-      await tx.wait(1, TX_WAIT_TIMEOUT)
+      await txWait(tx.hash, {
+        label: "eth_getFilterLogs transfer",
+      })
       await new Promise((resolve) => setTimeout(resolve, 3000))
 
       // Create the filter for a contract
@@ -214,7 +219,7 @@ describe("eth queries", () => {
       expect(changes[0]).toHaveProperty("data")
       expect(changes[0]).toHaveProperty("topics")
     },
-    TEST_TIMEOUT,
+    TEST_TIMEOUT * 2,
   )
 
   it(
@@ -230,7 +235,7 @@ describe("eth queries", () => {
       }
       // Execute some contract TX
       const tx = await contract.transfer(alice, parseEther("0.01"))
-      await tx.wait(1, TX_WAIT_TIMEOUT)
+      await txWait(tx.hash, { label: "eth_getLogs transfer" })
       await new Promise((resolve) => setTimeout(resolve, 3000))
 
       // Assert logs
@@ -240,7 +245,7 @@ describe("eth queries", () => {
       expect(changes[0]).toHaveProperty("data")
       expect(changes[0]).toHaveProperty("topics")
     },
-    TEST_TIMEOUT,
+    TEST_TIMEOUT * 2,
   )
 
   it(

--- a/evm-e2e/test/native_transfer.test.ts
+++ b/evm-e2e/test/native_transfer.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test"
 import { parseEther, toBigInt } from "ethers"
 
-import { account, provider, TEST_TIMEOUT, TX_WAIT_TIMEOUT } from "./testdeps"
-import { alice, txResultLite } from "./utils"
+import { account, provider, TEST_TIMEOUT } from "./testdeps"
+import { alice, txResultLite, txWait } from "./utils"
 
 describe("native transfer", () => {
   it(
@@ -20,8 +20,8 @@ describe("native transfer", () => {
         value: amountToSend,
       }
       const txResponse = await account.sendTransaction(transaction)
-      await txResponse.wait(1, TX_WAIT_TIMEOUT)
-      expect(txResponse).toHaveProperty("blockHash")
+      const receipt = await txWait(txResponse, { label: "native transfer" })
+      expect(receipt.blockHash).toBeDefined()
 
       const senderBalanceAfter = await provider.getBalance(account)
       const recipientBalanceAfter = await provider.getBalance(alice)

--- a/evm-e2e/test/precompile_statedb.test.ts
+++ b/evm-e2e/test/precompile_statedb.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test"
 import { Contract, Wallet } from "ethers"
 
 import { account, provider, TEST_TIMEOUT } from "./testdeps"
+import { txWait } from "./utils"
 
 // Load the full ABI from the artifact file
 const contractArtifact = JSON.parse(
@@ -85,7 +86,11 @@ describe("StateDB corruption test", () => {
       }
 
       const transactions = await Promise.all(txPromises)
-      const receipts = await Promise.all(transactions.map((tx) => tx.wait()))
+      const receipts = await Promise.all(
+        transactions.map((tx, idx) =>
+          txWait(tx, { label: `precompile_statedb bankMsgSend ${idx}` }),
+        ),
+      )
 
       // Stop simulations
       simulationRunning = false

--- a/evm-e2e/test/tx_receipt.test.ts
+++ b/evm-e2e/test/tx_receipt.test.ts
@@ -3,7 +3,7 @@ import { ethers, Log, TransactionReceipt } from "ethers"
 
 import { TestERC20__factory } from "../types"
 import { account, TEST_TIMEOUT } from "./testdeps"
-import { deployContractEventsEmitter } from "./utils"
+import { deployContractEventsEmitter, txWait } from "./utils"
 
 describe("Transaction Receipt Tests", () => {
   let recipient = ethers.Wallet.createRandom().address
@@ -16,7 +16,7 @@ describe("Transaction Receipt Tests", () => {
         to: recipient,
         value,
       })
-      const receipt = await tx.wait()
+      const receipt = await txWait(tx, { label: "receipt simple transfer" })
 
       assertBaseReceiptFields(receipt)
       expect(receipt.to).toEqual(recipient)
@@ -30,7 +30,9 @@ describe("Transaction Receipt Tests", () => {
     async () => {
       const factory = new TestERC20__factory(account)
       const deployTx = await factory.deploy()
-      const receipt = await deployTx.deploymentTransaction().wait()
+      const receipt = await txWait(deployTx.deploymentTransaction()!, {
+        label: "receipt contract deployment",
+      })
 
       assertBaseReceiptFields(receipt)
       expect(receipt.to).toBeNull() // Contract creation has no 'to' address
@@ -50,7 +52,7 @@ describe("Transaction Receipt Tests", () => {
       const expectedValue = 123n
 
       const tx = await contract.emitEvent(expectedValue)
-      const receipt = await tx.wait()
+      const receipt = await txWait(tx, { label: "receipt event emission" })
 
       assertBaseReceiptFields(receipt)
       expect(receipt.to).toEqual(contract.target.toString())

--- a/evm-e2e/test/utils.ts
+++ b/evm-e2e/test/utils.ts
@@ -4,6 +4,7 @@ import {
   ContractTransactionResponse,
   parseEther,
   toBigInt,
+  TransactionReceipt,
   TransactionResponse,
   Wallet,
   type TransactionRequest,
@@ -69,6 +70,102 @@ export const txResultLite = (
   }
 }
 
+type WaitForTxReceiptOptions = {
+  attempts?: number
+  blockTimeoutMs?: number
+  pollIntervalMs?: number
+  label?: string
+  requireSuccess?: boolean
+}
+
+const waitForBlockAfter = async (
+  blockNumber: number,
+  timeoutMs: number,
+  pollIntervalMs: number,
+  txHash: string,
+): Promise<number> => {
+  const startedAt = Date.now()
+  let latestBlock = blockNumber
+
+  while (Date.now() - startedAt < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+    latestBlock = await provider.getBlockNumber()
+    if (latestBlock > blockNumber) {
+      return latestBlock
+    }
+  }
+
+  throw new Error(
+    `[txWait] timed out after ${timeoutMs}ms waiting for next block after ${blockNumber} while waiting for tx ${txHash}; latestBlock=${latestBlock}`,
+  )
+}
+
+type TxWaitInput = string | TransactionResponse | ContractTransactionResponse
+
+const txHashOf = (tx: TxWaitInput): string => {
+  return typeof tx === "string" ? tx : tx.hash
+}
+
+export const txWait = async (
+  tx: TxWaitInput,
+  options: WaitForTxReceiptOptions = {},
+): Promise<TransactionReceipt> => {
+  const normalizedTxHash = txHashOf(tx).trim()
+  if (normalizedTxHash.length === 0) {
+    throw new Error("txWait received an empty tx hash")
+  }
+
+  const attempts = options.attempts ?? 4
+  const blockTimeoutMs = options.blockTimeoutMs ?? TX_WAIT_TIMEOUT
+  const pollIntervalMs = options.pollIntervalMs ?? 250
+  const requireSuccess = options.requireSuccess ?? true
+  const label = options.label ?? "tx"
+  const startedAt = Date.now()
+
+  let receipt: TransactionReceipt | null = null
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const latestBlock = await provider.getBlockNumber()
+    console.log(
+      `[txWait:${label}] txQuery=${attempt}/${attempts} tx=${normalizedTxHash} latestBlock=${latestBlock}`,
+    )
+
+    receipt = await provider.getTransactionReceipt(normalizedTxHash)
+    if (receipt !== null) {
+      console.log(
+        `[txWait:${label}] confirmed txQuery=${attempt}/${attempts} tx=${normalizedTxHash} block=${receipt.blockNumber} status=${receipt.status} logs=${receipt.logs.length} elapsedMs=${Date.now() - startedAt}`,
+      )
+      break
+    }
+
+    if (attempt < attempts) {
+      await waitForBlockAfter(
+        latestBlock,
+        blockTimeoutMs,
+        pollIntervalMs,
+        normalizedTxHash,
+      )
+    }
+  }
+
+  if (receipt === null) {
+    throw new Error(
+      `[txWait:${label}] tx ${normalizedTxHash} not found after ${attempts} receipt queries and ${attempts - 1} block waits; elapsedMs=${Date.now() - startedAt}`,
+    )
+  }
+
+  if (typeof tx !== "string") {
+    receipt = (await tx.wait(0)) ?? receipt
+  }
+
+  if (requireSuccess && receipt.status !== 1) {
+    throw new Error(
+      `transaction execution reverted: [txWait:${label}] tx=${normalizedTxHash} block=${receipt.blockNumber} status=${receipt.status} logs=${receipt.logs.length} elapsedMs=${Date.now() - startedAt}`,
+    )
+  }
+
+  return receipt
+}
+
 export const deployContractTestERC20 = async () => {
   const factory = new TestERC20__factory(account)
   const contract = await factory.deploy()
@@ -111,7 +208,7 @@ export const sendTestNibi = async () => {
     value: parseEther("0.01"),
   }
   const txResponse = await account.sendTransaction(transaction)
-  await txResponse.wait(1, TX_WAIT_TIMEOUT)
+  await txWait(txResponse, { label: "sendTestNibi" })
   console.log("sendTestNibi txResp: %o", txResultLite(txResponse))
   return txResponse
 }

--- a/evm-e2e/test/wrapped_nibiru_wnibi.test.ts
+++ b/evm-e2e/test/wrapped_nibiru_wnibi.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test"
 import { parseUnits, toBigInt, Wallet } from "ethers"
 
-import { account, provider, TEST_TIMEOUT, TX_WAIT_TIMEOUT } from "./testdeps"
-import { deployContractWNIBI } from "./utils"
+import { account, provider, TEST_TIMEOUT } from "./testdeps"
+import { deployContractWNIBI, txWait } from "./utils"
 
 test(
   "WNIBI.sol deposits via ether transfer",
@@ -27,7 +27,7 @@ test(
         to: contractAddr,
         value: amountWei,
       })
-      await txResp.wait()
+      await txWait(txResp, { label: "wnibi transfer deposit" })
 
       // Check balances after deposit
       const contractBalWei = await provider.getBalance(contractAddr)
@@ -42,7 +42,7 @@ test(
     {
       const amountWei = parseUnits("351", 12)
       const txResp = await contract.withdraw(amountWei)
-      await txResp.wait()
+      await txWait(txResp, { label: "wnibi withdraw" })
 
       // Check balanaces after withdraw
       const contractBalWei = await provider.getBalance(contractAddr)
@@ -60,7 +60,7 @@ test(
       let tx = await contract.deposit({
         value: amountToSend,
       })
-      await tx.wait(1, TX_WAIT_TIMEOUT)
+      await txWait(tx, { label: "wnibi method deposit" })
 
       // Check balanaces after deposit
       const balanceAfter = await contract.balanceOf(account.address)
@@ -73,7 +73,7 @@ test(
       const amountToSend = parseUnits("200", 12) // WNIBI tokens for alice
 
       let tx = await contract.transfer(alice.address, amountToSend)
-      await tx.wait(1, TX_WAIT_TIMEOUT)
+      await txWait(tx, { label: "wnibi transfer" })
 
       // Check balances after transfer and correct total supply
       const aliceBalance = await contract.balanceOf(alice)

--- a/evm-e2e/test/zero_gas_erc20.test.ts
+++ b/evm-e2e/test/zero_gas_erc20.test.ts
@@ -2,8 +2,8 @@ import { newClog } from "@uniquedivine/jiyuu"
 import { expect, test } from "bun:test" // eslint-disable-line import/no-unresolved
 import { parseUnits, Wallet } from "ethers"
 
-import { account, provider, TEST_TIMEOUT, TX_WAIT_TIMEOUT } from "./testdeps"
-import { deployContractTestERC20 } from "./utils"
+import { account, provider, TEST_TIMEOUT } from "./testdeps"
+import { deployContractTestERC20, txWait } from "./utils"
 import { addZeroGasContract } from "./zero_gas_chain_helpers"
 
 const { clog, cerr, clogCmd } = newClog(
@@ -33,7 +33,7 @@ test(
     expect(freshInitialTokenBalance).toEqual(0n)
     const amountToFundFresh = parseUnits("100", 18)
     const fundTx = await contract.transfer(fresh.address, amountToFundFresh)
-    await fundTx.wait(1, TX_WAIT_TIMEOUT)
+    await txWait(fundTx, { label: "zero_gas fund fresh account" })
     const freshTokenBalanceAfterFund = await contract.balanceOf(fresh.address)
     expect(freshTokenBalanceAfterFund).toEqual(amountToFundFresh)
     const freshNibiBefore = await provider.getBalance(fresh.address)
@@ -55,7 +55,7 @@ test(
     )
 
     clog("Tx should succeed and be directed to the zero-gas ERC20 contract.")
-    const receipt = await zeroGasTx.wait(1, TX_WAIT_TIMEOUT)
+    const receipt = await txWait(zeroGasTx, { label: "zero_gas transfer" })
     expect(receipt.status).toEqual(1)
     expect(receipt.to?.toLowerCase()).toEqual(zeroGasErc20Addr.toLowerCase())
 
@@ -91,7 +91,9 @@ test(
         maxPriorityFeePerGas: 1_000_000_000n,
       },
     )
-    const nonzeroFeeReceipt = await nonzeroFeeTx.wait(1, TX_WAIT_TIMEOUT)
+    const nonzeroFeeReceipt = await txWait(nonzeroFeeTx, {
+      label: "zero_gas nonzero fee transfer",
+    })
     expect(nonzeroFeeReceipt.status).toEqual(1)
     expect(nonzeroFeeReceipt.to?.toLowerCase()).toEqual(
       zeroGasErc20Addr.toLowerCase(),


### PR DESCRIPTION
Implemented a shared txWait helper for EVM E2E tests.

txWait replaces direct tx.wait(...) usage across normal evm-e2e/test/*.ts
files, while leaving passkey code alone. It polls
getTransactionReceipt(txHash) with bounded block-based retries, logs each
receipt query as txQuery=N/4, and reports confirmation with tx hash, block,
status, log count, and elapsed time.

The flaky log-query tests now use txWait(tx.hash, ...) instead of
tx.wait(1, TX_WAIT_TIMEOUT) and have TEST_TIMEOUT * 2 to allow bounded
receipt waits plus existing filter/log sleeps.

Remaining direct tx.wait() calls are only in passkey paths and inside
txWait itself, where it calls tx.wait(0) after the receipt is already
visible to preserve ethers receipt behavior without relying on ethers’
polling.

