### PR TITLE
fix(gov): Shorten mainnet voting period in v2.16

### DIFF
--- a/app/appconst/appconst.go
+++ b/app/appconst/appconst.go
@@ -76,6 +76,9 @@ func RuntimeVersion() string {
 
 // EIP 155 Chain IDs for Nibiru
 const (
+	// SDK_CHAIN_ID_MAINNET is the CometBFT / Cosmos SDK chain ID for Nibiru mainnet.
+	SDK_CHAIN_ID_MAINNET = "cataclysm-1"
+
 	ETH_CHAIN_ID_MAINNET int64 = 6900
 
 	ETH_CHAIN_ID_TESTNET_1 int64 = 7210
@@ -97,7 +100,7 @@ const (
 // knownEthChainIDMap maps `sdk.Context` chain IDs to their corresponding EIP-155
 // Ethereum Chain IDs, which must be positive integers.
 var knownEthChainIDMap = map[string]int64{
-	"cataclysm-1": ETH_CHAIN_ID_MAINNET,
+	SDK_CHAIN_ID_MAINNET: ETH_CHAIN_ID_MAINNET,
 
 	"nibiru-testnet-1": ETH_CHAIN_ID_TESTNET_1,
 	"nibiru-testnet-2": ETH_CHAIN_ID_TESTNET_2,

--- a/app/appconst/appconst_test.go
+++ b/app/appconst/appconst_test.go
@@ -21,7 +21,7 @@ func (s *TestSuite) TestGetEthChainID() {
 	s.Run("mainnet", func() {
 		s.EqualValues(
 			big.NewInt(appconst.ETH_CHAIN_ID_MAINNET),
-			appconst.GetEthChainID("cataclysm-1"),
+			appconst.GetEthChainID(appconst.SDK_CHAIN_ID_MAINNET),
 		)
 	})
 	s.Run("localnet", func() {

--- a/app/upgrades/v2.go
+++ b/app/upgrades/v2.go
@@ -3,6 +3,7 @@ package upgrades
 import (
 	"fmt"
 	"slices"
+	"time"
 
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -85,8 +86,41 @@ var (
 		StoreUpgrades: store.StoreUpgrades{},
 	}
 
-	Upgrade2_16_0 = NewVanillaUpgrade("v2.16.0")
+	Upgrade2_16_0 = Upgrade{
+		UpgradeName:   "v2.16.0",
+		Handler:       Handler_v2_16{},
+		StoreUpgrades: store.StoreUpgrades{},
+	}
 )
+
+var _ HandlerImpl = (*Handler_v2_16)(nil)
+
+type Handler_v2_16 struct{}
+
+func (h Handler_v2_16) Handler(
+	mm *module.Manager,
+	cfg module.Configurator,
+	nibiru *keepers.PublicKeepers,
+) upgradetypes.UpgradeHandler {
+
+	return func(
+		ctx sdk.Context,
+		plan upgradetypes.Plan,
+		fromVM module.VersionMap,
+	) (module.VersionMap, error) {
+		if ctx.ChainID() == appconst.SDK_CHAIN_ID_MAINNET {
+			params := nibiru.GovKeeper.GetParams(ctx)
+			*params.VotingPeriod = 24 * time.Hour
+			if err := nibiru.GovKeeper.SetParams(ctx, params); err != nil {
+				ctx.Logger().Error("v2.16.0 upgrade failure", "err", err)
+				ctx.EventManager().EmitEvent(
+					NewEventUpgradeFailure("v2.16.0", err),
+				)
+			}
+		}
+		return mm.RunMigrations(ctx, cfg, fromVM)
+	}
+}
 
 var _ HandlerImpl = (*Handler_v2_1)(nil)
 

--- a/app/upgrades/v2_14_0.go
+++ b/app/upgrades/v2_14_0.go
@@ -60,7 +60,7 @@ type Upgrade2_14_AddrCfg struct {
 // upgrade handler. Tests temporarily override contract fields after
 // instantiating real Wasm contracts at fresh test addresses.
 var AddrCfg_v2_14 = Upgrade2_14_AddrCfg{
-	MainnetChainID:  "cataclysm-1",
+	MainnetChainID:  appconst.SDK_CHAIN_ID_MAINNET,
 	Testnet2ChainID: "nibiru-testnet-2",
 
 	TreasuryCW3:      mustAccAddress("nibi1l8dxzwz9d4peazcqjclnkj2mhvtj7mpnkqx85mg0ndrlhwrnh7gskkzg0v"),

--- a/app/upgrades/v2_14_0_test.go
+++ b/app/upgrades/v2_14_0_test.go
@@ -13,6 +13,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/NibiruChain/nibiru/v2/app/appconst"
 	"github.com/NibiruChain/nibiru/v2/app/upgrades"
 	"github.com/NibiruChain/nibiru/v2/x/evm/evmtest"
 	"github.com/NibiruChain/nibiru/v2/x/nutil"
@@ -26,8 +27,6 @@ const (
 	artifactDir             = "testdata"
 	artifactCW3FlexMultisig = "cw3_flex_multisig.wasm"
 	artifactCW4Group        = "cw4_group.wasm"
-
-	chainIDMainnet = "cataclysm-1"
 )
 
 var (
@@ -49,7 +48,7 @@ var (
 // supplied by mainnet.
 func TestUpgrade2_14_0_HappyPath(t *testing.T) {
 	deps := evmtest.NewTestDeps()
-	deps.SetCtx(deps.Ctx().WithChainID(chainIDMainnet))
+	deps.SetCtx(deps.Ctx().WithChainID(appconst.SDK_CHAIN_ID_MAINNET))
 	ctx := deps.Ctx()
 
 	legacyMultisig := mustAccAddress(addrLegacyMultisig)
@@ -149,7 +148,7 @@ func TestUpgrade2_14_0_HappyPath(t *testing.T) {
 
 func TestUpgrade2_14_0_AddsLayerZeroAdaptersToZeroGasActorsMainnet(t *testing.T) {
 	deps := evmtest.NewTestDeps()
-	deps.SetCtx(deps.Ctx().WithChainID(chainIDMainnet))
+	deps.SetCtx(deps.Ctx().WithChainID(appconst.SDK_CHAIN_ID_MAINNET))
 
 	existingAlwaysZeroGas := "0x0000000000000000000000000000000000000005"
 	deps.App.SudoKeeper.ZeroGasActors.Set(deps.Ctx(), sudo.ZeroGasActors{
@@ -172,7 +171,7 @@ func TestUpgrade2_14_0_AddsLayerZeroAdaptersToZeroGasActorsMainnet(t *testing.T)
 
 func TestUpgrade2_14_0_DoesNotDuplicateLayerZeroAdapters(t *testing.T) {
 	deps := evmtest.NewTestDeps()
-	deps.SetCtx(deps.Ctx().WithChainID(chainIDMainnet))
+	deps.SetCtx(deps.Ctx().WithChainID(appconst.SDK_CHAIN_ID_MAINNET))
 
 	existingAlwaysZeroGas := "0x0000000000000000000000000000000000000005"
 	deps.App.SudoKeeper.ZeroGasActors.Set(deps.Ctx(), sudo.ZeroGasActors{

--- a/app/upgrades/v2_16_0_test.go
+++ b/app/upgrades/v2_16_0_test.go
@@ -1,0 +1,38 @@
+package upgrades_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NibiruChain/nibiru/v2/app/appconst"
+	"github.com/NibiruChain/nibiru/v2/app/upgrades"
+	"github.com/NibiruChain/nibiru/v2/x/evm/evmtest"
+)
+
+func TestUpgrade2_16_0_SetsGovVotingPeriodOnMainnet(t *testing.T) {
+	deps := evmtest.NewTestDeps()
+	deps.SetCtx(deps.Ctx().WithChainID(appconst.SDK_CHAIN_ID_MAINNET))
+
+	require.NoError(t, deps.RunUpgrade(upgrades.Upgrade2_16_0))
+
+	params := deps.App.GovKeeper.GetParams(deps.Ctx())
+	require.NotNil(t, params.VotingPeriod)
+	require.Equal(t, 24*time.Hour, *params.VotingPeriod)
+}
+
+func TestUpgrade2_16_0_SkipsGovVotingPeriodOnNonMainnet(t *testing.T) {
+	deps := evmtest.NewTestDeps()
+	ctx := deps.Ctx()
+
+	before := deps.App.GovKeeper.GetParams(ctx)
+	require.NotNil(t, before.VotingPeriod)
+	beforePeriod := *before.VotingPeriod
+
+	require.NoError(t, deps.RunUpgrade(upgrades.Upgrade2_16_0))
+
+	after := deps.App.GovKeeper.GetParams(ctx)
+	require.NotNil(t, after.VotingPeriod)
+	require.Equal(t, beforePeriod, *after.VotingPeriod)
+}

--- a/app/upgrades/v2_7_0_test.go
+++ b/app/upgrades/v2_7_0_test.go
@@ -22,7 +22,7 @@ import (
 func (s *Suite2_7_0) TestMainnet() {
 	deps := evmtest.NewTestDeps()
 
-	deps.SetCtx(deps.Ctx().WithChainID("cataclysm-1")) // Pretend to be mainnet
+	deps.SetCtx(deps.Ctx().WithChainID(appconst.SDK_CHAIN_ID_MAINNET)) // Pretend to be mainnet
 	s.Equal(
 		big.NewInt(appconst.ETH_CHAIN_ID_MAINNET).String(),
 		deps.EvmKeeper.EthChainID(deps.Ctx()).String(),

--- a/gosdk/netinfo.go
+++ b/gosdk/netinfo.go
@@ -39,7 +39,7 @@ var (
 		EvmRpc:            "https://evm-rpc.nibiru.fi:443",
 		EvmRpcArchive:     "https://evm-rpc.archive.nibiru.fi:443",
 		EvmWebsocket:      "wss://evm-rpc-ws.nibiru.fi",
-		CmtChainID:        "cataclysm-1",
+		CmtChainID:        appconst.SDK_CHAIN_ID_MAINNET,
 		GrpcEndpoint:      "grpc.nibiru.fi:443",
 		TmRpcEndpoint:     "https://rpc.nibiru.fi:443",
 		WebsocketEndpoint: "",

--- a/x/evm/evmstate/funtoken_from_coin_test.go
+++ b/x/evm/evmstate/funtoken_from_coin_test.go
@@ -9,6 +9,7 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/NibiruChain/nibiru/v2/app/appconst"
 	"github.com/NibiruChain/nibiru/v2/eth"
 	"github.com/NibiruChain/nibiru/v2/x/evm"
 	"github.com/NibiruChain/nibiru/v2/x/evm/embeds"
@@ -287,7 +288,7 @@ func (s *SuiteFunToken) TestCreateFunTokenPermissions_MainnetCoin() {
 
 	s.Run("sad: mainnet unauthorized sender does not pay fee", func() {
 		deps := evmtest.NewTestDeps()
-		deps.SetCtx(deps.Ctx().WithChainID("cataclysm-1"))
+		deps.SetCtx(deps.Ctx().WithChainID(appconst.SDK_CHAIN_ID_MAINNET))
 
 		bankDenom := "mainnet-unauthorized"
 		fee := deps.EvmKeeper.FeeForCreateFunToken(deps.Ctx())
@@ -321,7 +322,7 @@ func (s *SuiteFunToken) TestCreateFunTokenPermissions_MainnetCoin() {
 	s.Run("happy: mainnet sudoer can create funtoken", func() {
 		deps := evmtest.NewTestDeps()
 		deps.SetCtx(deps.Ctx().
-			WithChainID("cataclysm-1").
+			WithChainID(appconst.SDK_CHAIN_ID_MAINNET).
 			WithGasMeter(sdk.NewInfiniteGasMeter()))
 
 		bankDenom := "mainnet-sudoer"

--- a/x/evm/evmstate/funtoken_from_erc20_test.go
+++ b/x/evm/evmstate/funtoken_from_erc20_test.go
@@ -264,7 +264,7 @@ func (s *SuiteFunToken) TestCreateFunTokenPermissions_ERC20() {
 	s.Run("happy: mainnet governance authority can create after unauthorized sender is rejected", func() {
 		deps := evmtest.NewTestDeps()
 		deps.SetCtx(deps.Ctx().
-			WithChainID("cataclysm-1").
+			WithChainID(appconst.SDK_CHAIN_ID_MAINNET).
 			WithGasMeter(sdk.NewInfiniteGasMeter()))
 		erc20Addr := deployERC20(&deps)
 		authority := auth.NewModuleAddress(govtypes.ModuleName)


### PR DESCRIPTION
# Shorten mainnet governance voting period in v2.16

This PR updates the v2.16 upgrade handler to shorten Nibiru mainnet's governance voting period from two days to one day while keeping the upgrade non-halting if the parameter update fails.

## Key Changes

1. Adds a custom `v2.16.0` upgrade handler that updates gov params only on Nibiru mainnet before running standard module migrations.
1. Keeps the v2.16 handler aligned with the v2.15 failure pattern by logging and emitting an `upgrade_failure` event instead of returning an error.
1. Introduces `appconst.SDK_CHAIN_ID_MAINNET` as the shared CometBFT/Cosmos SDK mainnet chain ID and replaces repeated `cataclysm-1` literals in Go code.
1. Adds upgrade tests for mainnet application and non-mainnet no-op behavior so the voting period change is covered through the registered upgrade path.