### PR TITLE
build(wasmvm-ffi): Port go-wasmvm into lib/wasmvm-ffia; CI and release automation

### DIFF
--- a/.github/workflows/wasmvm-ffi.yml
+++ b/.github/workflows/wasmvm-ffi.yml
@@ -29,7 +29,7 @@ jobs:
             wasmvm:
               - "lib/wasmvm-ffi/**"
               - "justfile"
-              - ".github/workflows/wasm-vm-ffi.yml"
+              - ".github/workflows/wasmvm-ffi.yml"
 
   # rust-base-tests (job): Tests the Rust crate `wasmvm`, generated bindings,
   # and Rust docs.
@@ -412,19 +412,25 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: libwasmvm-muslc
-          path: release-artifacts
+          path: dist/libwasmvm
 
       - name: Download tested glibc artifacts
         uses: actions/download-artifact@v4
         with:
           name: libwasmvm-glibc
-          path: release-artifacts
+          path: dist/libwasmvm
 
       - name: Download tested Darwin artifacts
         uses: actions/download-artifact@v4
         with:
           name: libwasmvm-darwin
-          path: release-artifacts
+          path: dist/libwasmvm
+
+      - name: Collect libwasmvm release artifacts
+        run: |
+          mkdir -p dist/libwasmvm
+          find dist/libwasmvm -mindepth 2 -type f -name 'libwasmvm*' \
+            -exec cp -t dist/libwasmvm {} +
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/wasmvm-ffi.yml
+++ b/.github/workflows/wasmvm-ffi.yml
@@ -50,19 +50,18 @@ jobs:
         uses: taiki-e/install-action@just
 
       - name: Cache Cargo
+        id: rust-cache-wasmvm
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            lib/wasmvm-ffi/libwasmvm/target/debug/.fingerprint
-            lib/wasmvm-ffi/libwasmvm/target/debug/build
-            lib/wasmvm-ffi/libwasmvm/target/debug/deps
-            lib/wasmvm-ffi/libwasmvm/target/release/.fingerprint
-            lib/wasmvm-ffi/libwasmvm/target/release/build
-            lib/wasmvm-ffi/libwasmvm/target/release/deps
-          key: cargo-rust-sanity-stable-${{ hashFiles('lib/wasmvm-ffi/libwasmvm/Cargo.lock') }}
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            lib/wasmvm-ffi/libwasmvm/target/
+          key: ${{ runner.os }}-cargo-wasmvm-ffi-${{ hashFiles('lib/wasmvm-ffi/libwasmvm/Cargo.lock') }}
           restore-keys: |
-            cargo-rust-sanity-stable-
+            ${{ runner.os }}-cargo-wasmvm-ffi-
 
       - name: Run Rust sanity checks
         run: just wasmvm ci-rust
@@ -85,19 +84,18 @@ jobs:
         uses: taiki-e/install-action@just
 
       - name: Cache Cargo
+        id: rust-cache-wasmvm
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/registry
-            lib/wasmvm-ffi/libwasmvm/target/debug/.fingerprint
-            lib/wasmvm-ffi/libwasmvm/target/debug/build
-            lib/wasmvm-ffi/libwasmvm/target/debug/deps
-            lib/wasmvm-ffi/libwasmvm/target/release/.fingerprint
-            lib/wasmvm-ffi/libwasmvm/target/release/build
-            lib/wasmvm-ffi/libwasmvm/target/release/deps
-          key: cargo-clippy-stable-${{ hashFiles('lib/wasmvm-ffi/libwasmvm/Cargo.lock') }}
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            lib/wasmvm-ffi/libwasmvm/target/
+          key: ${{ runner.os }}-cargo-wasmvm-ffi-${{ hashFiles('lib/wasmvm-ffi/libwasmvm/Cargo.lock') }}
           restore-keys: |
-            cargo-clippy-stable-
+            ${{ runner.os }}-cargo-wasmvm-ffi-
 
       - name: Run Clippy
         run: just wasmvm clippy
@@ -171,6 +169,20 @@ jobs:
 
       - name: Install just
         uses: taiki-e/install-action@just
+
+      - name: Cache Cargo
+        id: rust-cache-wasmvm
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            lib/wasmvm-ffi/libwasmvm/target/
+          key: ${{ runner.os }}-cargo-wasmvm-ffi-${{ hashFiles('lib/wasmvm-ffi/libwasmvm/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-wasmvm-ffi-
 
       - name: Build Rust shared library
         run: just wasmvm build-rust

--- a/.github/workflows/wasmvm-ffi.yml
+++ b/.github/workflows/wasmvm-ffi.yml
@@ -1,0 +1,441 @@
+name: "Wasm VM FFI"
+# Builds release candidate libwasmvm artifacts on ordinary branch and PR runs.
+# Durable GitHub Release publishing only runs from main.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # changes-wasmvm (job): Detects changes that should run Wasm VM FFI jobs.
+  changes-wasmvm:
+    runs-on: ubuntu-latest
+    outputs:
+      wasmvm: ${{ steps.filter.outputs.wasmvm }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for Wasm VM FFI changes
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            wasmvm:
+              - "lib/wasmvm-ffi/**"
+              - "justfile"
+              - ".github/workflows/wasm-vm-ffi.yml"
+
+  # rust-base-tests (job): Tests the Rust crate `wasmvm`, generated bindings,
+  # and Rust docs.
+  rust-base-tests:
+    needs: changes-wasmvm
+    if: needs.changes-wasmvm.outputs.wasmvm == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            lib/wasmvm-ffi/libwasmvm/target/debug/.fingerprint
+            lib/wasmvm-ffi/libwasmvm/target/debug/build
+            lib/wasmvm-ffi/libwasmvm/target/debug/deps
+            lib/wasmvm-ffi/libwasmvm/target/release/.fingerprint
+            lib/wasmvm-ffi/libwasmvm/target/release/build
+            lib/wasmvm-ffi/libwasmvm/target/release/deps
+          key: cargo-rust-sanity-stable-${{ hashFiles('lib/wasmvm-ffi/libwasmvm/Cargo.lock') }}
+          restore-keys: |
+            cargo-rust-sanity-stable-
+
+      - name: Run Rust sanity checks
+        run: just wasmvm ci-rust
+
+  # rust-lint (job): Runs Rust linting for crate `wasmvm` with Clippy.
+  rust-lint:
+    needs: changes-wasmvm
+    if: needs.changes-wasmvm.outputs.wasmvm == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            lib/wasmvm-ffi/libwasmvm/target/debug/.fingerprint
+            lib/wasmvm-ffi/libwasmvm/target/debug/build
+            lib/wasmvm-ffi/libwasmvm/target/debug/deps
+            lib/wasmvm-ffi/libwasmvm/target/release/.fingerprint
+            lib/wasmvm-ffi/libwasmvm/target/release/build
+            lib/wasmvm-ffi/libwasmvm/target/release/deps
+          key: cargo-clippy-stable-${{ hashFiles('lib/wasmvm-ffi/libwasmvm/Cargo.lock') }}
+          restore-keys: |
+            cargo-clippy-stable-
+
+      - name: Run Clippy
+        run: just wasmvm clippy
+
+  # go-base-tests (job): Tests Go formatting, module tidiness, shell scripts,
+  # and no-CGO builds.
+  go-base-tests:
+    needs: changes-wasmvm
+    if: needs.changes-wasmvm.outputs.wasmvm == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.19.7
+          cache: true
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Install Go and shell tools
+        run: |
+          go install mvdan.cc/gofumpt@v0.4.0
+          GO111MODULE=on go install mvdan.cc/sh/v3/cmd/shfmt@v3.7.0
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y shellcheck
+
+      - name: Run Go checks
+        run: just wasmvm ci-go
+
+      - name: Run script checks
+        run: just wasmvm ci-scripts
+
+  # go-lint (job): Runs Go linting for module `github.com/CosmWasm/wasmvm`.
+  go-lint:
+    needs: changes-wasmvm
+    if: needs.changes-wasmvm.outputs.wasmvm == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Run golangci-lint
+        run: just wasmvm lint-go --fix=false
+
+  # go-ffi-tests (job): Tests the Go-to-Rust FFI path after rebuilding shared
+  # library `libwasmvm`.
+  go-ffi-tests:
+    needs: changes-wasmvm
+    if: needs.changes-wasmvm.outputs.wasmvm == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.19.7
+          cache: true
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Build Rust shared library
+        run: just wasmvm build-rust
+
+      - name: Run Go tests
+        run: just wasmvm test-go
+
+      - name: Run Go race-safety tests
+        run: just wasmvm test-go-safety
+
+      - name: Build Go packages
+        run: just wasmvm build-go
+
+  # rust-cargo-audit (job): Audits Rust dependencies for crate `wasmvm` when
+  # enabled by repository vars.
+  # TODO: Enable this as a scheduled or advisory security workflow if dependency
+  # vulnerability visibility becomes useful for this fork.
+  rust-cargo-audit:
+    needs: changes-wasmvm
+    if: vars.ENABLE_CARGO_AUDIT == 'true' && needs.changes-wasmvm.outputs.wasmvm == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ vars.ENABLE_CARGO_AUDIT == 'true' }}
+
+      - name: Install Rust
+        if: ${{ vars.ENABLE_CARGO_AUDIT == 'true' }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        if: ${{ vars.ENABLE_CARGO_AUDIT == 'true' }}
+        run: cargo install --debug cargo-audit --version 0.21.0 --locked
+
+      - name: Run cargo audit
+        if: ${{ vars.ENABLE_CARGO_AUDIT == 'true' }}
+        run: just wasmvm audit
+
+  # rust-sanity-windows (job): Tests crate `wasmvm` on Windows when enabled by
+  # repository vars.
+  # TODO: Enable this if Windows Rust support matters for future artifact or
+  # consumer workflows. The Nibiru release path currently validates Linux only.
+  # ```
+  # rust-sanity-windows:
+  #   name: Windows Rust sanity
+  #   runs-on: windows-latest
+  #   timeout-minutes: 45
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       if: ${{ vars.ENABLE_WINDOWS_RUST_SANITY == 'true' }}
+  #
+  #     - name: Install Rust
+  #       if: ${{ vars.ENABLE_WINDOWS_RUST_SANITY == 'true' }}
+  #       uses: dtolnay/rust-toolchain@stable
+  #
+  #     - name: Run Rust unit tests
+  #       if: ${{ vars.ENABLE_WINDOWS_RUST_SANITY == 'true' }}
+  #       working-directory: lib/wasmvm-ffi/libwasmvm
+  #       run: cargo test
+  # ```
+
+  # build-static-libs (job): Builds Linux musl static library artifacts for
+  # `libwasmvm`.
+  build-static-libs:
+    needs:
+      - changes-wasmvm
+      - rust-base-tests
+      - go-base-tests
+      - go-ffi-tests
+    if: needs.changes-wasmvm.outputs.wasmvm == 'true'
+    name: static musl libraries
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Build static builder image
+        run: just wasmvm docker-image-static
+
+      - name: Build static musl libraries
+        run: just wasmvm artifact-static
+
+      - name: Collect static artifacts
+        run: |
+          mkdir -p artifacts/static-musl
+          cp lib/wasmvm-ffi/internal/api/libwasmvm_muslc.a artifacts/static-musl/libwasmvm_muslc.x86_64.a
+          cp lib/wasmvm-ffi/internal/api/libwasmvm_muslc.aarch64.a artifacts/static-musl/
+          (cd artifacts/static-musl && sha256sum -- libwasmvm_muslc.x86_64.a libwasmvm_muslc.aarch64.a > checksums.txt && cat checksums.txt)
+
+      - name: Upload musl static libraries
+        uses: actions/upload-artifact@v4
+        with:
+          name: libwasmvm-muslc
+          path: |
+            artifacts/static-musl/libwasmvm_muslc.x86_64.a
+            artifacts/static-musl/libwasmvm_muslc.aarch64.a
+            artifacts/static-musl/checksums.txt
+          if-no-files-found: error
+
+  # alpine-muslc-go-tests (job): Tests Go packages against the musl static
+  # `libwasmvm` artifacts in Alpine.
+  # TODO: Enable this when static musl Go consumer tests are worth the runtime
+  # cost. This is stronger than building artifacts because it exercises the Go
+  # packages with tag `muslc` inside Alpine.
+  alpine-muslc-go-tests:
+    needs: changes-wasmvm
+    if: vars.ENABLE_ALPINE_MUSLC_GO_TESTS == 'true' && needs.changes-wasmvm.outputs.wasmvm == 'true'
+    name: Alpine muslc Go tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ vars.ENABLE_ALPINE_MUSLC_GO_TESTS == 'true' }}
+
+      - name: Build static musl library and run Alpine Go tests
+        if: ${{ vars.ENABLE_ALPINE_MUSLC_GO_TESTS == 'true' }}
+        run: just wasmvm test-alpine
+
+  # build-shared-linux (job): Builds Linux glibc shared library artifacts for
+  # `libwasmvm`.
+  build-shared-linux:
+    needs:
+      - changes-wasmvm
+      - rust-base-tests
+      - go-base-tests
+      - go-ffi-tests
+    if: needs.changes-wasmvm.outputs.wasmvm == 'true'
+    name: Linux shared libraries
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Build Linux builder image
+        run: just wasmvm docker-image-linux
+
+      - name: Build Linux shared libraries
+        run: just wasmvm artifact-linux
+
+      - name: Collect Linux shared artifacts
+        run: |
+          mkdir -p artifacts/linux-shared
+          cp lib/wasmvm-ffi/internal/api/libwasmvm.x86_64.so artifacts/linux-shared/
+          cp lib/wasmvm-ffi/internal/api/libwasmvm.aarch64.so artifacts/linux-shared/
+          (cd artifacts/linux-shared && sha256sum -- libwasmvm.aarch64.so libwasmvm.x86_64.so > checksums.txt && cat checksums.txt)
+
+      - name: Upload Linux shared libraries
+        uses: actions/upload-artifact@v4
+        with:
+          name: libwasmvm-glibc
+          path: |
+            artifacts/linux-shared/libwasmvm.x86_64.so
+            artifacts/linux-shared/libwasmvm.aarch64.so
+            artifacts/linux-shared/checksums.txt
+          if-no-files-found: error
+
+  # build-macos-artifacts (job): Builds Darwin shared and static library
+  # artifacts for `libwasmvm`.
+  build-macos-artifacts:
+    needs:
+      - changes-wasmvm
+      - rust-base-tests
+      - go-base-tests
+      - go-ffi-tests
+    if: needs.changes-wasmvm.outputs.wasmvm == 'true'
+    name: Darwin artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Build Darwin builder image
+        run: just wasmvm docker-image-cross
+
+      - name: Build Darwin libraries
+        run: just wasmvm artifact-darwin
+
+      - name: Collect Darwin artifacts
+        run: |
+          mkdir -p artifacts/darwin
+          cp lib/wasmvm-ffi/internal/api/libwasmvm.dylib artifacts/darwin/
+          cp lib/wasmvm-ffi/internal/api/libwasmvmstatic_darwin.a artifacts/darwin/
+          (cd artifacts/darwin && sha256sum -- libwasmvm.dylib libwasmvmstatic_darwin.a > checksums.txt && cat checksums.txt)
+
+      - name: Upload Darwin libraries
+        uses: actions/upload-artifact@v4
+        with:
+          name: libwasmvm-darwin
+          path: |
+            artifacts/darwin/libwasmvm.dylib
+            artifacts/darwin/libwasmvmstatic_darwin.a
+            artifacts/darwin/checksums.txt
+          if-no-files-found: error
+
+  # publish-wasm-release (job): Publishes tested `libwasmvm` artifacts to a
+  # GitHub Release.
+  publish-wasm-release:
+    name: publish libwasmvm release
+    needs:
+      - build-static-libs
+      - build-shared-linux
+      - build-macos-artifacts
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-publish-wasm-release-${{ github.ref }}
+      cancel-in-progress: true
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout tested commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Use tested commit as local main branch
+        run: git checkout -B main "$GITHUB_SHA"
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Download tested musl artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: libwasmvm-muslc
+          path: release-artifacts
+
+      - name: Download tested glibc artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: libwasmvm-glibc
+          path: release-artifacts
+
+      - name: Download tested Darwin artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: libwasmvm-darwin
+          path: release-artifacts
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Test release script
+        run: just wasmvm release test
+
+      - name: Configure git tag identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Publish tested libwasmvm release
+        run: just wasmvm release publish --run

--- a/gh-pr.md
+++ b/gh-pr.md
@@ -1,0 +1,20 @@
+# Add Wasm VM FFI CI and release automation
+
+This PR adds the first Nibiru-native CI and release automation for the `lib/wasmvm-ffi` subtree, so the copied WasmVM FFI module can be tested, built, and prepared for artifact releases from the monorepo.
+
+## Key Changes
+
+1. Adds workflow `Wasm VM FFI` for the `lib/wasmvm-ffi` subtree, with path-filtered jobs for Rust base tests, Rust linting, Go base tests, Go linting, Go FFI tests, Docker artifact builds, and release publishing.
+
+1. Routes workflow commands through command `just wasmvm ...`, keeping the workflow rooted at the Nibiru repository while delegating execution to the subtree `justfile`.
+
+1. Adds command `just test-alpine` inside `lib/wasmvm-ffi` as the workflow-facing entrypoint for Alpine musl Go tests, while preserving the existing Makefile-backed implementation for now.
+
+1. Updates the libwasmvm release helper to publish from repository `NibiruChain/nibiru` using Go submodule-style tags such as `lib/wasmvm-ffi/v1.6.0`, while preserving the existing `libwasmvm_*` release asset filenames.
+
+## Manual Testing I Did Locally
+
+- `bunx github-actionlint .github/workflows/wasmvm-ffi.yml`
+- `just wasmvm ci-go`
+- `just wasmvm release test`
+- `just wasmvm release publish` dry run only

--- a/lib/wasmvm-ffi/.github/workflows/build.yml
+++ b/lib/wasmvm-ffi/.github/workflows/build.yml
@@ -166,19 +166,25 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: libwasmvm-muslc
-          path: release-artifacts
+          path: dist/libwasmvm
 
       - name: Download tested glibc artifacts
         uses: actions/download-artifact@v4
         with:
           name: libwasmvm-glibc
-          path: release-artifacts
+          path: dist/libwasmvm
 
       - name: Download tested Darwin artifacts
         uses: actions/download-artifact@v4
         with:
           name: libwasmvm-darwin
-          path: release-artifacts
+          path: dist/libwasmvm
+
+      - name: Collect libwasmvm release artifacts
+        run: |
+          mkdir -p dist/libwasmvm
+          find dist/libwasmvm -mindepth 2 -type f -name 'libwasmvm*' \
+            -exec cp -t dist/libwasmvm {} +
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2

--- a/lib/wasmvm-ffi/justfile
+++ b/lib/wasmvm-ffi/justfile
@@ -138,6 +138,10 @@ test-go:
 test-go-safety:
   make test-safety
 
+# Run Go tests against the static musl libwasmvm library in Alpine.
+test-alpine:
+  make test-alpine
+
 # Build and test without cgo.
 test-no-cgo:
   #!/usr/bin/env bash

--- a/lib/wasmvm-ffi/libwasmvm/.gitignore
+++ b/lib/wasmvm-ffi/libwasmvm/.gitignore
@@ -1,3 +1,4 @@
 # Build results
 target/
-artifacts/
+artifacts/*
+!artifacts/.gitkeep

--- a/lib/wasmvm-ffi/scripts/releaseArtifacts.test.ts
+++ b/lib/wasmvm-ffi/scripts/releaseArtifacts.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, test } from "bun:test"
@@ -9,6 +9,7 @@ import {
   computeNextLibwasmvmReleaseTag,
   findLatestLibwasmvmReleaseTag,
   findLatestLibwasmvmReleaseTagFromGhOutput,
+  getLatestStableReleaseTag,
   normalizeReleaseTag,
   parseGhReleaseListTags,
   parseLibwasmvmReleaseTag,
@@ -16,6 +17,7 @@ import {
   quoteShellArg,
   REAL_FILTERED_GH_RELEASE_LIST_OUTPUT,
   renderReleaseMetadataMarkdown,
+  resolveDefaultArtifactsDir,
   sortLibwasmvmReleaseTags,
   validateExistingArtifacts,
 } from "./releaseArtifacts"
@@ -226,6 +228,31 @@ describe("quoteShellArg", () => {
   })
 })
 
+describe("resolveDefaultArtifactsDir", () => {
+  test("resolves dist/libwasmvm under the repository root", async () => {
+    const tempRepoRoot = await mkdtemp(join(tmpdir(), "libwasmvm-repo-"))
+    const commands: string[] = []
+
+    try {
+      const artifactsDir = await resolveDefaultArtifactsDir(async (command) => {
+        commands.push(command)
+        if (command === "git rev-parse --show-toplevel") {
+          return `${tempRepoRoot}\n`
+        }
+        throw new Error(`Unexpected command: ${command}`)
+      })
+
+      expect(artifactsDir).toBe(join(tempRepoRoot, "dist", "libwasmvm"))
+      expect(commands).toEqual(["git rev-parse --show-toplevel"])
+      await expect(stat(artifactsDir)).resolves.toMatchObject({
+        isDirectory: () => true,
+      })
+    } finally {
+      await rm(tempRepoRoot, { recursive: true, force: true })
+    }
+  })
+})
+
 describe("validateExistingArtifacts", () => {
   test("requires all release files", async () => {
     const artifactsDir = await mkdtemp(join(tmpdir(), "libwasmvm-artifacts-"))
@@ -285,7 +312,7 @@ describe("buildPublishDryRunPlan", () => {
 describe("renderReleaseMetadataMarkdown", () => {
   test("renders release metadata and release assets", () => {
     const releaseUrl =
-      "https://github.com/NibiruChain/nibiru/releases/tag/lib/wasmvm-ffi/v1.6.0"
+      "https://github.com/NibiruChain/nibiru/releases/tag/lib%2Fwasmvm-ffi%2Fv1.6.0"
     const markdown = renderReleaseMetadataMarkdown({
       tag: "lib/wasmvm-ffi/v1.6.0",
       commitSha: "abc123",
@@ -307,11 +334,32 @@ describe("renderReleaseMetadataMarkdown", () => {
   })
 })
 
+describe("getLatestStableReleaseTag", () => {
+  test("finds the latest prefixed release from local tags without gh release list", async () => {
+    const commands: string[] = []
+    const tag = await getLatestStableReleaseTag(async (command) => {
+      commands.push(command)
+      if (command === `git tag --list "lib/wasmvm-ffi/v*.*.*"`) {
+        return "lib/wasmvm-ffi/v1.5.9\nlib/wasmvm-ffi/v1.6.0\n"
+      }
+      if (command.includes("gh release view 'lib/wasmvm-ffi/v1.6.0'")) {
+        return JSON.stringify({ tagName: "lib/wasmvm-ffi/v1.6.0" })
+      }
+      throw new Error(`Unexpected command: ${command}`)
+    })
+
+    expect(tag).toBe("lib/wasmvm-ffi/v1.6.0")
+    expect(commands.some((command) => command.startsWith("gh release list "))).toBe(
+      false,
+    )
+  })
+})
+
 describe("assertArtifactCommitAfterLatestRelease", () => {
   test("passes when no stable releases exist yet", async () => {
     await assertArtifactCommitAfterLatestRelease("abc123", async (command) => {
-      if (command.startsWith("gh release list ")) {
-        return "[]"
+      if (command === `git tag --list "lib/wasmvm-ffi/v*.*.*"`) {
+        return ""
       }
       throw new Error(`Unexpected command: ${command}`)
     })
@@ -321,8 +369,11 @@ describe("assertArtifactCommitAfterLatestRelease", () => {
     const commands: string[] = []
     await assertArtifactCommitAfterLatestRelease("new123", async (command) => {
       commands.push(command)
-      if (command.startsWith("gh release list ")) {
-        return JSON.stringify([{ tagName: "lib/wasmvm-ffi/v1.6.0" }])
+      if (command === `git tag --list "lib/wasmvm-ffi/v*.*.*"`) {
+        return "lib/wasmvm-ffi/v1.6.0\n"
+      }
+      if (command.includes("gh release view 'lib/wasmvm-ffi/v1.6.0'")) {
+        return JSON.stringify({ tagName: "lib/wasmvm-ffi/v1.6.0" })
       }
       if (command.includes("git rev-parse ")) return "old123\n"
       if (command.includes("git merge-base --is-ancestor")) return ""
@@ -367,8 +418,8 @@ describe("publishArtifacts", () => {
         }
 
         if (command.includes("git tag --points-at 'abc123'")) return ""
-        if (command.startsWith("gh release list ")) {
-          return JSON.stringify([{ tagName: "lib/wasmvm-ffi/v1.5.9" }])
+        if (command.includes("gh release view 'lib/wasmvm-ffi/v1.5.9'")) {
+          return JSON.stringify({ tagName: "lib/wasmvm-ffi/v1.5.9" })
         }
         if (command.includes("git rev-parse ")) return "old123\n"
         if (command.includes("git merge-base --is-ancestor")) return ""

--- a/lib/wasmvm-ffi/scripts/releaseArtifacts.test.ts
+++ b/lib/wasmvm-ffi/scripts/releaseArtifacts.test.ts
@@ -147,8 +147,8 @@ describe("findLatestLibwasmvmReleaseTag", () => {
 })
 
 describe("computeNextLibwasmvmReleaseTag", () => {
-  test("starts the Nibiru release line at lib/wasmvm-ffi/v1.6.0", () => {
-    expect(computeNextLibwasmvmReleaseTag([])).toBe("lib/wasmvm-ffi/v1.6.0")
+  test("starts the Nibiru release line at lib/wasmvm-ffi/v1.10.0", () => {
+    expect(computeNextLibwasmvmReleaseTag([])).toBe("lib/wasmvm-ffi/v1.10.0")
   })
 
   test("bumps from the upstream v1.5.9 line to lib/wasmvm-ffi/v1.6.0", () => {

--- a/lib/wasmvm-ffi/scripts/releaseArtifacts.test.ts
+++ b/lib/wasmvm-ffi/scripts/releaseArtifacts.test.ts
@@ -21,10 +21,10 @@ import {
 } from "./releaseArtifacts"
 
 const RELEASE_LIST_WITH_LIBWASMVM_RELEASES = JSON.stringify([
-  { tagName: "v1.5.9" },
-  { tagName: "v1.6.0" },
+  { tagName: "lib/wasmvm-ffi/v1.5.9" },
+  { tagName: "lib/wasmvm-ffi/v1.6.0" },
   { tagName: "libwasmvm/v9.9.9" },
-  { tagName: "v1.10.0" },
+  { tagName: "lib/wasmvm-ffi/v1.10.0" },
 ])
 
 const writeRequiredArtifacts = async (artifactsDir: string): Promise<void> => {
@@ -56,22 +56,30 @@ const writeRequiredArtifacts = async (artifactsDir: string): Promise<void> => {
 }
 
 describe("normalizeReleaseTag", () => {
-  test("keeps a plain semantic version tag unchanged", () => {
-    expect(normalizeReleaseTag("v1.6.0")).toBe("v1.6.0")
+  test("keeps a subdirectory release tag unchanged", () => {
+    expect(normalizeReleaseTag("lib/wasmvm-ffi/v1.6.0")).toBe(
+      "lib/wasmvm-ffi/v1.6.0",
+    )
   })
 
   test("normalizes a GitHub Release URL", () => {
-    const url = "https://github.com/NibiruChain/go-wasmvm/releases/tag/v1.6.0"
+    const url =
+      "https://github.com/NibiruChain/nibiru/releases/tag/lib%2Fwasmvm-ffi%2Fv1.6.0"
 
-    expect(normalizeReleaseTag(url)).toBe("v1.6.0")
+    expect(normalizeReleaseTag(url)).toBe("lib/wasmvm-ffi/v1.6.0")
   })
 
   test("trims surrounding whitespace", () => {
-    expect(normalizeReleaseTag("  v1.6.0  ")).toBe("v1.6.0")
+    expect(normalizeReleaseTag("  lib/wasmvm-ffi/v1.6.0  ")).toBe(
+      "lib/wasmvm-ffi/v1.6.0",
+    )
   })
 
   test("rejects unsupported release targets", () => {
     expect(() => normalizeReleaseTag("v1.6")).toThrow("Invalid release target")
+    expect(() => normalizeReleaseTag("v1.6.0")).toThrow(
+      "Invalid release target",
+    )
     expect(() => normalizeReleaseTag("libwasmvm/v1.6.0")).toThrow(
       "Invalid release target",
     )
@@ -84,9 +92,9 @@ describe("normalizeReleaseTag", () => {
 })
 
 describe("parseLibwasmvmReleaseTag", () => {
-  test("parses a plain semantic version release tag", () => {
-    expect(parseLibwasmvmReleaseTag("v1.6.0")).toEqual({
-      tag: "v1.6.0",
+  test("parses a subdirectory release tag", () => {
+    expect(parseLibwasmvmReleaseTag("lib/wasmvm-ffi/v1.6.0")).toEqual({
+      tag: "lib/wasmvm-ffi/v1.6.0",
       major: 1,
       minor: 6,
       patch: 0,
@@ -94,6 +102,7 @@ describe("parseLibwasmvmReleaseTag", () => {
   })
 
   test("ignores unrelated or prerelease tags", () => {
+    expect(parseLibwasmvmReleaseTag("v1.6.0")).toBeUndefined()
     expect(parseLibwasmvmReleaseTag("libwasmvm/v1.6.0")).toBeUndefined()
     expect(parseLibwasmvmReleaseTag("v1.6.0-rc.1")).toBeUndefined()
     expect(parseLibwasmvmReleaseTag("foo")).toBeUndefined()
@@ -104,21 +113,30 @@ describe("sortLibwasmvmReleaseTags", () => {
   test("filters unrelated tags and sorts by semantic version", () => {
     expect(
       sortLibwasmvmReleaseTags([
-        "v1.10.0",
+        "lib/wasmvm-ffi/v1.10.0",
+        "v1.99.0",
         "libwasmvm/v9.9.9",
-        "v1.6.2",
-        "v1.6.10",
+        "lib/wasmvm-ffi/v1.6.2",
+        "lib/wasmvm-ffi/v1.6.10",
         "v1.6.0-rc.1",
       ]),
-    ).toEqual(["v1.6.2", "v1.6.10", "v1.10.0"])
+    ).toEqual([
+      "lib/wasmvm-ffi/v1.6.2",
+      "lib/wasmvm-ffi/v1.6.10",
+      "lib/wasmvm-ffi/v1.10.0",
+    ])
   })
 })
 
 describe("findLatestLibwasmvmReleaseTag", () => {
   test("returns the highest plain semantic version tag", () => {
     expect(
-      findLatestLibwasmvmReleaseTag(["v1.6.0", "v1.7.0", "foo/v99.0.0"]),
-    ).toBe("v1.7.0")
+      findLatestLibwasmvmReleaseTag([
+        "lib/wasmvm-ffi/v1.6.0",
+        "lib/wasmvm-ffi/v1.7.0",
+        "foo/v99.0.0",
+      ]),
+    ).toBe("lib/wasmvm-ffi/v1.7.0")
   })
 
   test("returns undefined when no plain semantic version tags exist", () => {
@@ -127,26 +145,34 @@ describe("findLatestLibwasmvmReleaseTag", () => {
 })
 
 describe("computeNextLibwasmvmReleaseTag", () => {
-  test("starts the Nibiru release line at v1.6.0", () => {
-    expect(computeNextLibwasmvmReleaseTag([])).toBe("v1.6.0")
+  test("starts the Nibiru release line at lib/wasmvm-ffi/v1.6.0", () => {
+    expect(computeNextLibwasmvmReleaseTag([])).toBe("lib/wasmvm-ffi/v1.6.0")
   })
 
-  test("bumps from the upstream v1.5.9 line to v1.6.0", () => {
-    expect(computeNextLibwasmvmReleaseTag(["v1.5.9"])).toBe("v1.6.0")
+  test("bumps from the upstream v1.5.9 line to lib/wasmvm-ffi/v1.6.0", () => {
+    expect(computeNextLibwasmvmReleaseTag(["lib/wasmvm-ffi/v1.5.9"])).toBe(
+      "lib/wasmvm-ffi/v1.6.0",
+    )
   })
 
   test("computes patch, minor, and major bumps", () => {
-    const tags = ["v1.6.0"]
+    const tags = ["lib/wasmvm-ffi/v1.6.0"]
 
-    expect(computeNextLibwasmvmReleaseTag(tags, "patch")).toBe("v1.6.1")
-    expect(computeNextLibwasmvmReleaseTag(tags, "minor")).toBe("v1.7.0")
-    expect(computeNextLibwasmvmReleaseTag(tags, "major")).toBe("v2.0.0")
+    expect(computeNextLibwasmvmReleaseTag(tags, "patch")).toBe(
+      "lib/wasmvm-ffi/v1.6.1",
+    )
+    expect(computeNextLibwasmvmReleaseTag(tags, "minor")).toBe(
+      "lib/wasmvm-ffi/v1.7.0",
+    )
+    expect(computeNextLibwasmvmReleaseTag(tags, "major")).toBe(
+      "lib/wasmvm-ffi/v2.0.0",
+    )
   })
 
   test("rejects invalid bump types", () => {
-    expect(() => computeNextLibwasmvmReleaseTag(["v1.6.0"], "banana")).toThrow(
-      "Invalid bump type",
-    )
+    expect(() =>
+      computeNextLibwasmvmReleaseTag(["lib/wasmvm-ffi/v1.6.0"], "banana"),
+    ).toThrow("Invalid bump type")
   })
 })
 
@@ -159,7 +185,12 @@ describe("parseGhReleaseListTags", () => {
 
   test("extracts tag names from gh release JSON output", () => {
     expect(parseGhReleaseListTags(RELEASE_LIST_WITH_LIBWASMVM_RELEASES)).toEqual(
-      ["v1.5.9", "v1.6.0", "libwasmvm/v9.9.9", "v1.10.0"],
+      [
+        "lib/wasmvm-ffi/v1.5.9",
+        "lib/wasmvm-ffi/v1.6.0",
+        "libwasmvm/v9.9.9",
+        "lib/wasmvm-ffi/v1.10.0",
+      ],
     )
   })
 
@@ -184,13 +215,13 @@ describe("findLatestLibwasmvmReleaseTagFromGhOutput", () => {
       findLatestLibwasmvmReleaseTagFromGhOutput(
         RELEASE_LIST_WITH_LIBWASMVM_RELEASES,
       ),
-    ).toBe("v1.10.0")
+    ).toBe("lib/wasmvm-ffi/v1.10.0")
   })
 })
 
 describe("quoteShellArg", () => {
   test("quotes shell arguments with embedded single quotes", () => {
-    expect(quoteShellArg("v1.6.0")).toBe("'v1.6.0'")
+    expect(quoteShellArg("lib/wasmvm-ffi/v1.6.0")).toBe("'lib/wasmvm-ffi/v1.6.0'")
     expect(quoteShellArg("don't")).toBe("'don'\\''t'")
   })
 })
@@ -223,7 +254,7 @@ describe("buildPublishDryRunPlan", () => {
     const plan = buildPublishDryRunPlan(
       "feature",
       "abc123",
-      ["v1.5.9"],
+      ["lib/wasmvm-ffi/v1.5.9"],
       "minor",
       "tmp-artifacts",
     )
@@ -232,19 +263,19 @@ describe("buildPublishDryRunPlan", () => {
       bumpType: "minor",
       branch: "feature",
       commitSha: "abc123",
-      nextTag: "v1.6.0",
+      nextTag: "lib/wasmvm-ffi/v1.6.0",
       commands: [
         "test -d tmp-artifacts",
-        'git tag --no-sign -a v1.6.0 abc123 -m "libwasmvm v1.6.0"',
-        "git push origin v1.6.0",
-        "gh release create v1.6.0 " +
+        'git tag --no-sign -a lib/wasmvm-ffi/v1.6.0 abc123 -m "libwasmvm lib/wasmvm-ffi/v1.6.0"',
+        "git push origin lib/wasmvm-ffi/v1.6.0",
+        "gh release create lib/wasmvm-ffi/v1.6.0 " +
           "tmp-artifacts/libwasmvm_muslc.x86_64.a " +
           "tmp-artifacts/libwasmvm_muslc.aarch64.a " +
           "tmp-artifacts/libwasmvm.x86_64.so " +
           "tmp-artifacts/libwasmvm.aarch64.so " +
           "tmp-artifacts/libwasmvm.dylib " +
           "tmp-artifacts/libwasmvmstatic_darwin.a " +
-          '--repo NibiruChain/go-wasmvm --title "libwasmvm v1.6.0" ' +
+          '--repo NibiruChain/nibiru --title "libwasmvm lib/wasmvm-ffi/v1.6.0" ' +
           "--notes-file <release-body.md>",
       ],
     })
@@ -253,17 +284,20 @@ describe("buildPublishDryRunPlan", () => {
 
 describe("renderReleaseMetadataMarkdown", () => {
   test("renders release metadata and release assets", () => {
-    const releaseUrl = "https://github.com/NibiruChain/go-wasmvm/releases/tag/v1.6.0"
+    const releaseUrl =
+      "https://github.com/NibiruChain/nibiru/releases/tag/lib/wasmvm-ffi/v1.6.0"
     const markdown = renderReleaseMetadataMarkdown({
-      tag: "v1.6.0",
+      tag: "lib/wasmvm-ffi/v1.6.0",
       commitSha: "abc123",
       commitSubject: "Update wasm runtime",
       releaseUrl,
       workflowRunUrl:
-        "https://github.com/NibiruChain/go-wasmvm/actions/runs/1",
+        "https://github.com/NibiruChain/nibiru/actions/runs/1",
     })
 
-    expect(markdown).toContain(`- Release tag: [\`v1.6.0\`](${releaseUrl})`)
+    expect(markdown).toContain(
+      `- Release tag: [\`lib/wasmvm-ffi/v1.6.0\`](${releaseUrl})`,
+    )
     expect(markdown).toContain("- Source commit: `abc123` Update wasm runtime")
     expect(markdown).toContain("- `libwasmvm_muslc.x86_64.a`")
     expect(markdown).toContain("- `libwasmvm.aarch64.so`")
@@ -288,7 +322,7 @@ describe("assertArtifactCommitAfterLatestRelease", () => {
     await assertArtifactCommitAfterLatestRelease("new123", async (command) => {
       commands.push(command)
       if (command.startsWith("gh release list ")) {
-        return JSON.stringify([{ tagName: "v1.6.0" }])
+        return JSON.stringify([{ tagName: "lib/wasmvm-ffi/v1.6.0" }])
       }
       if (command.includes("git rev-parse ")) return "old123\n"
       if (command.includes("git merge-base --is-ancestor")) return ""
@@ -314,7 +348,9 @@ describe("publishArtifacts", () => {
         commands.push(command)
         if (command === "git branch --show-current") return "main\n"
         if (command === "git rev-parse HEAD") return "abc123\n"
-        if (command === `git tag --list "v*.*.*"`) return "v1.5.9\n"
+        if (command === `git tag --list "lib/wasmvm-ffi/v*.*.*"`) {
+          return "lib/wasmvm-ffi/v1.5.9\n"
+        }
 
         const emptyExact = ["command -v gh >/dev/null 2>&1"]
         const emptyPrefixes = [
@@ -332,7 +368,7 @@ describe("publishArtifacts", () => {
 
         if (command.includes("git tag --points-at 'abc123'")) return ""
         if (command.startsWith("gh release list ")) {
-          return JSON.stringify([{ tagName: "v1.5.9" }])
+          return JSON.stringify([{ tagName: "lib/wasmvm-ffi/v1.5.9" }])
         }
         if (command.includes("git rev-parse ")) return "old123\n"
         if (command.includes("git merge-base --is-ancestor")) return ""
@@ -370,11 +406,15 @@ describe("publishArtifacts", () => {
         commands.push(command)
         if (command === "git branch --show-current") return "main\n"
         if (command === "git rev-parse HEAD") return "abc123\n"
-        if (command === `git tag --list "v*.*.*"`) return "v1.6.0\n"
+        if (command === `git tag --list "lib/wasmvm-ffi/v*.*.*"`) {
+          return "lib/wasmvm-ffi/v1.6.0\n"
+        }
         if (command === "command -v gh >/dev/null 2>&1") return ""
-        if (command.includes("git tag --points-at 'abc123'")) return "v1.6.0\n"
-        if (command.includes("gh release view 'v1.6.0'")) {
-          return JSON.stringify({ tagName: "v1.6.0" })
+        if (command.includes("git tag --points-at 'abc123'")) {
+          return "lib/wasmvm-ffi/v1.6.0\n"
+        }
+        if (command.includes("gh release view 'lib/wasmvm-ffi/v1.6.0'")) {
+          return JSON.stringify({ tagName: "lib/wasmvm-ffi/v1.6.0" })
         }
         throw new Error(`Unexpected command: ${command}`)
       },
@@ -400,10 +440,14 @@ describe("publishArtifacts", () => {
         runner: async (command) => {
           if (command === "git branch --show-current") return "main\n"
           if (command === "git rev-parse HEAD") return "abc123\n"
-          if (command === `git tag --list "v*.*.*"`) return "v1.6.0\n"
+          if (command === `git tag --list "lib/wasmvm-ffi/v*.*.*"`) {
+            return "lib/wasmvm-ffi/v1.6.0\n"
+          }
           if (command === "command -v gh >/dev/null 2>&1") return ""
-          if (command.includes("git tag --points-at 'abc123'")) return "v1.6.0\n"
-          if (command.includes("gh release view 'v1.6.0'")) {
+          if (command.includes("git tag --points-at 'abc123'")) {
+            return "lib/wasmvm-ffi/v1.6.0\n"
+          }
+          if (command.includes("gh release view 'lib/wasmvm-ffi/v1.6.0'")) {
             throw new Error("release not found")
           }
           throw new Error(`Unexpected command: ${command}`)

--- a/lib/wasmvm-ffi/scripts/releaseArtifacts.ts
+++ b/lib/wasmvm-ffi/scripts/releaseArtifacts.ts
@@ -1,19 +1,19 @@
 #!/usr/bin/env bun
-import { spawn } from "node:child_process"
-import { mkdtemp, rm, stat } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
-import { Command } from "commander"
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
 
-const DEFAULT_BUMP_TYPE = "minor"
-const RELEASE_TAG_PREFIX = "lib/wasmvm-ffi/"
-const FIRST_RELEASE_TAG = `${RELEASE_TAG_PREFIX}v1.6.0`
-const RELEASE_VERSION_PATTERN = "v[0-9]+\\.[0-9]+\\.[0-9]+"
-const RELEASE_TAG_PATTERN = `${RELEASE_TAG_PREFIX}${RELEASE_VERSION_PATTERN}`
-const GITHUB_REPO = "NibiruChain/nibiru"
-const LOCAL_ARTIFACTS_DIR = "release-artifacts"
-const RELEASE_BRANCH = "main"
-const BUMP_TYPES = ["patch", "minor", "major"] as const
+const DEFAULT_BUMP_TYPE = "minor";
+const RELEASE_TAG_PREFIX = "lib/wasmvm-ffi/";
+const FIRST_RELEASE_TAG = `${RELEASE_TAG_PREFIX}v1.6.0`;
+const RELEASE_VERSION_PATTERN = "v[0-9]+\\.[0-9]+\\.[0-9]+";
+const RELEASE_TAG_PATTERN = `${RELEASE_TAG_PREFIX}${RELEASE_VERSION_PATTERN}`;
+const GITHUB_REPO = "NibiruChain/nibiru";
+const LIBWASMVM_DIST_DIR = "dist/libwasmvm";
+const RELEASE_BRANCH = "main";
+const BUMP_TYPES = ["patch", "minor", "major"] as const;
 const REQUIRED_RELEASE_ARTIFACTS = [
   "libwasmvm_muslc.x86_64.a",
   "libwasmvm_muslc.aarch64.a",
@@ -21,59 +21,59 @@ const REQUIRED_RELEASE_ARTIFACTS = [
   "libwasmvm.aarch64.so",
   "libwasmvm.dylib",
   "libwasmvmstatic_darwin.a",
-] as const
+] as const;
 
-type BumpType = (typeof BUMP_TYPES)[number]
-type CommandRunner = (command: string) => Promise<string>
+type BumpType = (typeof BUMP_TYPES)[number];
+type CommandRunner = (command: string) => Promise<string>;
 
 export interface LibwasmvmReleaseVersion {
-  tag: string
-  major: number
-  minor: number
-  patch: number
+  tag: string;
+  major: number;
+  minor: number;
+  patch: number;
 }
 
 export interface PublishDryRunPlan {
-  bumpType: BumpType
-  branch: string
-  commitSha: string
-  nextTag: string
-  commands: string[]
+  bumpType: BumpType;
+  branch: string;
+  commitSha: string;
+  nextTag: string;
+  commands: string[];
 }
 
 export interface PublishReleaseMetadata {
-  tag: string
-  commitSha: string
-  commitSubject: string
-  releaseUrl: string
-  workflowRunUrl?: string
+  tag: string;
+  commitSha: string;
+  commitSubject: string;
+  releaseUrl: string;
+  workflowRunUrl?: string;
 }
 
-export const REAL_FILTERED_GH_RELEASE_LIST_OUTPUT = `[]`
+export const REAL_FILTERED_GH_RELEASE_LIST_OUTPUT = `[]`;
 
 export const runShellCommand = async (command: string): Promise<string> => {
-  console.log(`$ ${command}`)
+  console.log(`$ ${command}`);
 
   return new Promise((resolve, reject) => {
     const child = spawn(command, {
       shell: true,
       stdio: ["ignore", "pipe", "pipe"],
-    })
-    let stdout = ""
-    let stderr = ""
+    });
+    let stdout = "";
+    let stderr = "";
 
-    child.stdout.setEncoding("utf8")
-    child.stderr.setEncoding("utf8")
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
     child.stdout.on("data", (chunk) => {
-      stdout += chunk
-    })
+      stdout += chunk;
+    });
     child.stderr.on("data", (chunk) => {
-      stderr += chunk
-    })
-    child.on("error", reject)
+      stderr += chunk;
+    });
+    child.on("error", reject);
     child.on("close", (code) => {
       if (stderr.trim() !== "") {
-        console.error(stderr.trim())
+        console.error(stderr.trim());
       }
       if (code !== 0) {
         reject(
@@ -81,55 +81,69 @@ export const runShellCommand = async (command: string): Promise<string> => {
             `Command failed with exit code ${code}: ` +
               `${stderr || stdout || command}`,
           ),
-        )
-        return
+        );
+        return;
       }
-      resolve(stdout)
-    })
-  })
-}
+      resolve(stdout);
+    });
+  });
+};
+
+export const getRepoRoot = async (
+  runner: CommandRunner = runShellCommand,
+): Promise<string> => (await runner("git rev-parse --show-toplevel")).trim();
+
+export const resolveDefaultArtifactsDir = async (
+  runner: CommandRunner = runShellCommand,
+): Promise<string> => {
+  const artifactsDir = join(await getRepoRoot(runner), LIBWASMVM_DIST_DIR);
+  await mkdir(artifactsDir, { recursive: true });
+  return artifactsDir;
+};
 
 export const quoteShellArg = (value: string): string => {
-  return `'${value.replaceAll("'", "'\\''")}'`
-}
+  return `'${value.replaceAll("'", "'\\''")}'`;
+};
 
 export const normalizeBumpType = (value: string | undefined): BumpType => {
   if (value === undefined) {
-    return DEFAULT_BUMP_TYPE
+    return DEFAULT_BUMP_TYPE;
   }
 
   if (BUMP_TYPES.includes(value as BumpType)) {
-    return value as BumpType
+    return value as BumpType;
   }
 
   throw new Error(
     `Invalid bump type "${value}". Use one of: ${BUMP_TYPES.join(", ")}`,
-  )
-}
+  );
+};
 
 export const normalizeReleaseTag = (value: string): string => {
-  const input = value.trim()
-  const releaseTagRegex = new RegExp(`^${RELEASE_TAG_PATTERN}$`)
+  const input = value.trim();
+  const releaseTagRegex = new RegExp(`^${RELEASE_TAG_PATTERN}$`);
 
   if (releaseTagRegex.test(input)) {
-    return input
+    return input;
   }
 
   try {
-    const url = new URL(input)
-    const releasePathPrefix = `/${GITHUB_REPO}/releases/tag/`
+    const url = new URL(input);
+    const releasePathPrefix = `/${GITHUB_REPO}/releases/tag/`;
 
     if (url.hostname !== "github.com") {
-      throw new Error("URL is not a github.com release URL")
+      throw new Error("URL is not a github.com release URL");
     }
 
     if (!url.pathname.startsWith(releasePathPrefix)) {
-      throw new Error("URL path is not a Nibiru release tag path")
+      throw new Error("URL path is not a Nibiru release tag path");
     }
 
-    const tag = decodeURIComponent(url.pathname.slice(releasePathPrefix.length))
+    const tag = decodeURIComponent(
+      url.pathname.slice(releasePathPrefix.length),
+    );
     if (releaseTagRegex.test(tag)) {
-      return tag
+      return tag;
     }
   } catch {
     // Fall through to the shared error below.
@@ -137,18 +151,18 @@ export const normalizeReleaseTag = (value: string): string => {
 
   throw new Error(
     `Invalid release target "${value}". Use ${RELEASE_TAG_PREFIX}vX.Y.Z or a Nibiru GitHub Release URL.`,
-  )
-}
+  );
+};
 
 export const parseLibwasmvmReleaseTag = (
   tag: string,
 ): LibwasmvmReleaseVersion | undefined => {
   const match = tag.match(
     /^lib\/wasmvm-ffi\/v(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)$/,
-  )
+  );
 
   if (match?.groups === undefined) {
-    return undefined
+    return undefined;
   }
 
   return {
@@ -156,8 +170,8 @@ export const parseLibwasmvmReleaseTag = (
     major: Number(match.groups.major),
     minor: Number(match.groups.minor),
     patch: Number(match.groups.patch),
-  }
-}
+  };
+};
 
 const compareLibwasmvmReleaseVersions = (
   left: LibwasmvmReleaseVersion,
@@ -167,8 +181,8 @@ const compareLibwasmvmReleaseVersions = (
     left.major - right.major ||
     left.minor - right.minor ||
     left.patch - right.patch
-  )
-}
+  );
+};
 
 export const sortLibwasmvmReleaseTags = (tags: string[]): string[] => {
   return tags
@@ -177,117 +191,115 @@ export const sortLibwasmvmReleaseTags = (tags: string[]): string[] => {
       (version): version is LibwasmvmReleaseVersion => version !== undefined,
     )
     .sort(compareLibwasmvmReleaseVersions)
-    .map((version) => version.tag)
-}
+    .map((version) => version.tag);
+};
 
 export const findLatestLibwasmvmReleaseTag = (
   tags: string[],
 ): string | undefined => {
-  return sortLibwasmvmReleaseTags(tags).at(-1)
-}
+  return sortLibwasmvmReleaseTags(tags).at(-1);
+};
 
 export const computeNextLibwasmvmReleaseTag = (
   tags: string[],
   bumpType?: string,
 ): string => {
-  const normalizedBumpType = normalizeBumpType(bumpType)
-  const latestTag = findLatestLibwasmvmReleaseTag(tags)
+  const normalizedBumpType = normalizeBumpType(bumpType);
+  const latestTag = findLatestLibwasmvmReleaseTag(tags);
   const latestVersion =
-    latestTag === undefined ? undefined : parseLibwasmvmReleaseTag(latestTag)
+    latestTag === undefined ? undefined : parseLibwasmvmReleaseTag(latestTag);
 
   if (latestVersion === undefined) {
-    return FIRST_RELEASE_TAG
+    return FIRST_RELEASE_TAG;
   }
 
   if (normalizedBumpType === "patch") {
     return `${RELEASE_TAG_PREFIX}v${latestVersion.major}.${latestVersion.minor}.${
       latestVersion.patch + 1
-    }`
+    }`;
   }
 
   if (normalizedBumpType === "minor") {
     return `${RELEASE_TAG_PREFIX}v${latestVersion.major}.${
       latestVersion.minor + 1
-    }.0`
+    }.0`;
   }
 
-  return `${RELEASE_TAG_PREFIX}v${latestVersion.major + 1}.0.0`
-}
+  return `${RELEASE_TAG_PREFIX}v${latestVersion.major + 1}.0.0`;
+};
 
 export const parseGhReleaseListTags = (output: string): string[] => {
-  const parsed = JSON.parse(output) as Array<{ tagName: string }>
+  const parsed = JSON.parse(output) as Array<{ tagName: string }>;
   if (!Array.isArray(parsed)) {
-    throw new Error("Expected gh release list JSON output to be an array")
+    throw new Error("Expected gh release list JSON output to be an array");
   }
 
-  return parsed.map((release) => release.tagName)
-}
+  return parsed.map((release) => release.tagName);
+};
 
 export const findLatestLibwasmvmReleaseTagFromGhOutput = (
   output: string,
 ): string | undefined => {
-  return findLatestLibwasmvmReleaseTag(parseGhReleaseListTags(output))
-}
+  return findLatestLibwasmvmReleaseTag(parseGhReleaseListTags(output));
+};
 
 export const getLocalGitTags = async (
   runner: CommandRunner = runShellCommand,
 ): Promise<string[]> => {
-  const stdout = await runner(`git tag --list "${RELEASE_TAG_PREFIX}v*.*.*"`)
+  const stdout = await runner(`git tag --list "${RELEASE_TAG_PREFIX}v*.*.*"`);
   return stdout
     .split("\n")
     .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-}
+    .filter((line) => line.length > 0);
+};
 
 export const getLatestStableReleaseTag = async (
   runner: CommandRunner = runShellCommand,
 ): Promise<string> => {
-  const stdout = await runner(
-    `gh release list --repo ${GITHUB_REPO} --exclude-drafts --exclude-pre-releases --limit 100 --json tagName`,
-  )
-  const latestTag = findLatestLibwasmvmReleaseTagFromGhOutput(stdout)
+  const localTags = await getLocalGitTags(runner);
+  const latestTag = await findReleasedHeadTag(localTags, runner);
 
   if (latestTag === undefined) {
-    throw new Error(`No stable ${GITHUB_REPO} releases found`)
+    throw new Error(`No stable ${GITHUB_REPO} releases found`);
   }
 
-  return latestTag
-}
+  return latestTag;
+};
 
 export const ensureGhCli = async (
   runner: CommandRunner = runShellCommand,
 ): Promise<void> => {
   try {
-    await runner("command -v gh >/dev/null 2>&1")
+    await runner("command -v gh >/dev/null 2>&1");
   } catch {
     throw new Error(
       "GitHub CLI `gh` is required. Install it from https://cli.github.com/ " +
         "and run `gh auth login` if the repository requires authentication.",
-    )
+    );
   }
-}
+};
 
 export const validateExistingArtifacts = async (
   artifactsDir: string,
 ): Promise<void> => {
-  let artifactsStat
+  let artifactsStat;
   try {
-    artifactsStat = await stat(artifactsDir)
+    artifactsStat = await stat(artifactsDir);
   } catch {
-    throw new Error(`Missing artifacts directory: ${artifactsDir}`)
+    throw new Error(`Missing artifacts directory: ${artifactsDir}`);
   }
 
   if (!artifactsStat.isDirectory()) {
-    throw new Error(`Artifacts path is not a directory: ${artifactsDir}`)
+    throw new Error(`Artifacts path is not a directory: ${artifactsDir}`);
   }
 
   for (const fileName of REQUIRED_RELEASE_ARTIFACTS) {
-    const filePath = join(artifactsDir, fileName)
+    const filePath = join(artifactsDir, fileName);
     if (!(await Bun.file(filePath).exists())) {
-      throw new Error(`Missing required artifact file: ${filePath}`)
+      throw new Error(`Missing required artifact file: ${filePath}`);
     }
   }
-}
+};
 
 export const getLibwasmvmTagsPointingAtCommit = async (
   commit: string,
@@ -297,12 +309,12 @@ export const getLibwasmvmTagsPointingAtCommit = async (
     `git tag --points-at ${quoteShellArg(
       commit,
     )} --list "${RELEASE_TAG_PREFIX}v*.*.*"`,
-  )
+  );
   return stdout
     .split("\n")
     .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-}
+    .filter((line) => line.length > 0);
+};
 
 export const githubReleaseExists = async (
   tag: string,
@@ -311,12 +323,12 @@ export const githubReleaseExists = async (
   try {
     await runner(
       `gh release view ${quoteShellArg(tag)} --repo ${GITHUB_REPO} --json tagName`,
-    )
-    return true
+    );
+    return true;
   } catch {
-    return false
+    return false;
   }
-}
+};
 
 export const findReleasedHeadTag = async (
   headTags: string[],
@@ -324,12 +336,12 @@ export const findReleasedHeadTag = async (
 ): Promise<string | undefined> => {
   for (const tag of sortLibwasmvmReleaseTags(headTags).toReversed()) {
     if (await githubReleaseExists(tag, runner)) {
-      return tag
+      return tag;
     }
   }
 
-  return undefined
-}
+  return undefined;
+};
 
 export const getTagCommit = async (
   tag: string,
@@ -337,8 +349,8 @@ export const getTagCommit = async (
 ): Promise<string> => {
   return (
     await runner(`git rev-parse ${quoteShellArg(`${tag}^{commit}`)}`)
-  ).trim()
-}
+  ).trim();
+};
 
 export const isAncestorCommit = async (
   ancestorCommit: string,
@@ -350,56 +362,56 @@ export const isAncestorCommit = async (
       `git merge-base --is-ancestor ${quoteShellArg(
         ancestorCommit,
       )} ${quoteShellArg(descendantCommit)}`,
-    )
-    return true
+    );
+    return true;
   } catch {
-    return false
+    return false;
   }
-}
+};
 
 export const assertArtifactCommitAfterLatestRelease = async (
   artifactCommit: string,
   runner: CommandRunner = runShellCommand,
 ): Promise<void> => {
-  let latestReleaseTag: string
+  let latestReleaseTag: string;
   try {
-    latestReleaseTag = await getLatestStableReleaseTag(runner)
+    latestReleaseTag = await getLatestStableReleaseTag(runner);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
+    const message = error instanceof Error ? error.message : String(error);
     if (message.includes(`No stable ${GITHUB_REPO} releases found`)) {
-      return
+      return;
     }
-    throw error
+    throw error;
   }
 
-  const latestReleaseCommit = await getTagCommit(latestReleaseTag, runner)
+  const latestReleaseCommit = await getTagCommit(latestReleaseTag, runner);
   if (latestReleaseCommit === artifactCommit) {
     throw new Error(
       `Artifact commit ${artifactCommit} is already the latest release commit ` +
         `for ${latestReleaseTag}`,
-    )
+    );
   }
 
   if (!(await isAncestorCommit(latestReleaseCommit, artifactCommit, runner))) {
     throw new Error(
       `Artifact commit ${artifactCommit} is not after latest release ` +
         `${latestReleaseTag} (${latestReleaseCommit})`,
-    )
+    );
   }
-}
+};
 
 export const buildPublishDryRunPlan = (
   branch: string,
   commitSha: string,
   localTags: string[],
   bumpType?: string,
-  artifactsDir = LOCAL_ARTIFACTS_DIR,
+  artifactsDir: string,
 ): PublishDryRunPlan => {
-  const normalizedBumpType = normalizeBumpType(bumpType)
-  const nextTag = computeNextLibwasmvmReleaseTag(localTags, normalizedBumpType)
+  const normalizedBumpType = normalizeBumpType(bumpType);
+  const nextTag = computeNextLibwasmvmReleaseTag(localTags, normalizedBumpType);
   const artifactArgs = REQUIRED_RELEASE_ARTIFACTS.map(
     (fileName) => `${artifactsDir}/${fileName}`,
-  ).join(" ")
+  ).join(" ");
 
   return {
     bumpType: normalizedBumpType,
@@ -412,41 +424,41 @@ export const buildPublishDryRunPlan = (
       `git push origin ${nextTag}`,
       `gh release create ${nextTag} ${artifactArgs} --repo ${GITHUB_REPO} --title "libwasmvm ${nextTag}" --notes-file <release-body.md>`,
     ],
-  }
-}
+  };
+};
 
 export const printPublishDryRun = (plan: PublishDryRunPlan): void => {
-  console.log("Dry run: no release changes were made.")
+  console.log("Dry run: no release changes were made.");
   console.log(
     "Pass --run to tag the commit, create the GitHub Release, and upload assets.",
-  )
-  console.log("")
-  console.log(`Branch: ${plan.branch}`)
-  console.log(`Commit: ${plan.commitSha}`)
-  console.log(`Bump: ${plan.bumpType}`)
-  console.log(`Next tag: ${plan.nextTag}`)
-  console.log("")
-  console.log("Commands that would run:")
+  );
+  console.log("");
+  console.log(`Branch: ${plan.branch}`);
+  console.log(`Commit: ${plan.commitSha}`);
+  console.log(`Bump: ${plan.bumpType}`);
+  console.log(`Next tag: ${plan.nextTag}`);
+  console.log("");
+  console.log("Commands that would run:");
   for (const command of plan.commands) {
-    console.log(`  ${command}`)
+    console.log(`  ${command}`);
   }
-}
+};
 
 export const buildWorkflowRunUrl = (): string | undefined => {
-  const serverUrl = process.env.GITHUB_SERVER_URL
-  const repository = process.env.GITHUB_REPOSITORY
-  const runId = process.env.GITHUB_RUN_ID
+  const serverUrl = process.env.GITHUB_SERVER_URL;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const runId = process.env.GITHUB_RUN_ID;
 
   if (
     serverUrl === undefined ||
     repository === undefined ||
     runId === undefined
   ) {
-    return undefined
+    return undefined;
   }
 
-  return `${serverUrl}/${repository}/actions/runs/${runId}`
-}
+  return `${serverUrl}/${repository}/actions/runs/${runId}`;
+};
 
 export const renderReleaseMetadataMarkdown = (
   metadata: PublishReleaseMetadata,
@@ -462,167 +474,171 @@ export const renderReleaseMetadataMarkdown = (
     "## Release assets",
     "",
     ...REQUIRED_RELEASE_ARTIFACTS.map((fileName) => `- \`${fileName}\``),
-  ]
+  ];
 
   if (metadata.workflowRunUrl !== undefined) {
-    lines.push("", `- Workflow run: ${metadata.workflowRunUrl}`)
+    lines.push("", `- Workflow run: ${metadata.workflowRunUrl}`);
   }
 
-  lines.push("")
+  lines.push("");
 
-  return `${lines.join("\n")}\n`
-}
+  return `${lines.join("\n")}\n`;
+};
 
 export const createGitTagAndRelease = async (
   tag: string,
   commitSha: string,
   releaseBodyPath: string,
-  artifactsDir = LOCAL_ARTIFACTS_DIR,
+  artifactsDir: string,
   runner: CommandRunner = runShellCommand,
 ): Promise<void> => {
   const artifactArgs = REQUIRED_RELEASE_ARTIFACTS.map((fileName) =>
     quoteShellArg(join(artifactsDir, fileName)),
-  ).join(" ")
+  ).join(" ");
 
   await runner(
     `git tag --no-sign -a ${quoteShellArg(tag)} ${quoteShellArg(
       commitSha,
     )} -m ${quoteShellArg(`libwasmvm ${tag}`)}`,
-  )
-  await runner(`git push origin ${quoteShellArg(tag)}`)
+  );
+  await runner(`git push origin ${quoteShellArg(tag)}`);
   await runner(
     `gh release create ${quoteShellArg(
       tag,
     )} ${artifactArgs} --repo ${GITHUB_REPO} --title ${quoteShellArg(
       `libwasmvm ${tag}`,
     )} --notes-file ${quoteShellArg(releaseBodyPath)}`,
-  )
-}
+  );
+};
 
 export const publishArtifacts = async (
   bumpType?: string,
   options: {
-    run?: boolean
-    artifactsDir?: string
-    runner?: CommandRunner
+    run?: boolean;
+    artifactsDir?: string;
+    runner?: CommandRunner;
   } = {},
 ): Promise<void> => {
-  const runner = options.runner ?? runShellCommand
-  const artifactsDir = options.artifactsDir ?? LOCAL_ARTIFACTS_DIR
-  const normalizedBumpType = normalizeBumpType(bumpType)
-  const branch = (await runner("git branch --show-current")).trim()
-  const commitSha = (await runner("git rev-parse HEAD")).trim()
-  const localTags = await getLocalGitTags(runner)
+  const runner = options.runner ?? runShellCommand;
+  const artifactsDir =
+    options.artifactsDir ?? (await resolveDefaultArtifactsDir(runner));
+  const normalizedBumpType = normalizeBumpType(bumpType);
+  const branch = (await runner("git branch --show-current")).trim();
+  const commitSha = (await runner("git rev-parse HEAD")).trim();
+  const localTags = await getLocalGitTags(runner);
   const dryRunPlan = buildPublishDryRunPlan(
     branch,
     commitSha,
     localTags,
     normalizedBumpType,
     artifactsDir,
-  )
+  );
 
   if (options.run !== true) {
-    printPublishDryRun(dryRunPlan)
-    return
+    printPublishDryRun(dryRunPlan);
+    return;
   }
 
   if (branch !== RELEASE_BRANCH) {
     throw new Error(
       `Refusing to publish from branch "${branch}". Use ${RELEASE_BRANCH}.`,
-    )
+    );
   }
 
-  await ensureGhCli(runner)
-  await validateExistingArtifacts(artifactsDir)
+  await ensureGhCli(runner);
+  await validateExistingArtifacts(artifactsDir);
 
-  const artifactTags = await getLibwasmvmTagsPointingAtCommit(commitSha, runner)
+  const artifactTags = await getLibwasmvmTagsPointingAtCommit(
+    commitSha,
+    runner,
+  );
   if (artifactTags.length > 0) {
-    const releasedArtifactTag = await findReleasedHeadTag(artifactTags, runner)
+    const releasedArtifactTag = await findReleasedHeadTag(artifactTags, runner);
     if (releasedArtifactTag !== undefined) {
       console.log(
         `${releasedArtifactTag} already has a GitHub Release; skipping.`,
-      )
-      return
+      );
+      return;
     }
 
-    const latestArtifactTag = sortLibwasmvmReleaseTags(artifactTags).at(-1)
+    const latestArtifactTag = sortLibwasmvmReleaseTags(artifactTags).at(-1);
     throw new Error(
       `${latestArtifactTag} tags artifact commit ${commitSha} ` +
         "but does not have a GitHub Release.",
-    )
+    );
   }
 
-  await assertArtifactCommitAfterLatestRelease(commitSha, runner)
+  await assertArtifactCommitAfterLatestRelease(commitSha, runner);
 
   if (localTags.includes(dryRunPlan.nextTag)) {
     throw new Error(
       `${dryRunPlan.nextTag} already exists but does not have a release ` +
         "for the current HEAD.",
-    )
+    );
   }
 
   const commitSubject = (
     await runner(`git log -1 --format=%s ${quoteShellArg(commitSha)}`)
-  ).trim()
+  ).trim();
   const metadata: PublishReleaseMetadata = {
     tag: dryRunPlan.nextTag,
     commitSha,
     commitSubject,
-    releaseUrl: `https://github.com/${GITHUB_REPO}/releases/tag/${dryRunPlan.nextTag}`,
+    releaseUrl: `https://github.com/${GITHUB_REPO}/releases/tag/${encodeURIComponent(dryRunPlan.nextTag)}`,
     workflowRunUrl: buildWorkflowRunUrl(),
-  }
+  };
   const releaseNotesDir = await mkdtemp(
     join(tmpdir(), "libwasmvm-release-notes-"),
-  )
+  );
 
   try {
-    const releaseBodyPath = join(releaseNotesDir, "release-body.md")
+    const releaseBodyPath = join(releaseNotesDir, "release-body.md");
     await Bun.write(
       Bun.file(releaseBodyPath),
       renderReleaseMetadataMarkdown(metadata),
-    )
+    );
     await createGitTagAndRelease(
       dryRunPlan.nextTag,
       commitSha,
       releaseBodyPath,
       artifactsDir,
       runner,
-    )
+    );
   } finally {
-    await rm(releaseNotesDir, { recursive: true, force: true })
+    await rm(releaseNotesDir, { recursive: true, force: true });
   }
-  console.log(`Published ${dryRunPlan.nextTag}`)
-}
+  console.log(`Published ${dryRunPlan.nextTag}`);
+};
 
 export const printNextTag = async (bumpType?: string): Promise<void> => {
-  const tags = await getLocalGitTags()
-  console.log(computeNextLibwasmvmReleaseTag(tags, bumpType))
-}
+  const tags = await getLocalGitTags();
+  console.log(computeNextLibwasmvmReleaseTag(tags, bumpType));
+};
 
 export const testReleaseHelper = async (
   runner: CommandRunner = runShellCommand,
 ): Promise<void> => {
-  await runner("bun test scripts")
-}
+  await runner("bun test scripts");
+};
 
 const runCliAction = async (
   action: () => void | Promise<void>,
 ): Promise<void> => {
   try {
-    await action()
+    await action();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    console.error(message)
-    process.exit(1)
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
   }
-}
+};
 
-const program = new Command()
+const program = new Command();
 
 program
   .name("releaseArtifacts")
   .description("go-wasmvm libwasmvm artifact release helper")
-  .helpOption("--help", "display help for command")
+  .helpOption("--help", "display help for command");
 
 program
   .command("publish")
@@ -630,29 +646,29 @@ program
   .argument("[bump]", "patch | minor | major", DEFAULT_BUMP_TYPE)
   .option("--run", "execute the release; without this, print a dry run")
   .action((bumpType: string | undefined, options: { run?: boolean }) => {
-    return runCliAction(() => publishArtifacts(bumpType, options))
-  })
+    return runCliAction(() => publishArtifacts(bumpType, options));
+  });
 
 program
   .command("next-tag")
   .description("Compute the next libwasmvm release tag")
   .argument("[bump]", "patch | minor | major", DEFAULT_BUMP_TYPE)
   .action((bumpType?: string) => {
-    return runCliAction(() => printNextTag(bumpType))
-  })
+    return runCliAction(() => printNextTag(bumpType));
+  });
 
 program
   .command("test")
   .description("Run release helper tests")
   .action(() => {
-    return runCliAction(() => testReleaseHelper())
-  })
+    return runCliAction(() => testReleaseHelper());
+  });
 
 if (import.meta.main) {
   if (process.argv.length <= 2) {
-    program.outputHelp()
-    process.exit(0)
+    program.outputHelp();
+    process.exit(0);
   }
 
-  await program.parseAsync()
+  await program.parseAsync();
 }

--- a/lib/wasmvm-ffi/scripts/releaseArtifacts.ts
+++ b/lib/wasmvm-ffi/scripts/releaseArtifacts.ts
@@ -6,9 +6,11 @@ import { join } from "node:path"
 import { Command } from "commander"
 
 const DEFAULT_BUMP_TYPE = "minor"
-const FIRST_RELEASE_TAG = "v1.6.0"
+const RELEASE_TAG_PREFIX = "lib/wasmvm-ffi/"
+const FIRST_RELEASE_TAG = `${RELEASE_TAG_PREFIX}v1.6.0`
 const RELEASE_VERSION_PATTERN = "v[0-9]+\\.[0-9]+\\.[0-9]+"
-const GITHUB_REPO = "NibiruChain/go-wasmvm"
+const RELEASE_TAG_PATTERN = `${RELEASE_TAG_PREFIX}${RELEASE_VERSION_PATTERN}`
+const GITHUB_REPO = "NibiruChain/nibiru"
 const LOCAL_ARTIFACTS_DIR = "release-artifacts"
 const RELEASE_BRANCH = "main"
 const BUMP_TYPES = ["patch", "minor", "major"] as const
@@ -107,26 +109,26 @@ export const normalizeBumpType = (value: string | undefined): BumpType => {
 
 export const normalizeReleaseTag = (value: string): string => {
   const input = value.trim()
-  const versionRegex = new RegExp(`^${RELEASE_VERSION_PATTERN}$`)
+  const releaseTagRegex = new RegExp(`^${RELEASE_TAG_PATTERN}$`)
 
-  if (versionRegex.test(input)) {
+  if (releaseTagRegex.test(input)) {
     return input
   }
 
   try {
     const url = new URL(input)
-    const releasePathPrefix = "/NibiruChain/go-wasmvm/releases/tag/"
+    const releasePathPrefix = `/${GITHUB_REPO}/releases/tag/`
 
     if (url.hostname !== "github.com") {
       throw new Error("URL is not a github.com release URL")
     }
 
     if (!url.pathname.startsWith(releasePathPrefix)) {
-      throw new Error("URL path is not a go-wasmvm release tag path")
+      throw new Error("URL path is not a Nibiru release tag path")
     }
 
     const tag = decodeURIComponent(url.pathname.slice(releasePathPrefix.length))
-    if (versionRegex.test(tag)) {
+    if (releaseTagRegex.test(tag)) {
       return tag
     }
   } catch {
@@ -134,7 +136,7 @@ export const normalizeReleaseTag = (value: string): string => {
   }
 
   throw new Error(
-    `Invalid release target "${value}". Use vX.Y.Z or a go-wasmvm GitHub Release URL.`,
+    `Invalid release target "${value}". Use ${RELEASE_TAG_PREFIX}vX.Y.Z or a Nibiru GitHub Release URL.`,
   )
 }
 
@@ -142,7 +144,7 @@ export const parseLibwasmvmReleaseTag = (
   tag: string,
 ): LibwasmvmReleaseVersion | undefined => {
   const match = tag.match(
-    /^v(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)$/,
+    /^lib\/wasmvm-ffi\/v(?<major>[0-9]+)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)$/,
   )
 
   if (match?.groups === undefined) {
@@ -198,16 +200,18 @@ export const computeNextLibwasmvmReleaseTag = (
   }
 
   if (normalizedBumpType === "patch") {
-    return `v${latestVersion.major}.${latestVersion.minor}.${
+    return `${RELEASE_TAG_PREFIX}v${latestVersion.major}.${latestVersion.minor}.${
       latestVersion.patch + 1
     }`
   }
 
   if (normalizedBumpType === "minor") {
-    return `v${latestVersion.major}.${latestVersion.minor + 1}.0`
+    return `${RELEASE_TAG_PREFIX}v${latestVersion.major}.${
+      latestVersion.minor + 1
+    }.0`
   }
 
-  return `v${latestVersion.major + 1}.0.0`
+  return `${RELEASE_TAG_PREFIX}v${latestVersion.major + 1}.0.0`
 }
 
 export const parseGhReleaseListTags = (output: string): string[] => {
@@ -228,7 +232,7 @@ export const findLatestLibwasmvmReleaseTagFromGhOutput = (
 export const getLocalGitTags = async (
   runner: CommandRunner = runShellCommand,
 ): Promise<string[]> => {
-  const stdout = await runner(`git tag --list "v*.*.*"`)
+  const stdout = await runner(`git tag --list "${RELEASE_TAG_PREFIX}v*.*.*"`)
   return stdout
     .split("\n")
     .map((line) => line.trim())
@@ -290,7 +294,9 @@ export const getLibwasmvmTagsPointingAtCommit = async (
   runner: CommandRunner = runShellCommand,
 ): Promise<string[]> => {
   const stdout = await runner(
-    `git tag --points-at ${quoteShellArg(commit)} --list "v*.*.*"`,
+    `git tag --points-at ${quoteShellArg(
+      commit,
+    )} --list "${RELEASE_TAG_PREFIX}v*.*.*"`,
   )
   return stdout
     .split("\n")

--- a/lib/wasmvm-ffi/scripts/releaseArtifacts.ts
+++ b/lib/wasmvm-ffi/scripts/releaseArtifacts.ts
@@ -7,7 +7,7 @@ import { Command } from "commander";
 
 const DEFAULT_BUMP_TYPE = "minor";
 const RELEASE_TAG_PREFIX = "lib/wasmvm-ffi/";
-const FIRST_RELEASE_TAG = `${RELEASE_TAG_PREFIX}v1.6.0`;
+const FIRST_RELEASE_TAG = `${RELEASE_TAG_PREFIX}v1.10.0`;
 const RELEASE_VERSION_PATTERN = "v[0-9]+\\.[0-9]+\\.[0-9]+";
 const RELEASE_TAG_PATTERN = `${RELEASE_TAG_PREFIX}${RELEASE_VERSION_PATTERN}`;
 const GITHUB_REPO = "NibiruChain/nibiru";


### PR DESCRIPTION
# Add Wasm VM FFI CI and release automation

This PR adds the first Nibiru-native CI and release automation for the `lib/wasmvm-ffi` subtree, so the copied WasmVM FFI module can be tested, built, and prepared for artifact releases from the monorepo.

## Key Changes

1. Adds workflow `Wasm VM FFI` for the `lib/wasmvm-ffi` subtree, with path-filtered jobs for Rust base tests, Rust linting, Go base tests, Go linting, Go FFI tests, Docker artifact builds, and release publishing.

1. Routes workflow commands through command `just wasmvm ...`, keeping the workflow rooted at the Nibiru repository while delegating execution to the subtree `justfile`.

1. Adds command `just test-alpine` inside `lib/wasmvm-ffi` as the workflow-facing entrypoint for Alpine musl Go tests, while preserving the existing Makefile-backed implementation for now.

1. Updates the libwasmvm release helper to publish from repository `NibiruChain/nibiru` using Go submodule-style tags such as `lib/wasmvm-ffi/v1.6.0`, while preserving the existing `libwasmvm_*` release asset filenames.

## Manual Testing I Did Locally

- `bunx github-actionlint .github/workflows/wasmvm-ffi.yml`
- `just wasmvm ci-go`
- `just wasmvm release test`
- `just wasmvm release publish` dry run only