### PR TITLE
build: Modernize protobuf formatting and drop Docker proto tooling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+# Protobuf formatting configuration. Edit this file, then run `just proto fmt`.
+---
+Language: Proto
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 0
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+SpacesInSquareBrackets: true # True := [ (gogoproto...) ] instead of [(gogoproto...)]
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true

--- a/.clang-format
+++ b/.clang-format
@@ -1,9 +1,11 @@
-# Protobuf formatting configuration. Edit this file, then run `just proto fmt`.
+# Protobuf formatting configuration for clang-format, invoked by `just proto fmt`.
+# Unlike `buf format`, clang-format reads this file, so edit these rules to tune
+# the repository's protobuf style and rerun `just proto fmt` to apply them.
 ---
 Language: Proto
 BasedOnStyle: Google
 IndentWidth: 2
-ColumnLimit: 0
+ColumnLimit: 100  # 0 disables this.
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
 SpacesInSquareBrackets: true # True := [ (gogoproto...) ] instead of [(gogoproto...)]

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -60,8 +60,9 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Set up Buf
-        uses: bufbuild/buf-setup-action@v1.55.1
+        uses: bufbuild/buf-setup-action@v1.50.0
         with:
+          version: 1.55.1
           github_token: ${{ github.token }}
       - name: Install just
         uses: taiki-e/install-action@just

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -53,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Install clang-format
+        run: sudo apt-get install -y clang-format
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -57,6 +57,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: Set up Buf
+        uses: bufbuild/buf-setup-action@v1.55.1
+        with:
+          github_token: ${{ github.token }}
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Regenerate protobuf output

--- a/contrib/scripts/proto.sh
+++ b/contrib/scripts/proto.sh
@@ -3,6 +3,8 @@ set -Eeuo pipefail
 
 # BUF_VERSION: Version installed only when Buf is missing from PATH.
 BUF_VERSION="1.55.1"
+PROTOC_GEN_GOCOSMOS_VERSION="1.4.10"
+PROTOC_GEN_GRPC_GATEWAY_VERSION="1.16.0"
 
 # REPO_ROOT: Resolve the repository so this script also works outside its root.
 REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")/../.." rev-parse --show-toplevel)"
@@ -91,6 +93,16 @@ add_brew_clang_format_to_path() {
   export PATH="${brew_prefix}/bin:${PATH}"
 }
 
+# add_go_bin_to_path: Expose binaries installed by `go install` to this process.
+add_go_bin_to_path() {
+  local go_bin
+  go_bin="$(go env GOBIN)"
+  if [[ -z "${go_bin}" ]]; then
+    go_bin="$(go env GOPATH)/bin"
+  fi
+  export PATH="${go_bin}:${PATH}"
+}
+
 # check_buf: Ensure Buf is available for `proto lint` and `proto gen`.
 # Installs BUF_VERSION with Go only when Buf is absent from PATH.
 check_buf() {
@@ -104,11 +116,59 @@ check_buf() {
     return 1
   fi
 
+  add_go_bin_to_path
+  if which_ok buf >/dev/null 2>&1; then
+    return 0
+  fi
+
   run_cmd go install "github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION}"
-  if ! which_ok buf; then
-    log_error "buf was installed but is not on PATH. Add \$(go env GOPATH)/bin to PATH and retry."
+  add_go_bin_to_path
+  if ! which_ok buf >/dev/null 2>&1; then
+    log_error "buf installation completed, but its Go bin directory does not contain an executable."
     return 1
   fi
+}
+
+# go_tool_has_version: Check whether a Go binary has the expected module version.
+go_tool_has_version() {
+  local binary="$1"
+  local module="$2"
+  local version="$3"
+  local binary_path
+
+  binary_path="$(command -v "${binary}")" || return 1
+  go version -m "${binary_path}" 2>/dev/null | awk \
+    -v module="${module}" -v version="v${version}" \
+    '$1 == "mod" && $2 == module && $3 == version { found = 1 } END { exit !found }'
+}
+
+# check_proto_plugins: Install the pinned Buf plugins when absent or outdated.
+check_proto_plugins() {
+  local plugin_spec plugin package module version
+  local -a plugin_specs=(
+    "protoc-gen-gocosmos|github.com/cosmos/gogoproto/protoc-gen-gocosmos|github.com/cosmos/gogoproto|${PROTOC_GEN_GOCOSMOS_VERSION}"
+    "protoc-gen-grpc-gateway|github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway|github.com/grpc-ecosystem/grpc-gateway|${PROTOC_GEN_GRPC_GATEWAY_VERSION}"
+  )
+
+  if ! which_ok go; then
+    log_error "Go is required to install protobuf generation plugins."
+    return 1
+  fi
+  add_go_bin_to_path
+
+  for plugin_spec in "${plugin_specs[@]}"; do
+    IFS='|' read -r plugin package module version <<<"${plugin_spec}"
+    if go_tool_has_version "${plugin}" "${module}" "${version}"; then
+      continue
+    fi
+
+    log_info "Installing ${plugin} v${version}"
+    run_cmd go install "${package}@v${version}"
+    if ! go_tool_has_version "${plugin}" "${module}" "${version}"; then
+      log_error "${plugin} v${version} installation could not be verified."
+      return 1
+    fi
+  done
 }
 
 # proto_gen: Generate protobuf Go and API files with the host Buf toolchain.
@@ -116,6 +176,7 @@ proto_gen() {
   log_info "Generating Protobuf files"
   if [[ "${PRINT_CMD}" != "true" ]]; then
     check_buf
+    check_proto_plugins
   fi
   run_cmd bash contrib/scripts/protocgen.sh
 }
@@ -123,11 +184,27 @@ proto_gen() {
 # proto_fmt: Format Nibiru, Cosmos SDK, and IBC-Go protobuf files with
 # clang-format and the repository's .clang-format rules.
 proto_fmt() {
+  local dir
+  local -a targets=()
+
   log_info "Formatting Protobuf files"
   if [[ "${PRINT_CMD}" != "true" ]]; then
     check_clang_format
   fi
-  run_cmd find ./proto ./lib/cosmos-sdk/proto ./lib/ibc-go/proto -name '*.proto' -exec clang-format -i {} \;
+
+  for dir in ./proto ./lib/cosmos-sdk/proto ./lib/ibc-go/proto; do
+    if [[ -d "${dir}" ]]; then
+      targets+=("${dir}")
+    else
+      log_warning "Skipping missing protobuf directory: ${dir}"
+    fi
+  done
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    log_error "No protobuf directories were found to format."
+    return 1
+  fi
+
+  run_cmd find "${targets[@]}" -name '*.proto' -exec clang-format -i {} \;
 }
 
 # proto_lint: Run Buf lint from the Nibiru-owned proto module root.

--- a/contrib/scripts/proto.sh
+++ b/contrib/scripts/proto.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+# BUF_VERSION: Version installed only when Buf is missing from PATH.
 BUF_VERSION="1.55.1"
 
+# REPO_ROOT: Resolve the repository so this script also works outside its root.
 REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")/../.." rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 # shellcheck source=contrib/bashlib.sh
 source contrib/bashlib.sh
 
+# usage: Print the proto command dispatcher help text.
 usage() {
   cat <<EOF
 NAME:
@@ -29,11 +32,13 @@ GLOBAL OPTIONS:
 EOF
 }
 
+# shell_join: Print a shell-escaped command for a readable execution log.
 shell_join() {
   printf '%q ' "$@"
   printf '\n'
 }
 
+# run_cmd: Print a command, then execute it unless --cmd requested a preview.
 run_cmd() {
   if [[ "${PRINT_CMD}" == "true" ]]; then
     shell_join "$@"
@@ -44,15 +49,50 @@ run_cmd() {
   "$@"
 }
 
+# check_clang_format: Ensure the formatter is available for `proto fmt`.
+#
+# Behavior:
+#   - Use an existing PATH or Homebrew keg-only installation when available.
+#   - Otherwise, install via apt-get first and Homebrew second.
+#   - Return an actionable error if neither installation path provides it.
 check_clang_format() {
-  if which_ok clang-format; then
+  if which_ok clang-format >/dev/null 2>&1; then
     return 0
+  fi
+
+  add_brew_clang_format_to_path && which_ok clang-format && return 0
+
+  log_info "Installing clang-format for $(uname -m)"
+  if command -v apt-get >/dev/null 2>&1; then
+    if sudo apt-get install -y clang-format; then
+      which_ok clang-format && return 0
+    fi
+    log_warning "Unable to install clang-format with apt-get; trying Homebrew."
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    if brew install clang-format; then
+      add_brew_clang_format_to_path && which_ok clang-format && return 0
+    fi
   fi
 
   log_error "clang-format is required for protobuf formatting. Install clang-format and ensure it is on PATH."
   return 1
 }
 
+# add_brew_clang_format_to_path: Expose Homebrew's keg-only clang-format to
+# the current script process. Returns 1 when Homebrew or its formatter is absent.
+add_brew_clang_format_to_path() {
+  local brew_prefix
+  command -v brew >/dev/null 2>&1 || return 1
+  brew_prefix="$(brew --prefix clang-format 2>/dev/null)" || return 1
+  [[ -x "${brew_prefix}/bin/clang-format" ]] || return 1
+
+  export PATH="${brew_prefix}/bin:${PATH}"
+}
+
+# check_buf: Ensure Buf is available for `proto lint` and `proto gen`.
+# Installs BUF_VERSION with Go only when Buf is absent from PATH.
 check_buf() {
   if which_ok buf >/dev/null 2>&1; then
     return 0
@@ -71,6 +111,7 @@ check_buf() {
   fi
 }
 
+# proto_gen: Generate protobuf Go and API files with the host Buf toolchain.
 proto_gen() {
   log_info "Generating Protobuf files"
   if [[ "${PRINT_CMD}" != "true" ]]; then
@@ -79,14 +120,17 @@ proto_gen() {
   run_cmd bash contrib/scripts/protocgen.sh
 }
 
+# proto_fmt: Format Nibiru, Cosmos SDK, and IBC-Go protobuf files with
+# clang-format and the repository's .clang-format rules.
 proto_fmt() {
   log_info "Formatting Protobuf files"
   if [[ "${PRINT_CMD}" != "true" ]]; then
     check_clang_format
   fi
-  run_cmd find ./proto -name '*.proto' -exec clang-format -i {} \;
+  run_cmd find ./proto ./lib/cosmos-sdk/proto ./lib/ibc-go/proto -name '*.proto' -exec clang-format -i {} \;
 }
 
+# proto_lint: Run Buf lint from the Nibiru-owned proto module root.
 proto_lint() {
   log_info "Linting Protobuf files"
   if [[ "${PRINT_CMD}" != "true" ]]; then
@@ -98,6 +142,7 @@ proto_lint() {
   )
 }
 
+# proto_all: Run formatting, linting, then generation in that order.
 proto_all() {
   proto_fmt
   proto_lint

--- a/contrib/scripts/proto.sh
+++ b/contrib/scripts/proto.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-PROTO_VERSION="0.14.0"
-PROTO_IMAGE="ghcr.io/cosmos/proto-builder:${PROTO_VERSION}"
-PROTO_FMT_IMAGE="tendermintdev/docker-build-proto"
+BUF_VERSION="1.55.1"
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")/../.." rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+# shellcheck source=contrib/bashlib.sh
+source contrib/bashlib.sh
 
 usage() {
   cat <<EOF
@@ -26,14 +29,6 @@ GLOBAL OPTIONS:
 EOF
 }
 
-log_info() {
-  printf 'INFO: %s\n' "$*" >&2
-}
-
-log_error() {
-  printf 'ERROR: %s\n' "$*" >&2
-}
-
 shell_join() {
   printf '%q ' "$@"
   printf '\n'
@@ -49,50 +44,58 @@ run_cmd() {
   "$@"
 }
 
-repo_root() {
-  git rev-parse --show-toplevel
+check_clang_format() {
+  if which_ok clang-format; then
+    return 0
+  fi
+
+  log_error "clang-format is required for protobuf formatting. Install clang-format and ensure it is on PATH."
+  return 1
 }
 
-docker_run() {
-  local -r image="$1"
-  shift
+check_buf() {
+  if which_ok buf >/dev/null 2>&1; then
+    return 0
+  fi
 
-  run_cmd docker run \
-    --rm \
-    -v "$(repo_root):/workspace" \
-    --workdir /workspace \
-    "${image}" \
-    "$@"
+  log_info "buf is not present; installing buf ${BUF_VERSION}"
+  if ! which_ok go; then
+    log_error "buf is required for protobuf linting and generation. Install Go, then run: go install github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION}"
+    return 1
+  fi
+
+  run_cmd go install "github.com/bufbuild/buf/cmd/buf@v${BUF_VERSION}"
+  if ! which_ok buf; then
+    log_error "buf was installed but is not on PATH. Add \$(go env GOPATH)/bin to PATH and retry."
+    return 1
+  fi
 }
 
 proto_gen() {
   log_info "Generating Protobuf files"
-  run_cmd docker run \
-    --rm \
-    --user root \
-    -e "HOST_UID=$(id -u)" \
-    -e "HOST_GID=$(id -g)" \
-    -v "$(repo_root):/workspace" \
-    --workdir /workspace \
-    "${PROTO_IMAGE}" \
-    sh -lc 'apk add --no-cache bash go git su-exec >/dev/null && export PATH="/go/bin:$PATH" && su-exec "$HOST_UID:$HOST_GID" env HOME=/tmp PATH="/go/bin:$PATH" bash ./contrib/scripts/protocgen.sh'
+  if [[ "${PRINT_CMD}" != "true" ]]; then
+    check_buf
+  fi
+  run_cmd bash contrib/scripts/protocgen.sh
 }
 
-# FIXME: TODO https://github.com/NibiruChain/nibiru/issues/2636
 proto_fmt() {
   log_info "Formatting Protobuf files"
-  docker_run \
-    "${PROTO_FMT_IMAGE}" \
-    find ./ -not -path "./third_party/*" -name "*.proto" -exec clang-format -i {} ";"
+  if [[ "${PRINT_CMD}" != "true" ]]; then
+    check_clang_format
+  fi
+  run_cmd find ./proto -name '*.proto' -exec clang-format -i {} \;
 }
 
 proto_lint() {
   log_info "Linting Protobuf files"
-  run_cmd docker run --rm \
-    -v "$(repo_root):/workspace" \
-    --workdir /workspace/proto \
-    "${PROTO_IMAGE}" \
-    buf lint --error-format=json "$@"
+  if [[ "${PRINT_CMD}" != "true" ]]; then
+    check_buf
+  fi
+  (
+    cd proto
+    run_cmd buf lint --error-format=json "$@"
+  )
 }
 
 proto_all() {

--- a/eth/rpc/rpcapi/api_eth_test.go
+++ b/eth/rpc/rpcapi/api_eth_test.go
@@ -474,21 +474,16 @@ func (s *NodeSuite) Test_SmartContract() {
 		s.Require().NoError(err)
 		s.Require().Equal(tx.Hash(), txHash)
 
-		s.T().Log("Wait one block so the tx won't be pending")
-		s.Require().NoError(s.cli.WaitForNextBlock())
+		txReceipt, err := s.waitForEthReceipt(txHash)
+		s.Require().NoErrorf(err, "receipt for txHash: %s", txHash.Hex())
+		s.Equal(txHash, txReceipt.TxHash)
 
-		s.T().Log("Assert: tx NOT pending")
-
-		var pendingTxs []*rpc.EthTxJsonRPC
-		pendingTxs, err = s.ethAPI.GetPendingTransactions()
+		s.T().Log("Assert: confirmed tx is not pending")
+		pendingTxs, err := s.ethAPI.GetPendingTransactions()
 		s.NoError(err)
 		for _, pendingTx := range pendingTxs {
 			s.Require().NotEqual(txHash, pendingTx.Hash)
 		}
-
-		txReceipt, err := s.waitForEthReceipt(txHash)
-		s.Require().NoErrorf(err, "receipt for txHash: %s", txHash.Hex())
-		s.Equal(txHash, txReceipt.TxHash)
 
 		rpcTx, err := s.ethAPI.GetTransactionByHash(txHash)
 		s.NoError(err)
@@ -526,7 +521,6 @@ func (s *NodeSuite) Test_SmartContract() {
 
 		resTxHash, err := s.ethAPI.SendRawTransaction(txBz)
 		s.Require().NoError(err)
-		s.Require().NoError(s.cli.WaitForNextBlock())
 		s.Equal(tx.Hash().Hex(), resTxHash.Hex())
 
 		txReceipt, err := s.waitForEthReceipt(resTxHash)

--- a/eth/rpc/rpcapi/nonce_test.go
+++ b/eth/rpc/rpcapi/nonce_test.go
@@ -77,11 +77,6 @@ func (s *BackendSuite) TestNonceIncrementWithMultipleMsgsTx() {
 		s.T().Logf("sdk.TxResp %v: %s", txMsg.name, jsonBz)
 	}
 
-	s.Require().NoError(s.cli.WaitForNextBlock())
-
-	currentNonce = s.getCurrentNonce(s.evmSenderEthAddr)
-	s.Require().Equal(nonce+3, currentNonce)
-
 	s.T().Log("Assert all transactions included in block")
 	for _, txMsg := range txMsgs {
 		blockNum, blockHash, receipt, err := WaitForReceipt(s, txMsg.coreTx.Hash())
@@ -90,6 +85,12 @@ func (s *BackendSuite) TestNonceIncrementWithMultipleMsgsTx() {
 		s.Require().NotNilf(blockNum, "expect receipt | %v", txMsg.name)
 		s.Require().NotNilf(blockHash, "expect receipt | %v", txMsg.name)
 	}
+
+	currentNonce = s.getCurrentNonce(s.evmSenderEthAddr)
+	s.Require().GreaterOrEqualf(
+		currentNonce, nonce+3, "nonce (before) %d, currentNonce %d must differ by at least 3",
+		nonce, currentNonce,
+	)
 }
 
 // buildSDKTxWithEVMMessages creates an SDK transaction with EVM messages

--- a/lib/cosmos-sdk/baseapp/testutil/messages.proto
+++ b/lib/cosmos-sdk/baseapp/testutil/messages.proto
@@ -33,7 +33,4 @@ service Counter2 {
   rpc IncrementCounter(MsgCounter2) returns (MsgCreateCounterResponse);
 }
 
-service KeyValue {
-  rpc Set(MsgKeyValue) returns (MsgCreateKeyValueResponse);
-}
-
+service KeyValue { rpc Set(MsgKeyValue) returns (MsgCreateKeyValueResponse); }

--- a/lib/cosmos-sdk/proto/amino/amino.proto
+++ b/lib/cosmos-sdk/proto/amino/amino.proto
@@ -4,8 +4,9 @@ package amino;
 
 import "google/protobuf/descriptor.proto";
 
-// TODO(fdymylja): once we fully migrate to protov2 the go_package needs to be updated.
-// We need this right now because gogoproto codegen needs to import the extension.
+// TODO(fdymylja): once we fully migrate to protov2 the go_package needs to be
+// updated. We need this right now because gogoproto codegen needs to import the
+// extension.
 option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types/tx/amino";
 
 extend google.protobuf.MessageOptions {

--- a/lib/cosmos-sdk/proto/cosmos/app/runtime/v1alpha1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/app/runtime/v1alpha1/module.proto
@@ -8,7 +8,7 @@ import "cosmos/app/v1alpha1/module.proto";
 message Module {
   option (cosmos.app.v1alpha1.module) = {
     go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/runtime"
-    use_package: {name: "cosmos.app.v1alpha1"}
+    use_package: { name: "cosmos.app.v1alpha1" }
   };
 
   // app_name is the name of the app.
@@ -30,17 +30,17 @@ message Module {
   repeated string init_genesis = 4;
 
   // export_genesis specifies the order in which to export module genesis data.
-  // If this is left empty, the init_genesis order will be used for export genesis
-  // if it is specified.
+  // If this is left empty, the init_genesis order will be used for export
+  // genesis if it is specified.
   repeated string export_genesis = 5;
 
-  // override_store_keys is an optional list of overrides for the module store keys
-  // to be used in keeper construction.
+  // override_store_keys is an optional list of overrides for the module store
+  // keys to be used in keeper construction.
   repeated StoreKeyConfig override_store_keys = 6;
 }
 
-// StoreKeyConfig may be supplied to override the default module store key, which
-// is the module name.
+// StoreKeyConfig may be supplied to override the default module store key,
+// which is the module name.
 message StoreKeyConfig {
   // name of the module to override the store key of
   string module_name = 1;

--- a/lib/cosmos-sdk/proto/cosmos/app/v1alpha1/config.proto
+++ b/lib/cosmos-sdk/proto/cosmos/app/v1alpha1/config.proto
@@ -9,15 +9,16 @@ import "google/protobuf/any.proto";
 // baseapp and tx handlers (and possibly even Tendermint) that an app needs
 // can be described in a config object. For compatibility, the framework should
 // allow a mixture of declarative and imperative app wiring, however, apps
-// that strive for the maximum ease of maintainability should be able to describe
-// their state machine with a config object alone.
+// that strive for the maximum ease of maintainability should be able to
+// describe their state machine with a config object alone.
 message Config {
   // modules are the module configurations for the app.
   repeated ModuleConfig modules = 1;
 
-  // golang_bindings specifies explicit interface to implementation type bindings which
-  // depinject uses to resolve interface inputs to provider functions.  The scope of this
-  // field's configuration is global (not module specific).
+  // golang_bindings specifies explicit interface to implementation type
+  // bindings which depinject uses to resolve interface inputs to provider
+  // functions.  The scope of this field's configuration is global (not module
+  // specific).
   repeated GolangBinding golang_bindings = 2;
 }
 
@@ -30,26 +31,31 @@ message ModuleConfig {
   // For example, for the module cosmos.bank.module.v1.Module, we may chose
   // to simply name the module "bank" in the app. When we upgrade to
   // cosmos.bank.module.v2.Module, the app-specific name "bank" stays the same
-  // and the framework knows that the v2 module should receive all the same state
-  // that the v1 module had. Note: modules should provide info on which versions
-  // they can migrate from in the ModuleDescriptor.can_migration_from field.
+  // and the framework knows that the v2 module should receive all the same
+  // state that the v1 module had. Note: modules should provide info on which
+  // versions they can migrate from in the ModuleDescriptor.can_migration_from
+  // field.
   string name = 1;
 
   // config is the config object for the module. Module config messages should
-  // define a ModuleDescriptor using the cosmos.app.v1alpha1.is_module extension.
+  // define a ModuleDescriptor using the cosmos.app.v1alpha1.is_module
+  // extension.
   google.protobuf.Any config = 2;
 
-  // golang_bindings specifies explicit interface to implementation type bindings which
-  // depinject uses to resolve interface inputs to provider functions.  The scope of this
-  // field's configuration is module specific.
+  // golang_bindings specifies explicit interface to implementation type
+  // bindings which depinject uses to resolve interface inputs to provider
+  // functions.  The scope of this field's configuration is module specific.
   repeated GolangBinding golang_bindings = 3;
 }
 
-// GolangBinding is an explicit interface type to implementing type binding for dependency injection.
+// GolangBinding is an explicit interface type to implementing type binding for
+// dependency injection.
 message GolangBinding {
-  // interface_type is the interface type which will be bound to a specific implementation type
+  // interface_type is the interface type which will be bound to a specific
+  // implementation type
   string interface_type = 1;
 
-  // implementation is the implementing type which will be supplied when an input of type interface is requested
+  // implementation is the implementing type which will be supplied when an
+  // input of type interface is requested
   string implementation = 2;
 }

--- a/lib/cosmos-sdk/proto/cosmos/app/v1alpha1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/app/v1alpha1/module.proto
@@ -7,11 +7,12 @@ import "google/protobuf/descriptor.proto";
 extend google.protobuf.MessageOptions {
   // module indicates that this proto type is a config object for an app module
   // and optionally provides other descriptive information about the module.
-  // It is recommended that a new module config object and go module is versioned
-  // for every state machine breaking version of a module. The recommended
-  // pattern for doing this is to put module config objects in a separate proto
-  // package from the API they expose. Ex: the cosmos.group.v1 API would be
-  // exposed by module configs cosmos.group.module.v1, cosmos.group.module.v2, etc.
+  // It is recommended that a new module config object and go module is
+  // versioned for every state machine breaking version of a module. The
+  // recommended pattern for doing this is to put module config objects in a
+  // separate proto package from the API they expose. Ex: the cosmos.group.v1
+  // API would be exposed by module configs cosmos.group.module.v1,
+  // cosmos.group.module.v2, etc.
   ModuleDescriptor module = 57193479;
 }
 
@@ -71,7 +72,8 @@ message PackageReference {
   // as it may mean that the pinned descriptor for a legacy module has been
   // improperly updated or that there is some other versioning discrepancy.
   // Runtime protobuf definitions will also be checked for compatibility
-  // with pinned file descriptors to make sure there are no incompatible changes.
+  // with pinned file descriptors to make sure there are no incompatible
+  // changes.
   //
   // This behavior ensures that:
   // * pinned proto images are up-to-date
@@ -84,7 +86,6 @@ message PackageReference {
 // MigrateFromInfo is information on a module version that a newer module
 // can migrate from.
 message MigrateFromInfo {
-
   // module is the fully-qualified protobuf name of the module config object
   // for the previous module version, ex: "cosmos.group.module.v1.Module".
   string module = 1;

--- a/lib/cosmos-sdk/proto/cosmos/app/v1alpha1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/app/v1alpha1/query.proto
@@ -6,7 +6,6 @@ import "cosmos/app/v1alpha1/config.proto";
 
 // Query is the app module query service.
 service Query {
-
   // Config returns the current app config.
   rpc Config(QueryConfigRequest) returns (QueryConfigResponse) {}
 }
@@ -16,7 +15,6 @@ message QueryConfigRequest {}
 
 // QueryConfigRequest is the Query/Config response type.
 message QueryConfigResponse {
-
   // config is the current app config.
   Config config = 1;
 }

--- a/lib/cosmos-sdk/proto/cosmos/auth/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/auth/module/v1/module.proto
@@ -6,7 +6,9 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object for the auth module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/auth"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/auth"
+  };
 
   // bech32_prefix is the bech32 account prefix for the app.
   string bech32_prefix = 1;
@@ -14,7 +16,8 @@ message Module {
   // module_account_permissions are module account permissions.
   repeated ModuleAccountPermission module_account_permissions = 2;
 
-  // authority defines the custom module authority. If not set, defaults to the governance module.
+  // authority defines the custom module authority. If not set, defaults to the
+  // governance module.
   string authority = 3;
 }
 

--- a/lib/cosmos-sdk/proto/cosmos/auth/v1beta1/auth.proto
+++ b/lib/cosmos-sdk/proto/cosmos/auth/v1beta1/auth.proto
@@ -12,50 +12,51 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/auth/type
 // for basic account functionality. Any custom account type should extend this
 // type for additional functionality (e.g. vesting).
 message BaseAccount {
-  option (amino.name) = "cosmos-sdk/BaseAccount";
-  option (gogoproto.goproto_getters) = false;
-  option (gogoproto.equal) = false;
+  option (amino.name)                        = "cosmos-sdk/BaseAccount";
+  option (gogoproto.goproto_getters)         = false;
+  option (gogoproto.equal)                   = false;
   option (cosmos_proto.implements_interface) = "cosmos.auth.v1beta1.AccountI";
 
-  string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  google.protobuf.Any pub_key = 2 [
-    (gogoproto.jsontag) = "public_key,omitempty",
-    (amino.field_name) = "public_key"
-  ];
+  string              address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  google.protobuf.Any pub_key = 2
+      [(gogoproto.jsontag) = "public_key,omitempty", (amino.field_name) = "public_key"];
   uint64 account_number = 3;
-  uint64 sequence = 4;
+  uint64 sequence       = 4;
 }
 
 // ModuleAccount defines an account for modules that holds coins on a pool.
 message ModuleAccount {
-  option (amino.name) = "cosmos-sdk/ModuleAccount";
-  option (gogoproto.goproto_getters) = false;
+  option (amino.name)                        = "cosmos-sdk/ModuleAccount";
+  option (gogoproto.goproto_getters)         = false;
   option (cosmos_proto.implements_interface) = "cosmos.auth.v1beta1.ModuleAccountI";
 
-  BaseAccount base_account = 1 [(gogoproto.embed) = true];
-  string name = 2;
-  repeated string permissions = 3;
+  BaseAccount     base_account = 1 [(gogoproto.embed) = true];
+  string          name         = 2;
+  repeated string permissions  = 3;
 }
 
-// ModuleCredential represents a unclaimable pubkey for base accounts controlled by modules.
+// ModuleCredential represents a unclaimable pubkey for base accounts controlled
+// by modules.
 //
 // Since: cosmos-sdk 0.47
 message ModuleCredential {
-  // module_name is the name of the module used for address derivation (passed into address.Module).
+  // module_name is the name of the module used for address derivation (passed
+  // into address.Module).
   string module_name = 1;
-  // derivation_keys is for deriving a module account address (passed into address.Module)
-  // adding more keys creates sub-account addresses (passed into address.Derive)
+  // derivation_keys is for deriving a module account address (passed into
+  // address.Module) adding more keys creates sub-account addresses (passed into
+  // address.Derive)
   repeated bytes derivation_keys = 2;
 }
 
 // Params defines the parameters for the auth module.
 message Params {
-  option (amino.name) = "cosmos-sdk/x/auth/Params";
+  option (amino.name)      = "cosmos-sdk/x/auth/Params";
   option (gogoproto.equal) = true;
 
-  uint64 max_memo_characters = 1;
-  uint64 tx_sig_limit = 2;
-  uint64 tx_size_cost_per_byte = 3;
-  uint64 sig_verify_cost_ed25519 = 4 [(gogoproto.customname) = "SigVerifyCostED25519"];
+  uint64 max_memo_characters       = 1;
+  uint64 tx_sig_limit              = 2;
+  uint64 tx_size_cost_per_byte     = 3;
+  uint64 sig_verify_cost_ed25519   = 4 [(gogoproto.customname) = "SigVerifyCostED25519"];
   uint64 sig_verify_cost_secp256k1 = 5 [(gogoproto.customname) = "SigVerifyCostSecp256k1"];
 }

--- a/lib/cosmos-sdk/proto/cosmos/auth/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/auth/v1beta1/genesis.proto
@@ -11,10 +11,7 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/auth/type
 // GenesisState defines the auth module's genesis state.
 message GenesisState {
   // params defines all the parameters of the module.
-  Params params = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // accounts are the accounts present at genesis.
   repeated google.protobuf.Any accounts = 2;

--- a/lib/cosmos-sdk/proto/cosmos/auth/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/auth/v1beta1/query.proto
@@ -21,13 +21,13 @@ service Query {
   // Since: cosmos-sdk 0.43
   rpc Accounts(QueryAccountsRequest) returns (QueryAccountsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/auth/v1beta1/accounts";
+    option (google.api.http).get               = "/cosmos/auth/v1beta1/accounts";
   }
 
   // Account returns account details based on address.
   rpc Account(QueryAccountRequest) returns (QueryAccountResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/auth/v1beta1/accounts/{address}";
+    option (google.api.http).get               = "/cosmos/auth/v1beta1/accounts/{address}";
   }
 
   // AccountAddressByID returns account address based on account number.
@@ -35,13 +35,13 @@ service Query {
   // Since: cosmos-sdk 0.46.2
   rpc AccountAddressByID(QueryAccountAddressByIDRequest) returns (QueryAccountAddressByIDResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/auth/v1beta1/address_by_id/{id}";
+    option (google.api.http).get               = "/cosmos/auth/v1beta1/address_by_id/{id}";
   }
 
   // Params queries all parameters.
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/auth/v1beta1/params";
+    option (google.api.http).get               = "/cosmos/auth/v1beta1/params";
   }
 
   // ModuleAccounts returns all the existing module accounts.
@@ -49,13 +49,14 @@ service Query {
   // Since: cosmos-sdk 0.46
   rpc ModuleAccounts(QueryModuleAccountsRequest) returns (QueryModuleAccountsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/auth/v1beta1/module_accounts";
+    option (google.api.http).get               = "/cosmos/auth/v1beta1/module_accounts";
   }
 
   // ModuleAccountByName returns the module account info by module name
-  rpc ModuleAccountByName(QueryModuleAccountByNameRequest) returns (QueryModuleAccountByNameResponse) {
+  rpc ModuleAccountByName(QueryModuleAccountByNameRequest)
+      returns (QueryModuleAccountByNameResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/auth/v1beta1/module_accounts/{name}";
+    option (google.api.http).get               = "/cosmos/auth/v1beta1/module_accounts/{name}";
   }
 
   // Bech32Prefix queries bech32Prefix
@@ -84,7 +85,7 @@ service Query {
   // Since: cosmos-sdk 0.47
   rpc AccountInfo(QueryAccountInfoRequest) returns (QueryAccountInfoResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/auth/v1beta1/account_info/{address}";
+    option (google.api.http).get               = "/cosmos/auth/v1beta1/account_info/{address}";
   }
 }
 
@@ -101,7 +102,8 @@ message QueryAccountsRequest {
 // Since: cosmos-sdk 0.43
 message QueryAccountsResponse {
   // accounts are the existing accounts
-  repeated google.protobuf.Any accounts = 1 [(cosmos_proto.accepts_interface) = "cosmos.auth.v1beta1.AccountI"];
+  repeated google.protobuf.Any accounts = 1
+      [(cosmos_proto.accepts_interface) = "cosmos.auth.v1beta1.AccountI"];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -109,7 +111,7 @@ message QueryAccountsResponse {
 
 // QueryAccountRequest is the request type for the Query/Account RPC method.
 message QueryAccountRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address defines the address to query for.
@@ -119,7 +121,8 @@ message QueryAccountRequest {
 // QueryAccountResponse is the response type for the Query/Account RPC method.
 message QueryAccountResponse {
   // account defines the account of the corresponding address.
-  google.protobuf.Any account = 1 [(cosmos_proto.accepts_interface) = "cosmos.auth.v1beta1.AccountI"];
+  google.protobuf.Any account = 1
+      [(cosmos_proto.accepts_interface) = "cosmos.auth.v1beta1.AccountI"];
 }
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.
@@ -131,26 +134,32 @@ message QueryParamsResponse {
   Params params = 1 [(gogoproto.nullable) = false];
 }
 
-// QueryModuleAccountsRequest is the request type for the Query/ModuleAccounts RPC method.
+// QueryModuleAccountsRequest is the request type for the Query/ModuleAccounts
+// RPC method.
 //
 // Since: cosmos-sdk 0.46
 message QueryModuleAccountsRequest {}
 
-// QueryModuleAccountsResponse is the response type for the Query/ModuleAccounts RPC method.
+// QueryModuleAccountsResponse is the response type for the Query/ModuleAccounts
+// RPC method.
 //
 // Since: cosmos-sdk 0.46
 message QueryModuleAccountsResponse {
-  repeated google.protobuf.Any accounts = 1 [(cosmos_proto.accepts_interface) = "cosmos.auth.v1beta1.ModuleAccountI"];
+  repeated google.protobuf.Any accounts = 1
+      [(cosmos_proto.accepts_interface) = "cosmos.auth.v1beta1.ModuleAccountI"];
 }
 
-// QueryModuleAccountByNameRequest is the request type for the Query/ModuleAccountByName RPC method.
+// QueryModuleAccountByNameRequest is the request type for the
+// Query/ModuleAccountByName RPC method.
 message QueryModuleAccountByNameRequest {
   string name = 1;
 }
 
-// QueryModuleAccountByNameResponse is the response type for the Query/ModuleAccountByName RPC method.
+// QueryModuleAccountByNameResponse is the response type for the
+// Query/ModuleAccountByName RPC method.
 message QueryModuleAccountByNameResponse {
-  google.protobuf.Any account = 1 [(cosmos_proto.accepts_interface) = "cosmos.auth.v1beta1.ModuleAccountI"];
+  google.protobuf.Any account = 1
+      [(cosmos_proto.accepts_interface) = "cosmos.auth.v1beta1.ModuleAccountI"];
 }
 
 // Bech32PrefixRequest is the request type for Bech32Prefix rpc method.
@@ -172,7 +181,8 @@ message AddressBytesToStringRequest {
   bytes address_bytes = 1;
 }
 
-// AddressBytesToStringResponse is the response type for AddressString rpc method.
+// AddressBytesToStringResponse is the response type for AddressString rpc
+// method.
 //
 // Since: cosmos-sdk 0.46
 message AddressBytesToStringResponse {
@@ -186,14 +196,16 @@ message AddressStringToBytesRequest {
   string address_string = 1;
 }
 
-// AddressStringToBytesResponse is the response type for AddressBytes rpc method.
+// AddressStringToBytesResponse is the response type for AddressBytes rpc
+// method.
 //
 // Since: cosmos-sdk 0.46
 message AddressStringToBytesResponse {
   bytes address_bytes = 1;
 }
 
-// QueryAccountAddressByIDRequest is the request type for AccountAddressByID rpc method
+// QueryAccountAddressByIDRequest is the request type for AccountAddressByID rpc
+// method
 //
 // Since: cosmos-sdk 0.46.2
 message QueryAccountAddressByIDRequest {
@@ -210,7 +222,8 @@ message QueryAccountAddressByIDRequest {
   uint64 account_id = 2;
 }
 
-// QueryAccountAddressByIDResponse is the response type for AccountAddressByID rpc method
+// QueryAccountAddressByIDResponse is the response type for AccountAddressByID
+// rpc method
 //
 // Since: cosmos-sdk 0.46.2
 message QueryAccountAddressByIDResponse {

--- a/lib/cosmos-sdk/proto/cosmos/auth/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/auth/v1beta1/tx.proto
@@ -13,8 +13,8 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/auth/type
 service Msg {
   option (cosmos.msg.v1.service) = true;
 
-  // UpdateParams defines a (governance) operation for updating the x/auth module
-  // parameters. The authority defaults to the x/gov module account.
+  // UpdateParams defines a (governance) operation for updating the x/auth
+  // module parameters. The authority defaults to the x/gov module account.
   //
   // Since: cosmos-sdk 0.47
   rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
@@ -25,18 +25,16 @@ service Msg {
 // Since: cosmos-sdk 0.47
 message MsgUpdateParams {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/x/auth/MsgUpdateParams";
+  option (amino.name)           = "cosmos-sdk/x/auth/MsgUpdateParams";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // params defines the x/auth parameters to update.
   //
   // NOTE: All parameters must be supplied.
-  Params params = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a

--- a/lib/cosmos-sdk/proto/cosmos/authz/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/authz/module/v1/module.proto
@@ -6,5 +6,7 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the authz module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/authz"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/authz"
+  };
 }

--- a/lib/cosmos-sdk/proto/cosmos/authz/v1beta1/authz.proto
+++ b/lib/cosmos-sdk/proto/cosmos/authz/v1beta1/authz.proto
@@ -8,39 +8,40 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/authz";
+option go_package                      = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/authz";
 option (gogoproto.goproto_getters_all) = false;
 
 // GenericAuthorization gives the grantee unrestricted permissions to execute
 // the provided method on behalf of the granter's account.
 message GenericAuthorization {
-  option (amino.name) = "cosmos-sdk/GenericAuthorization";
+  option (amino.name)                        = "cosmos-sdk/GenericAuthorization";
   option (cosmos_proto.implements_interface) = "cosmos.authz.v1beta1.Authorization";
 
-  // Msg, identified by it's type URL, to grant unrestricted permissions to execute
+  // Msg, identified by it's type URL, to grant unrestricted permissions to
+  // execute
   string msg = 1;
 }
 
 // Grant gives permissions to execute
 // the provide method with expiration time.
 message Grant {
-  google.protobuf.Any authorization = 1 [(cosmos_proto.accepts_interface) = "cosmos.authz.v1beta1.Authorization"];
+  google.protobuf.Any authorization = 1
+      [(cosmos_proto.accepts_interface) = "cosmos.authz.v1beta1.Authorization"];
   // time when the grant will expire and will be pruned. If null, then the grant
   // doesn't have a time expiration (other conditions  in `authorization`
   // may apply to invalidate the grant)
-  google.protobuf.Timestamp expiration = 2 [
-    (gogoproto.stdtime) = true,
-    (gogoproto.nullable) = true
-  ];
+  google.protobuf.Timestamp expiration = 2
+      [(gogoproto.stdtime) = true, (gogoproto.nullable) = true];
 }
 
-// GrantAuthorization extends a grant with both the addresses of the grantee and granter.
-// It is used in genesis.proto and query.proto
+// GrantAuthorization extends a grant with both the addresses of the grantee and
+// granter. It is used in genesis.proto and query.proto
 message GrantAuthorization {
   string granter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   string grantee = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
-  google.protobuf.Any authorization = 3 [(cosmos_proto.accepts_interface) = "cosmos.authz.v1beta1.Authorization"];
+  google.protobuf.Any authorization = 3
+      [(cosmos_proto.accepts_interface) = "cosmos.authz.v1beta1.Authorization"];
   google.protobuf.Timestamp expiration = 4 [(gogoproto.stdtime) = true];
 }
 

--- a/lib/cosmos-sdk/proto/cosmos/authz/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/authz/v1beta1/genesis.proto
@@ -10,8 +10,6 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/authz";
 
 // GenesisState defines the authz module's genesis state.
 message GenesisState {
-  repeated GrantAuthorization authorization = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated GrantAuthorization authorization = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/authz/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/authz/v1beta1/query.proto
@@ -35,13 +35,15 @@ service Query {
 message QueryGrantsRequest {
   string granter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   string grantee = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // Optional, msg_type_url, when set, will query only grants matching given msg type.
+  // Optional, msg_type_url, when set, will query only grants matching given msg
+  // type.
   string msg_type_url = 3;
   // pagination defines an pagination for the request.
   cosmos.base.query.v1beta1.PageRequest pagination = 4;
 }
 
-// QueryGrantsResponse is the response type for the Query/Authorizations RPC method.
+// QueryGrantsResponse is the response type for the Query/Authorizations RPC
+// method.
 message QueryGrantsResponse {
   // authorizations is a list of grants granted for grantee by granter.
   repeated Grant grants = 1;
@@ -49,7 +51,8 @@ message QueryGrantsResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QueryGranterGrantsRequest is the request type for the Query/GranterGrants RPC method.
+// QueryGranterGrantsRequest is the request type for the Query/GranterGrants RPC
+// method.
 message QueryGranterGrantsRequest {
   string granter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
@@ -57,7 +60,8 @@ message QueryGranterGrantsRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// QueryGranterGrantsResponse is the response type for the Query/GranterGrants RPC method.
+// QueryGranterGrantsResponse is the response type for the Query/GranterGrants
+// RPC method.
 message QueryGranterGrantsResponse {
   // grants is a list of grants granted by the granter.
   repeated GrantAuthorization grants = 1;
@@ -65,7 +69,8 @@ message QueryGranterGrantsResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QueryGranteeGrantsRequest is the request type for the Query/IssuedGrants RPC method.
+// QueryGranteeGrantsRequest is the request type for the Query/IssuedGrants RPC
+// method.
 message QueryGranteeGrantsRequest {
   string grantee = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
@@ -73,7 +78,8 @@ message QueryGranteeGrantsRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// QueryGranteeGrantsResponse is the response type for the Query/GranteeGrants RPC method.
+// QueryGranteeGrantsResponse is the response type for the Query/GranteeGrants
+// RPC method.
 message QueryGranteeGrantsResponse {
   // grants is a list of grants granted to the grantee.
   repeated GrantAuthorization grants = 1;

--- a/lib/cosmos-sdk/proto/cosmos/authz/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/authz/v1beta1/tx.proto
@@ -9,7 +9,7 @@ import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/authz";
+option go_package                      = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/authz";
 option (gogoproto.goproto_getters_all) = false;
 
 // Msg defines the authz Msg service.
@@ -27,24 +27,22 @@ service Msg {
   // one signer corresponding to the granter of the authorization.
   rpc Exec(MsgExec) returns (MsgExecResponse);
 
-  // Revoke revokes any authorization corresponding to the provided method name on the
-  // granter's account that has been granted to the grantee.
+  // Revoke revokes any authorization corresponding to the provided method name
+  // on the granter's account that has been granted to the grantee.
   rpc Revoke(MsgRevoke) returns (MsgRevokeResponse);
 }
 
-// MsgGrant is a request type for Grant method. It declares authorization to the grantee
-// on behalf of the granter with the provided expiration time.
+// MsgGrant is a request type for Grant method. It declares authorization to the
+// grantee on behalf of the granter with the provided expiration time.
 message MsgGrant {
   option (cosmos.msg.v1.signer) = "granter";
-  option (amino.name) = "cosmos-sdk/MsgGrant";
+  option (amino.name)           = "cosmos-sdk/MsgGrant";
 
   string granter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   string grantee = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
-  cosmos.authz.v1beta1.Grant grant = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  cosmos.authz.v1beta1.Grant grant = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgExecResponse defines the Msg/MsgExecResponse response type.
@@ -57,13 +55,14 @@ message MsgExecResponse {
 // one signer corresponding to the granter of the authorization.
 message MsgExec {
   option (cosmos.msg.v1.signer) = "grantee";
-  option (amino.name) = "cosmos-sdk/MsgExec";
+  option (amino.name)           = "cosmos-sdk/MsgExec";
 
   string grantee = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // Execute Msg.
-  // The x/authz will try to find a grant matching (msg.signers[0], grantee, MsgTypeURL(msg))
-  // triple and validate it.
-  repeated google.protobuf.Any msgs = 2 [(cosmos_proto.accepts_interface) = "cosmos.base.v1beta1.Msg"];
+  // The x/authz will try to find a grant matching (msg.signers[0], grantee,
+  // MsgTypeURL(msg)) triple and validate it.
+  repeated google.protobuf.Any msgs = 2
+      [(cosmos_proto.accepts_interface) = "cosmos.base.v1beta1.Msg"];
 }
 
 // MsgGrantResponse defines the Msg/MsgGrant response type.
@@ -73,10 +72,10 @@ message MsgGrantResponse {}
 // granter's account with that has been granted to the grantee.
 message MsgRevoke {
   option (cosmos.msg.v1.signer) = "granter";
-  option (amino.name) = "cosmos-sdk/MsgRevoke";
+  option (amino.name)           = "cosmos-sdk/MsgRevoke";
 
-  string granter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string grantee = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string granter      = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string grantee      = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   string msg_type_url = 3;
 }
 

--- a/lib/cosmos-sdk/proto/cosmos/autocli/v1/options.proto
+++ b/lib/cosmos-sdk/proto/cosmos/autocli/v1/options.proto
@@ -15,10 +15,10 @@ message ModuleOptions {
 
 // ServiceCommandDescriptor describes a CLI command based on a protobuf service.
 message ServiceCommandDescriptor {
-
   // service is the fully qualified name of the protobuf service to build
   // the command from. It can be left empty if sub_commands are used instead
-  // which may be the case if a module provides multiple tx and/or query services.
+  // which may be the case if a module provides multiple tx and/or query
+  // services.
   string service = 1;
 
   // rpc_command_options are options for commands generated from rpc methods.
@@ -55,20 +55,23 @@ message RpcCommandOptions {
   // example is examples of how to use the command.
   string example = 5;
 
-  // alias is an array of aliases that can be used instead of the first word in Use.
+  // alias is an array of aliases that can be used instead of the first word in
+  // Use.
   repeated string alias = 6;
 
-  // suggest_for is an array of command names for which this command will be suggested -
-  // similar to aliases but only suggests.
+  // suggest_for is an array of command names for which this command will be
+  // suggested - similar to aliases but only suggests.
   repeated string suggest_for = 7;
 
-  // deprecated defines, if this command is deprecated and should print this string when used.
+  // deprecated defines, if this command is deprecated and should print this
+  // string when used.
   string deprecated = 8;
 
-  // version defines the version for this command. If this value is non-empty and the command does not
-  // define a "version" flag, a "version" boolean flag will be added to the command and, if specified,
-  // will print content of the "Version" variable. A shorthand "v" flag will also be added if the
-  // command does not define one.
+  // version defines the version for this command. If this value is non-empty and
+  // the command does not define a "version" flag, a "version" boolean flag will
+  // be added to the command and, if specified, will print content of the
+  // "Version" variable. A shorthand "v" flag will also be added if the command
+  // does not define one.
   string version = 9;
 
   // flag_options are options for flags generated from rpc request fields.
@@ -88,7 +91,6 @@ message RpcCommandOptions {
 // kebab-case name of the field. Fields can be turned into positional arguments
 // instead by using RpcCommandOptions.positional_args.
 message FlagOptions {
-
   // name is an alternate name to use for the field flag.
   string name = 1;
 
@@ -101,13 +103,15 @@ message FlagOptions {
   // default_value is the default value as text.
   string default_value = 4;
 
-  // default value is the default value as text if the flag is used without any value.
+  // default value is the default value as text if the flag is used without any
+  // value.
   string no_opt_default_value = 5;
 
   // deprecated is the usage text to show if this flag is deprecated.
   string deprecated = 6;
 
-  // shorthand_deprecated is the usage text to show if the shorthand of this flag is deprecated.
+  // shorthand_deprecated is the usage text to show if the shorthand of this flag
+  // is deprecated.
   string shorthand_deprecated = 7;
 
   // hidden hides the flag from help/usage text

--- a/lib/cosmos-sdk/proto/cosmos/autocli/v1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/autocli/v1/query.proto
@@ -12,8 +12,8 @@ option go_package = "cosmossdk.io/api/cosmos/base/cli/v1;cliv1";
 service Query {
   // AppOptions returns the autocli options for all of the modules in an app.
   rpc AppOptions(AppOptionsRequest) returns (AppOptionsResponse) {
-    // NOTE: autocli options SHOULD NOT be part of consensus and module_query_safe
-    // should be kept as false.
+    // NOTE: autocli options SHOULD NOT be part of consensus and
+    // module_query_safe should be kept as false.
     option (cosmos.query.v1.module_query_safe) = false;
   }
 }

--- a/lib/cosmos-sdk/proto/cosmos/bank/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/bank/module/v1/module.proto
@@ -6,14 +6,17 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the bank module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/bank"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/bank"
+  };
 
-  // blocked_module_accounts configures exceptional module accounts which should be blocked from receiving funds.
-  // If left empty it defaults to the list of account names supplied in the auth module configuration as
+  // blocked_module_accounts configures exceptional module accounts which should
+  // be blocked from receiving funds. If left empty it defaults to the list of
+  // account names supplied in the auth module configuration as
   // module_account_permissions
   repeated string blocked_module_accounts_override = 1;
 
-  // authority defines the custom module authority. If not set, defaults to the governance module.
+  // authority defines the custom module authority. If not set, defaults to the
+  // governance module.
   string authority = 2;
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/bank/v1beta1/authz.proto
+++ b/lib/cosmos-sdk/proto/cosmos/bank/v1beta1/authz.proto
@@ -14,16 +14,16 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/bank/type
 // Since: cosmos-sdk 0.43
 message SendAuthorization {
   option (cosmos_proto.implements_interface) = "cosmos.authz.v1beta1.Authorization";
-  option (amino.name) = "cosmos-sdk/SendAuthorization";
+  option (amino.name)                        = "cosmos-sdk/SendAuthorization";
 
   repeated cosmos.base.v1beta1.Coin spend_limit = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 
-  // allow_list specifies an optional list of addresses to whom the grantee can send tokens on behalf of the
-  // granter. If omitted, any recipient is allowed.
+  // allow_list specifies an optional list of addresses to whom the grantee can
+  // send tokens on behalf of the granter. If omitted, any recipient is allowed.
   //
   // Since: cosmos-sdk 0.47
   repeated string allow_list = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];

--- a/lib/cosmos-sdk/proto/cosmos/bank/v1beta1/bank.proto
+++ b/lib/cosmos-sdk/proto/cosmos/bank/v1beta1/bank.proto
@@ -11,50 +11,51 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/bank/type
 
 // Params defines the parameters for the bank module.
 message Params {
-  option (amino.name) = "cosmos-sdk/x/bank/Params";
+  option (amino.name)                 = "cosmos-sdk/x/bank/Params";
   option (gogoproto.goproto_stringer) = false;
   // Deprecated: Use of SendEnabled in params is deprecated.
   // For genesis, use the newly added send_enabled field in the genesis object.
   // Storage, lookup, and manipulation of this information is now in the keeper.
   //
-  // As of cosmos-sdk 0.47, this only exists for backwards compatibility of genesis files.
-  repeated SendEnabled send_enabled = 1 [deprecated = true];
-  bool default_send_enabled = 2;
+  // As of cosmos-sdk 0.47, this only exists for backwards compatibility of
+  // genesis files.
+  repeated SendEnabled send_enabled         = 1 [deprecated = true];
+  bool                 default_send_enabled = 2;
 }
 
 // SendEnabled maps coin denom to a send_enabled status (whether a denom is
 // sendable).
 message SendEnabled {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
-  string denom = 1;
-  bool enabled = 2;
+  string denom                        = 1;
+  bool   enabled                      = 2;
 }
 
 // Input models transaction input.
 message Input {
   option (cosmos.msg.v1.signer) = "address";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string   address                        = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   repeated cosmos.base.v1beta1.Coin coins = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
 
 // Output models transaction outputs.
 message Output {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string   address                        = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   repeated cosmos.base.v1beta1.Coin coins = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -65,14 +66,14 @@ message Output {
 message Supply {
   option deprecated = true;
 
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)           = true;
   option (gogoproto.goproto_getters) = false;
 
   option (cosmos_proto.implements_interface) = "cosmos.bank.v1beta1.SupplyI";
 
   repeated cosmos.base.v1beta1.Coin total = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -112,12 +113,13 @@ message Metadata {
   //
   // Since: cosmos-sdk 0.43
   string symbol = 6;
-  // URI to a document (on or off-chain) that contains additional information. Optional.
+  // URI to a document (on or off-chain) that contains additional information.
+  // Optional.
   //
   // Since: cosmos-sdk 0.46
   string uri = 7 [(gogoproto.customname) = "URI"];
-  // URIHash is a sha256 hash of a document pointed by URI. It's used to verify that
-  // the document didn't change. Optional.
+  // URIHash is a sha256 hash of a document pointed by URI. It's used to verify
+  // that the document didn't change. Optional.
   //
   // Since: cosmos-sdk 0.46
   string uri_hash = 8 [(gogoproto.customname) = "URIHash"];

--- a/lib/cosmos-sdk/proto/cosmos/bank/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/bank/v1beta1/genesis.proto
@@ -17,46 +17,37 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/bank/type
 // - Zero remainders SHOULD be omitted.
 message GenesisState {
   // params defines all the parameters of the module.
-  Params params = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // balances is an array containing the balances of all the accounts.
-  repeated Balance balances = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Balance balances = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
-  // supply represents the total supply. If it is left empty, then supply will be calculated based on the provided
-  // balances. Otherwise, it will be used to validate that the sum of the balances equals this amount.
+  // supply represents the total supply. If it is left empty, then supply will be
+  // calculated based on the provided balances. Otherwise, it will be used to
+  // validate that the sum of the balances equals this amount.
   repeated cosmos.base.v1beta1.Coin supply = 3 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
 
   // denom_metadata defines the metadata of the different coins.
-  repeated Metadata denom_metadata = 4 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Metadata denom_metadata = 4
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // send_enabled defines the denoms where send is enabled or disabled.
   //
   // Since: cosmos-sdk 0.47
-  repeated SendEnabled send_enabled = 5 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated SendEnabled send_enabled = 5
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // wei_balances: An array of all wei store balances.
-  // A wei store balance is a per-account NIBI remainder stored in wei (atto‑NIBI),
-  // each in the range [0, 10^12). Values >= 10^12 are normalized to unibi and
-  // recorded on the [GensisState] "balances" field.
+  // A wei store balance is a per-account NIBI remainder stored in wei
+  // (atto‑NIBI), each in the range [0, 10^12). Values >= 10^12 are normalized to
+  // unibi and recorded on the [GensisState] "balances" field.
   repeated WeiBalance wei_balances = 11 [
     // use high index of 11 to avoid futurecollision.
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
 }
@@ -64,7 +55,7 @@ message GenesisState {
 // Balance defines an account address and balance pair used in the bank module's
 // genesis state.
 message Balance {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the address of the balance holder.
@@ -73,8 +64,8 @@ message Balance {
   // coins defines the different coins this balance holds.
   repeated cosmos.base.v1beta1.Coin coins = 2 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
 }
 
@@ -83,7 +74,7 @@ message Balance {
 // microNIBI threshold of 10^{-6} NIBI. We defined attoNIBI (10^{-18} NIBI) as 1
 // wei because NIBI acts as "ether" on the Nibiru EVM.
 message WeiBalance {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // addr_bech_32 is the address of the balance holder.

--- a/lib/cosmos-sdk/proto/cosmos/bank/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/bank/v1beta1/query.proto
@@ -17,7 +17,7 @@ service Query {
   // Balance queries the balance of a single coin for a single account.
   rpc Balance(QueryBalanceRequest) returns (QueryBalanceResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/bank/v1beta1/balances/{address}/by_denom";
+    option (google.api.http).get               = "/cosmos/bank/v1beta1/balances/{address}/by_denom";
   }
 
   // AllBalances queries the balance of all coins for a single account.
@@ -26,7 +26,7 @@ service Query {
   // gas if the pagination field is incorrectly set.
   rpc AllBalances(QueryAllBalancesRequest) returns (QueryAllBalancesResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/bank/v1beta1/balances/{address}";
+    option (google.api.http).get               = "/cosmos/bank/v1beta1/balances/{address}";
   }
 
   // SpendableBalances queries the spendable balance of all coins for a single
@@ -48,7 +48,8 @@ service Query {
   // gas if the pagination field is incorrectly set.
   //
   // Since: cosmos-sdk 0.47
-  rpc SpendableBalanceByDenom(QuerySpendableBalanceByDenomRequest) returns (QuerySpendableBalanceByDenomResponse) {
+  rpc SpendableBalanceByDenom(QuerySpendableBalanceByDenomRequest)
+      returns (QuerySpendableBalanceByDenomResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
     option (google.api.http).get = "/cosmos/bank/v1beta1/spendable_balances/{address}/by_denom";
   }
@@ -59,7 +60,7 @@ service Query {
   // gas if the pagination field is incorrectly set.
   rpc TotalSupply(QueryTotalSupplyRequest) returns (QueryTotalSupplyResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/bank/v1beta1/supply";
+    option (google.api.http).get               = "/cosmos/bank/v1beta1/supply";
   }
 
   // SupplyOf queries the supply of a single coin.
@@ -68,26 +69,26 @@ service Query {
   // gas if the pagination field is incorrectly set.
   rpc SupplyOf(QuerySupplyOfRequest) returns (QuerySupplyOfResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/bank/v1beta1/supply/by_denom";
+    option (google.api.http).get               = "/cosmos/bank/v1beta1/supply/by_denom";
   }
 
   // Params queries the parameters of x/bank module.
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/bank/v1beta1/params";
+    option (google.api.http).get               = "/cosmos/bank/v1beta1/params";
   }
 
   // DenomsMetadata queries the client metadata of a given coin denomination.
   rpc DenomMetadata(QueryDenomMetadataRequest) returns (QueryDenomMetadataResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/bank/v1beta1/denoms_metadata/{denom}";
+    option (google.api.http).get               = "/cosmos/bank/v1beta1/denoms_metadata/{denom}";
   }
 
   // DenomsMetadata queries the client metadata for all registered coin
   // denominations.
   rpc DenomsMetadata(QueryDenomsMetadataRequest) returns (QueryDenomsMetadataResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/bank/v1beta1/denoms_metadata";
+    option (google.api.http).get               = "/cosmos/bank/v1beta1/denoms_metadata";
   }
 
   // DenomOwners queries for all account addresses that own a particular token
@@ -99,25 +100,26 @@ service Query {
   // Since: cosmos-sdk 0.46
   rpc DenomOwners(QueryDenomOwnersRequest) returns (QueryDenomOwnersResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/bank/v1beta1/denom_owners/{denom}";
+    option (google.api.http).get               = "/cosmos/bank/v1beta1/denom_owners/{denom}";
   }
 
   // SendEnabled queries for SendEnabled entries.
   //
-  // This query only returns denominations that have specific SendEnabled settings.
-  // Any denomination that does not have a specific setting will use the default
-  // params.default_send_enabled, and will not be returned by this query.
+  // This query only returns denominations that have specific SendEnabled
+  // settings. Any denomination that does not have a specific setting will use
+  // the default params.default_send_enabled, and will not be returned by this
+  // query.
   //
   // Since: cosmos-sdk 0.47
   rpc SendEnabled(QuerySendEnabledRequest) returns (QuerySendEnabledResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/bank/v1beta1/send_enabled";
+    option (google.api.http).get               = "/cosmos/bank/v1beta1/send_enabled";
   }
 }
 
 // QueryBalanceRequest is the request type for the Query/Balance RPC method.
 message QueryBalanceRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the address to query balances for.
@@ -135,7 +137,7 @@ message QueryBalanceResponse {
 
 // QueryBalanceRequest is the request type for the Query/AllBalances RPC method.
 message QueryAllBalancesRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the address to query balances for.
@@ -150,8 +152,8 @@ message QueryAllBalancesRequest {
 message QueryAllBalancesResponse {
   // balances is the balances of all the coins.
   repeated cosmos.base.v1beta1.Coin balances = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 
@@ -164,7 +166,7 @@ message QueryAllBalancesResponse {
 //
 // Since: cosmos-sdk 0.46
 message QuerySpendableBalancesRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the address to query spendable balances for.
@@ -174,15 +176,15 @@ message QuerySpendableBalancesRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// QuerySpendableBalancesResponse defines the gRPC response structure for querying
-// an account's spendable balances.
+// QuerySpendableBalancesResponse defines the gRPC response structure for
+// querying an account's spendable balances.
 //
 // Since: cosmos-sdk 0.46
 message QuerySpendableBalancesResponse {
   // balances is the spendable balances of all the coins.
   repeated cosmos.base.v1beta1.Coin balances = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 
@@ -195,7 +197,7 @@ message QuerySpendableBalancesResponse {
 //
 // Since: cosmos-sdk 0.47
 message QuerySpendableBalanceByDenomRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the address to query balances for.
@@ -217,7 +219,7 @@ message QuerySpendableBalanceByDenomResponse {
 // QueryTotalSupplyRequest is the request type for the Query/TotalSupply RPC
 // method.
 message QueryTotalSupplyRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // pagination defines an optional pagination for the request.
@@ -231,8 +233,8 @@ message QueryTotalSupplyRequest {
 message QueryTotalSupplyResponse {
   // supply is the supply of the coins
   repeated cosmos.base.v1beta1.Coin supply = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 
@@ -251,10 +253,7 @@ message QuerySupplyOfRequest {
 // QuerySupplyOfResponse is the response type for the Query/SupplyOf RPC method.
 message QuerySupplyOfResponse {
   // amount is the supply of the coin.
-  cosmos.base.v1beta1.Coin amount = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  cosmos.base.v1beta1.Coin amount = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryParamsRequest defines the request type for querying x/bank parameters.
@@ -262,50 +261,44 @@ message QueryParamsRequest {}
 
 // QueryParamsResponse defines the response type for querying x/bank parameters.
 message QueryParamsResponse {
-  Params params = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
-// QueryDenomsMetadataRequest is the request type for the Query/DenomsMetadata RPC method.
+// QueryDenomsMetadataRequest is the request type for the Query/DenomsMetadata
+// RPC method.
 message QueryDenomsMetadataRequest {
   // pagination defines an optional pagination for the request.
   cosmos.base.query.v1beta1.PageRequest pagination = 1;
 }
 
-// QueryDenomsMetadataResponse is the response type for the Query/DenomsMetadata RPC
-// method.
+// QueryDenomsMetadataResponse is the response type for the Query/DenomsMetadata
+// RPC method.
 message QueryDenomsMetadataResponse {
   // metadata provides the client information for all the registered tokens.
-  repeated Metadata metadatas = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Metadata metadatas = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QueryDenomMetadataRequest is the request type for the Query/DenomMetadata RPC method.
+// QueryDenomMetadataRequest is the request type for the Query/DenomMetadata RPC
+// method.
 message QueryDenomMetadataRequest {
   // denom is the coin denom to query the metadata for.
   string denom = 1;
 }
 
-// QueryDenomMetadataResponse is the response type for the Query/DenomMetadata RPC
-// method.
+// QueryDenomMetadataResponse is the response type for the Query/DenomMetadata
+// RPC method.
 message QueryDenomMetadataResponse {
-  // metadata describes and provides all the client information for the requested token.
-  Metadata metadata = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  // metadata describes and provides all the client information for the requested
+  // token.
+  Metadata metadata = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
-// QueryDenomOwnersRequest defines the request type for the DenomOwners RPC query,
-// which queries for a paginated set of all account holders of a particular
-// denomination.
+// QueryDenomOwnersRequest defines the request type for the DenomOwners RPC
+// query, which queries for a paginated set of all account holders of a
+// particular denomination.
 message QueryDenomOwnersRequest {
   // denom defines the coin denomination to query all account holders for.
   string denom = 1;
@@ -324,10 +317,8 @@ message DenomOwner {
   string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // balance is the balance of the denominated coin for an account.
-  cosmos.base.v1beta1.Coin balance = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  cosmos.base.v1beta1.Coin balance = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryDenomOwnersResponse defines the RPC response of a DenomOwners RPC query.
@@ -340,11 +331,13 @@ message QueryDenomOwnersResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QuerySendEnabledRequest defines the RPC request for looking up SendEnabled entries.
+// QuerySendEnabledRequest defines the RPC request for looking up SendEnabled
+// entries.
 //
 // Since: cosmos-sdk 0.47
 message QuerySendEnabledRequest {
-  // denoms is the specific denoms you want look up. Leave empty to get all entries.
+  // denoms is the specific denoms you want look up. Leave empty to get all
+  // entries.
   repeated string denoms = 1;
   // pagination defines an optional pagination for the request. This field is
   // only read if the denoms field is empty.

--- a/lib/cosmos-sdk/proto/cosmos/bank/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/bank/v1beta1/tx.proto
@@ -17,11 +17,12 @@ service Msg {
   // Send defines a method for sending coins from one account to another account.
   rpc Send(MsgSend) returns (MsgSendResponse);
 
-  // MultiSend defines a method for sending coins from some accounts to other accounts.
+  // MultiSend defines a method for sending coins from some accounts to other
+  // accounts.
   rpc MultiSend(MsgMultiSend) returns (MsgMultiSendResponse);
 
-  // UpdateParams defines a governance operation for updating the x/bank module parameters.
-  // The authority is defined in the keeper.
+  // UpdateParams defines a governance operation for updating the x/bank module
+  // parameters. The authority is defined in the keeper.
   //
   // Since: cosmos-sdk 0.47
   rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
@@ -38,16 +39,16 @@ service Msg {
 // MsgSend represents a message to send coins from one account to another.
 message MsgSend {
   option (cosmos.msg.v1.signer) = "from_address";
-  option (amino.name) = "cosmos-sdk/MsgSend";
+  option (amino.name)           = "cosmos-sdk/MsgSend";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string from_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string to_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string   from_address                    = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string   to_address                      = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   repeated cosmos.base.v1beta1.Coin amount = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -58,20 +59,14 @@ message MsgSendResponse {}
 // MsgMultiSend represents an arbitrary multi-in, multi-out send message.
 message MsgMultiSend {
   option (cosmos.msg.v1.signer) = "inputs";
-  option (amino.name) = "cosmos-sdk/MsgMultiSend";
+  option (amino.name)           = "cosmos-sdk/MsgMultiSend";
 
   option (gogoproto.equal) = false;
 
   // Inputs, despite being `repeated`, only allows one sender input. This is
   // checked in MsgMultiSend's ValidateBasic.
-  repeated Input inputs = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  repeated Output outputs = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Input  inputs  = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  repeated Output outputs = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgMultiSendResponse defines the Msg/MultiSend response type.
@@ -83,17 +78,15 @@ message MsgMultiSendResponse {}
 message MsgUpdateParams {
   option (cosmos.msg.v1.signer) = "authority";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
-  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
+  string authority    = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   option (amino.name) = "cosmos-sdk/x/bank/MsgUpdateParams";
 
   // params defines the x/bank parameters to update.
   //
   // NOTE: All parameters must be supplied.
-  Params params = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a
@@ -111,17 +104,17 @@ message MsgUpdateParamsResponse {}
 // Since: cosmos-sdk 0.47
 message MsgSetSendEnabled {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/MsgSetSendEnabled";
+  option (amino.name)           = "cosmos-sdk/MsgSetSendEnabled";
 
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // send_enabled is the list of entries to add or update.
   repeated SendEnabled send_enabled = 2;
 
-  // use_default_for is a list of denoms that should use the params.default_send_enabled value.
-  // Denoms listed here will have their SendEnabled entries deleted.
-  // If a denom is included that doesn't have a SendEnabled entry,
-  // it will be ignored.
+  // use_default_for is a list of denoms that should use the
+  // params.default_send_enabled value. Denoms listed here will have their
+  // SendEnabled entries deleted. If a denom is included that doesn't have a
+  // SendEnabled entry, it will be ignored.
   repeated string use_default_for = 3;
 }
 

--- a/lib/cosmos-sdk/proto/cosmos/base/abci/v1beta1/abci.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/abci/v1beta1/abci.proto
@@ -5,7 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 import "tendermint/abci/types.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types";
+option go_package                       = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types";
 option (gogoproto.goproto_stringer_all) = false;
 
 // TxResponse defines a structure containing relevant tx data and metadata. The
@@ -26,10 +26,8 @@ message TxResponse {
   // non-deterministic.
   string raw_log = 6;
   // The output of the application's logger (typed). May be non-deterministic.
-  repeated ABCIMessageLog logs = 7 [
-    (gogoproto.castrepeated) = "ABCIMessageLogs",
-    (gogoproto.nullable) = false
-  ];
+  repeated ABCIMessageLog logs = 7
+      [(gogoproto.castrepeated) = "ABCIMessageLogs", (gogoproto.nullable) = false];
   // Additional information. May be non-deterministic.
   string info = 8;
   // Amount of gas requested for transaction.
@@ -56,14 +54,12 @@ message ABCIMessageLog {
   option (gogoproto.stringer) = true;
 
   uint32 msg_index = 1 [(gogoproto.jsontag) = "msg_index"];
-  string log = 2;
+  string log       = 2;
 
   // Events contains a slice of Event objects that were emitted during some
   // execution.
-  repeated StringEvent events = 3 [
-    (gogoproto.castrepeated) = "StringEvents",
-    (gogoproto.nullable) = false
-  ];
+  repeated StringEvent events = 3
+      [(gogoproto.castrepeated) = "StringEvents", (gogoproto.nullable) = false];
 }
 
 // StringEvent defines en Event object wrapper where all the attributes
@@ -71,14 +67,14 @@ message ABCIMessageLog {
 message StringEvent {
   option (gogoproto.stringer) = true;
 
-  string type = 1;
+  string             type       = 1;
   repeated Attribute attributes = 2 [(gogoproto.nullable) = false];
 }
 
 // Attribute defines an attribute wrapper where the key and value are
 // strings instead of raw bytes.
 message Attribute {
-  string key = 1;
+  string key   = 1;
   string value = 2;
 }
 
@@ -117,21 +113,18 @@ message Result {
 // SimulationResponse defines the response generated when a transaction is
 // successfully simulated.
 message SimulationResponse {
-  GasInfo gas_info = 1 [
-    (gogoproto.embed) = true,
-    (gogoproto.nullable) = false
-  ];
-  Result result = 2;
+  GasInfo gas_info = 1 [(gogoproto.embed) = true, (gogoproto.nullable) = false];
+  Result  result   = 2;
 }
 
 // MsgData defines the data returned in a Result object during message
 // execution.
 message MsgData {
-  option deprecated = true;
+  option deprecated           = true;
   option (gogoproto.stringer) = true;
 
   string msg_type = 1;
-  bytes data = 2;
+  bytes  data     = 2;
 }
 
 // TxMsgData defines a list of MsgData. A transaction will have a MsgData object

--- a/lib/cosmos-sdk/proto/cosmos/base/kv/v1beta1/kv.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/kv/v1beta1/kv.proto
@@ -12,6 +12,6 @@ message Pairs {
 
 // Pair defines a key/value bytes tuple.
 message Pair {
-  bytes key = 1;
+  bytes key   = 1;
   bytes value = 2;
 }

--- a/lib/cosmos-sdk/proto/cosmos/base/query/v1beta1/pagination.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/query/v1beta1/pagination.proto
@@ -31,7 +31,8 @@ message PageRequest {
   // is set.
   bool count_total = 4;
 
-  // reverse is set to true if results are to be returned in the descending order.
+  // reverse is set to true if results are to be returned in the descending
+  // order.
   //
   // Since: cosmos-sdk 0.43
   bool reverse = 5;

--- a/lib/cosmos-sdk/proto/cosmos/base/reflection/v1beta1/reflection.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/reflection/v1beta1/reflection.proto
@@ -16,9 +16,8 @@ service ReflectionService {
   // ListImplementations list all the concrete types that implement a given
   // interface.
   rpc ListImplementations(ListImplementationsRequest) returns (ListImplementationsResponse) {
-    option (google.api.http).get =
-      "/cosmos/base/reflection/v1beta1/interfaces/"
-      "{interface_name}/implementations";
+    option (google.api.http).get = "/cosmos/base/reflection/v1beta1/interfaces/"
+                                   "{interface_name}/implementations";
   }
 }
 

--- a/lib/cosmos-sdk/proto/cosmos/base/reflection/v2alpha1/reflection.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/reflection/v2alpha1/reflection.proto
@@ -8,8 +8,9 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/server/grpc
 
 // AppDescriptor describes a cosmos-sdk based application
 message AppDescriptor {
-  // AuthnDescriptor provides information on how to authenticate transactions on the application
-  // NOTE: experimental and subject to change in future releases.
+  // AuthnDescriptor provides information on how to authenticate transactions on
+  // the application NOTE: experimental and subject to change in future
+  // releases.
   AuthnDescriptor authn = 1;
   // chain provides the chain descriptor
   ChainDescriptor chain = 2;
@@ -17,40 +18,44 @@ message AppDescriptor {
   CodecDescriptor codec = 3;
   // configuration provides metadata information regarding the sdk.Config type
   ConfigurationDescriptor configuration = 4;
-  // query_services provides metadata information regarding the available queriable endpoints
+  // query_services provides metadata information regarding the available
+  // queriable endpoints
   QueryServicesDescriptor query_services = 5;
-  // tx provides metadata information regarding how to send transactions to the given application
+  // tx provides metadata information regarding how to send transactions to the
+  // given application
   TxDescriptor tx = 6;
 }
 
 // TxDescriptor describes the accepted transaction type
 message TxDescriptor {
-  // fullname is the protobuf fullname of the raw transaction type (for instance the tx.Tx type)
-  // it is not meant to support polymorphism of transaction types, it is supposed to be used by
-  // reflection clients to understand if they can handle a specific transaction type in an application.
+  // fullname is the protobuf fullname of the raw transaction type (for instance
+  // the tx.Tx type) it is not meant to support polymorphism of transaction
+  // types, it is supposed to be used by reflection clients to understand if
+  // they can handle a specific transaction type in an application.
   string fullname = 1;
   // msgs lists the accepted application messages (sdk.Msg)
   repeated MsgDescriptor msgs = 2;
 }
 
-// AuthnDescriptor provides information on how to sign transactions without relying
-// on the online RPCs GetTxMetadata and CombineUnsignedTxAndSignatures
+// AuthnDescriptor provides information on how to sign transactions without
+// relying on the online RPCs GetTxMetadata and CombineUnsignedTxAndSignatures
 message AuthnDescriptor {
   // sign_modes defines the supported signature algorithm
   repeated SigningModeDescriptor sign_modes = 1;
 }
 
-// SigningModeDescriptor provides information on a signing flow of the application
-// NOTE(fdymylja): here we could go as far as providing an entire flow on how
-// to sign a message given a SigningModeDescriptor, but it's better to think about
-// this another time
+// SigningModeDescriptor provides information on a signing flow of the
+// application NOTE(fdymylja): here we could go as far as providing an entire
+// flow on how to sign a message given a SigningModeDescriptor, but it's better
+// to think about this another time
 message SigningModeDescriptor {
   // name defines the unique name of the signing mode
   string name = 1;
   // number is the unique int32 identifier for the sign_mode enum
   int32 number = 2;
-  // authn_info_provider_method_fullname defines the fullname of the method to call to get
-  // the metadata required to authenticate using the provided sign_modes
+  // authn_info_provider_method_fullname defines the fullname of the method to
+  // call to get the metadata required to authenticate using the provided
+  // sign_modes
   string authn_info_provider_method_fullname = 3;
 }
 
@@ -60,7 +65,8 @@ message ChainDescriptor {
   string id = 1;
 }
 
-// CodecDescriptor describes the registered interfaces and provides metadata information on the types
+// CodecDescriptor describes the registered interfaces and provides metadata
+// information on the types
 message CodecDescriptor {
   // interfaces is a list of the registerted interfaces descriptors
   repeated InterfaceDescriptor interfaces = 1;
@@ -70,10 +76,11 @@ message CodecDescriptor {
 message InterfaceDescriptor {
   // fullname is the name of the interface
   string fullname = 1;
-  // interface_accepting_messages contains information regarding the proto messages which contain the interface as
-  // google.protobuf.Any field
+  // interface_accepting_messages contains information regarding the proto
+  // messages which contain the interface as google.protobuf.Any field
   repeated InterfaceAcceptingMessageDescriptor interface_accepting_messages = 2;
-  // interface_implementers is a list of the descriptors of the interface implementers
+  // interface_implementers is a list of the descriptors of the interface
+  // implementers
   repeated InterfaceImplementerDescriptor interface_implementers = 3;
 }
 
@@ -82,20 +89,20 @@ message InterfaceImplementerDescriptor {
   // fullname is the protobuf queryable name of the interface implementer
   string fullname = 1;
   // type_url defines the type URL used when marshalling the type as any
-  // this is required so we can provide type safe google.protobuf.Any marshalling and
-  // unmarshalling, making sure that we don't accept just 'any' type
-  // in our interface fields
+  // this is required so we can provide type safe google.protobuf.Any
+  // marshalling and unmarshalling, making sure that we don't accept just 'any'
+  // type in our interface fields
   string type_url = 2;
 }
 
-// InterfaceAcceptingMessageDescriptor describes a protobuf message which contains
-// an interface represented as a google.protobuf.Any
+// InterfaceAcceptingMessageDescriptor describes a protobuf message which
+// contains an interface represented as a google.protobuf.Any
 message InterfaceAcceptingMessageDescriptor {
   // fullname is the protobuf fullname of the type containing the interface
   string fullname = 1;
-  // field_descriptor_names is a list of the protobuf name (not fullname) of the field
-  // which contains the interface as google.protobuf.Any (the interface is the same, but
-  // it can be in multiple fields of the same proto message)
+  // field_descriptor_names is a list of the protobuf name (not fullname) of the
+  // field which contains the interface as google.protobuf.Any (the interface is
+  // the same, but it can be in multiple fields of the same proto message)
   repeated string field_descriptor_names = 2;
 }
 
@@ -105,7 +112,8 @@ message ConfigurationDescriptor {
   string bech32_account_address_prefix = 1;
 }
 
-// MsgDescriptor describes a cosmos-sdk message that can be delivered with a transaction
+// MsgDescriptor describes a cosmos-sdk message that can be delivered with a
+// transaction
 message MsgDescriptor {
   // msg_type_url contains the TypeURL of a sdk.Msg.
   string msg_type_url = 1;
@@ -113,9 +121,10 @@ message MsgDescriptor {
 
 // ReflectionService defines a service for application reflection.
 service ReflectionService {
-  // GetAuthnDescriptor returns information on how to authenticate transactions in the application
-  // NOTE: this RPC is still experimental and might be subject to breaking changes or removal in
-  // future releases of the cosmos-sdk.
+  // GetAuthnDescriptor returns information on how to authenticate transactions
+  // in the application NOTE: this RPC is still experimental and might be
+  // subject to breaking changes or removal in future releases of the
+  // cosmos-sdk.
   rpc GetAuthnDescriptor(GetAuthnDescriptorRequest) returns (GetAuthnDescriptorResponse) {
     option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/authn";
   }
@@ -127,15 +136,20 @@ service ReflectionService {
   rpc GetCodecDescriptor(GetCodecDescriptorRequest) returns (GetCodecDescriptorResponse) {
     option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/codec";
   }
-  // GetConfigurationDescriptor returns the descriptor for the sdk.Config of the application
-  rpc GetConfigurationDescriptor(GetConfigurationDescriptorRequest) returns (GetConfigurationDescriptorResponse) {
+  // GetConfigurationDescriptor returns the descriptor for the sdk.Config of the
+  // application
+  rpc GetConfigurationDescriptor(GetConfigurationDescriptorRequest)
+      returns (GetConfigurationDescriptorResponse) {
     option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/configuration";
   }
-  // GetQueryServicesDescriptor returns the available gRPC queryable services of the application
-  rpc GetQueryServicesDescriptor(GetQueryServicesDescriptorRequest) returns (GetQueryServicesDescriptorResponse) {
+  // GetQueryServicesDescriptor returns the available gRPC queryable services of
+  // the application
+  rpc GetQueryServicesDescriptor(GetQueryServicesDescriptorRequest)
+      returns (GetQueryServicesDescriptorResponse) {
     option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/query_services";
   }
-  // GetTxDescriptor returns information on the used transaction object and available msgs that can be used
+  // GetTxDescriptor returns information on the used transaction object and
+  // available msgs that can be used
   rpc GetTxDescriptor(GetTxDescriptorRequest) returns (GetTxDescriptorResponse) {
     option (google.api.http).get = "/cosmos/base/reflection/v1beta1/app_descriptor/tx_descriptor";
   }
@@ -143,15 +157,18 @@ service ReflectionService {
 
 // GetAuthnDescriptorRequest is the request used for the GetAuthnDescriptor RPC
 message GetAuthnDescriptorRequest {}
-// GetAuthnDescriptorResponse is the response returned by the GetAuthnDescriptor RPC
+// GetAuthnDescriptorResponse is the response returned by the GetAuthnDescriptor
+// RPC
 message GetAuthnDescriptorResponse {
-  // authn describes how to authenticate to the application when sending transactions
+  // authn describes how to authenticate to the application when sending
+  // transactions
   AuthnDescriptor authn = 1;
 }
 
 // GetChainDescriptorRequest is the request used for the GetChainDescriptor RPC
 message GetChainDescriptorRequest {}
-// GetChainDescriptorResponse is the response returned by the GetChainDescriptor RPC
+// GetChainDescriptorResponse is the response returned by the GetChainDescriptor
+// RPC
 message GetChainDescriptorResponse {
   // chain describes application chain information
   ChainDescriptor chain = 1;
@@ -159,23 +176,29 @@ message GetChainDescriptorResponse {
 
 // GetCodecDescriptorRequest is the request used for the GetCodecDescriptor RPC
 message GetCodecDescriptorRequest {}
-// GetCodecDescriptorResponse is the response returned by the GetCodecDescriptor RPC
+// GetCodecDescriptorResponse is the response returned by the GetCodecDescriptor
+// RPC
 message GetCodecDescriptorResponse {
-  // codec describes the application codec such as registered interfaces and implementations
+  // codec describes the application codec such as registered interfaces and
+  // implementations
   CodecDescriptor codec = 1;
 }
 
-// GetConfigurationDescriptorRequest is the request used for the GetConfigurationDescriptor RPC
+// GetConfigurationDescriptorRequest is the request used for the
+// GetConfigurationDescriptor RPC
 message GetConfigurationDescriptorRequest {}
-// GetConfigurationDescriptorResponse is the response returned by the GetConfigurationDescriptor RPC
+// GetConfigurationDescriptorResponse is the response returned by the
+// GetConfigurationDescriptor RPC
 message GetConfigurationDescriptorResponse {
   // config describes the application's sdk.Config
   ConfigurationDescriptor config = 1;
 }
 
-// GetQueryServicesDescriptorRequest is the request used for the GetQueryServicesDescriptor RPC
+// GetQueryServicesDescriptorRequest is the request used for the
+// GetQueryServicesDescriptor RPC
 message GetQueryServicesDescriptorRequest {}
-// GetQueryServicesDescriptorResponse is the response returned by the GetQueryServicesDescriptor RPC
+// GetQueryServicesDescriptorResponse is the response returned by the
+// GetQueryServicesDescriptor RPC
 message GetQueryServicesDescriptorResponse {
   // queries provides information on the available queryable services
   QueryServicesDescriptor queries = 1;
@@ -200,7 +223,8 @@ message QueryServicesDescriptor {
 message QueryServiceDescriptor {
   // fullname is the protobuf fullname of the service descriptor
   string fullname = 1;
-  // is_module describes if this service is actually exposed by an application's module
+  // is_module describes if this service is actually exposed by an application's
+  // module
   bool is_module = 2;
   // methods provides a list of query service methods
   repeated QueryMethodDescriptor methods = 3;

--- a/lib/cosmos-sdk/proto/cosmos/base/snapshots/v1beta1/snapshot.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/snapshots/v1beta1/snapshot.proto
@@ -7,16 +7,16 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/snapshots/t
 
 // Snapshot contains Tendermint state sync snapshot info.
 message Snapshot {
-  uint64 height = 1;
-  uint32 format = 2;
-  uint32 chunks = 3;
-  bytes hash = 4;
+  uint64   height   = 1;
+  uint32   format   = 2;
+  uint32   chunks   = 3;
+  bytes    hash     = 4;
   Metadata metadata = 5 [(gogoproto.nullable) = false];
 }
 
 // Metadata contains SDK-specific snapshot metadata.
 message Metadata {
-  repeated bytes chunk_hashes = 1; // SHA-256 chunk hashes
+  repeated bytes chunk_hashes = 1;  // SHA-256 chunk hashes
 }
 
 // SnapshotItem is an item contained in a rootmulti.Store snapshot.
@@ -25,15 +25,12 @@ message Metadata {
 message SnapshotItem {
   // item is the specific type of snapshot item.
   oneof item {
-    SnapshotStoreItem store = 1;
-    SnapshotIAVLItem iavl = 2 [(gogoproto.customname) = "IAVL"];
-    SnapshotExtensionMeta extension = 3;
+    SnapshotStoreItem        store             = 1;
+    SnapshotIAVLItem         iavl              = 2 [(gogoproto.customname) = "IAVL"];
+    SnapshotExtensionMeta    extension         = 3;
     SnapshotExtensionPayload extension_payload = 4;
-    SnapshotKVItem kv = 5 [
-      deprecated = true,
-      (gogoproto.customname) = "KV"
-    ];
-    SnapshotSchema schema = 6 [deprecated = true];
+    SnapshotKVItem           kv     = 5 [deprecated = true, (gogoproto.customname) = "KV"];
+    SnapshotSchema           schema = 6 [deprecated = true];
   }
 }
 
@@ -48,7 +45,7 @@ message SnapshotStoreItem {
 //
 // Since: cosmos-sdk 0.46
 message SnapshotIAVLItem {
-  bytes key = 1;
+  bytes key   = 1;
   bytes value = 2;
   // version is block height
   int64 version = 3;
@@ -60,7 +57,7 @@ message SnapshotIAVLItem {
 //
 // Since: cosmos-sdk 0.46
 message SnapshotExtensionMeta {
-  string name = 1;
+  string name   = 1;
   uint32 format = 2;
 }
 
@@ -74,21 +71,22 @@ message SnapshotExtensionPayload {
 // SnapshotKVItem is an exported Key/Value Pair
 //
 // Since: cosmos-sdk 0.46
-// Deprecated: This message was part of store/v2alpha1 which has been deleted from v0.47.
+// Deprecated: This message was part of store/v2alpha1 which has been deleted
+// from v0.47.
 message SnapshotKVItem {
   option deprecated = true;
 
-  bytes key = 1;
+  bytes key   = 1;
   bytes value = 2;
 }
 
 // SnapshotSchema is an exported schema of smt store
 //
 // Since: cosmos-sdk 0.46
-// Deprecated: This message was part of store/v2alpha1 which has been deleted from v0.47.
+// Deprecated: This message was part of store/v2alpha1 which has been deleted
+// from v0.47.
 message SnapshotSchema {
   option deprecated = true;
 
   repeated bytes keys = 1;
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/base/store/v1beta1/commit_info.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/store/v1beta1/commit_info.proto
@@ -9,18 +9,16 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/store/types
 // CommitInfo defines commit information used by the multi-store when committing
 // a version/height.
 message CommitInfo {
-  int64 version = 1;
-  repeated StoreInfo store_infos = 2 [(gogoproto.nullable) = false];
-  google.protobuf.Timestamp timestamp = 3 [
-    (gogoproto.nullable) = false,
-    (gogoproto.stdtime) = true
-  ];
+  int64                     version     = 1;
+  repeated StoreInfo        store_infos = 2 [(gogoproto.nullable) = false];
+  google.protobuf.Timestamp timestamp   = 3
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
 }
 
 // StoreInfo defines store-specific commit information. It contains a reference
 // between a store name and the commit ID.
 message StoreInfo {
-  string name = 1;
+  string   name      = 1;
   CommitID commit_id = 2 [(gogoproto.nullable) = false];
 }
 
@@ -30,5 +28,5 @@ message CommitID {
   option (gogoproto.goproto_stringer) = false;
 
   int64 version = 1;
-  bytes hash = 2;
+  bytes hash    = 2;
 }

--- a/lib/cosmos-sdk/proto/cosmos/base/store/v1beta1/listening.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/store/v1beta1/listening.proto
@@ -5,16 +5,16 @@ import "tendermint/abci/types.proto";
 
 option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/store/types";
 
-// StoreKVPair is a KVStore KVPair used for listening to state changes (Sets and Deletes)
-// It optionally includes the StoreKey for the originating KVStore and a Boolean flag to distinguish between Sets and
-// Deletes
+// StoreKVPair is a KVStore KVPair used for listening to state changes (Sets and
+// Deletes) It optionally includes the StoreKey for the originating KVStore and
+// a Boolean flag to distinguish between Sets and Deletes
 //
 // Since: cosmos-sdk 0.43
 message StoreKVPair {
-  string store_key = 1; // the store key for the KVStore this pair originates from
-  bool delete = 2; // true indicates a delete operation, false indicates a set operation
-  bytes key = 3;
-  bytes value = 4;
+  string store_key = 1;  // the store key for the KVStore this pair originates from
+  bool delete      = 2;  // true indicates a delete operation, false indicates a set operation
+  bytes key        = 3;
+  bytes value      = 4;
 }
 
 // BlockMetadata contains all the abci event data of a block
@@ -22,13 +22,13 @@ message StoreKVPair {
 message BlockMetadata {
   // DeliverTx encapulate deliver tx request and response.
   message DeliverTx {
-    tendermint.abci.RequestDeliverTx request = 1;
+    tendermint.abci.RequestDeliverTx  request  = 1;
     tendermint.abci.ResponseDeliverTx response = 2;
   }
-  tendermint.abci.RequestBeginBlock request_begin_block = 1;
+  tendermint.abci.RequestBeginBlock  request_begin_block  = 1;
   tendermint.abci.ResponseBeginBlock response_begin_block = 2;
-  repeated DeliverTx deliver_txs = 3;
-  tendermint.abci.RequestEndBlock request_end_block = 4;
-  tendermint.abci.ResponseEndBlock response_end_block = 5;
-  tendermint.abci.ResponseCommit response_commit = 6;
+  repeated DeliverTx                 deliver_txs          = 3;
+  tendermint.abci.RequestEndBlock    request_end_block    = 4;
+  tendermint.abci.ResponseEndBlock   response_end_block   = 5;
+  tendermint.abci.ResponseCommit     response_commit      = 6;
 }

--- a/lib/cosmos-sdk/proto/cosmos/base/tendermint/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/tendermint/v1beta1/query.proto
@@ -42,7 +42,8 @@ service Service {
   }
 
   // GetValidatorSetByHeight queries validator-set at a given height.
-  rpc GetValidatorSetByHeight(GetValidatorSetByHeightRequest) returns (GetValidatorSetByHeightResponse) {
+  rpc GetValidatorSetByHeight(GetValidatorSetByHeightRequest)
+      returns (GetValidatorSetByHeightResponse) {
     option (google.api.http).get = "/cosmos/base/tendermint/v1beta1/validatorsets/{height}";
   }
 
@@ -56,49 +57,55 @@ service Service {
   }
 }
 
-// GetValidatorSetByHeightRequest is the request type for the Query/GetValidatorSetByHeight RPC method.
+// GetValidatorSetByHeightRequest is the request type for the
+// Query/GetValidatorSetByHeight RPC method.
 message GetValidatorSetByHeightRequest {
   int64 height = 1;
   // pagination defines an pagination for the request.
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// GetValidatorSetByHeightResponse is the response type for the Query/GetValidatorSetByHeight RPC method.
+// GetValidatorSetByHeightResponse is the response type for the
+// Query/GetValidatorSetByHeight RPC method.
 message GetValidatorSetByHeightResponse {
-  int64 block_height = 1;
-  repeated Validator validators = 2;
+  int64              block_height = 1;
+  repeated Validator validators   = 2;
   // pagination defines an pagination for the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 3;
 }
 
-// GetLatestValidatorSetRequest is the request type for the Query/GetValidatorSetByHeight RPC method.
+// GetLatestValidatorSetRequest is the request type for the
+// Query/GetValidatorSetByHeight RPC method.
 message GetLatestValidatorSetRequest {
   // pagination defines an pagination for the request.
   cosmos.base.query.v1beta1.PageRequest pagination = 1;
 }
 
-// GetLatestValidatorSetResponse is the response type for the Query/GetValidatorSetByHeight RPC method.
+// GetLatestValidatorSetResponse is the response type for the
+// Query/GetValidatorSetByHeight RPC method.
 message GetLatestValidatorSetResponse {
-  int64 block_height = 1;
-  repeated Validator validators = 2;
+  int64              block_height = 1;
+  repeated Validator validators   = 2;
   // pagination defines an pagination for the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 3;
 }
 
 // Validator is the type for the validator-set.
 message Validator {
-  string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  google.protobuf.Any pub_key = 2;
-  int64 voting_power = 3;
-  int64 proposer_priority = 4;
+  string              address           = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  google.protobuf.Any pub_key           = 2;
+  int64               voting_power      = 3;
+  int64               proposer_priority = 4;
 }
 
-// GetBlockByHeightRequest is the request type for the Query/GetBlockByHeight RPC method.
+// GetBlockByHeightRequest is the request type for the Query/GetBlockByHeight RPC
+// method.
 message GetBlockByHeightRequest {
   int64 height = 1;
 }
 
-// GetBlockByHeightResponse is the response type for the Query/GetBlockByHeight RPC method.
+// GetBlockByHeightResponse is the response type for the Query/GetBlockByHeight
+// RPC method.
 message GetBlockByHeightResponse {
   .tendermint.types.BlockID block_id = 1;
 
@@ -109,10 +116,12 @@ message GetBlockByHeightResponse {
   Block sdk_block = 3;
 }
 
-// GetLatestBlockRequest is the request type for the Query/GetLatestBlock RPC method.
+// GetLatestBlockRequest is the request type for the Query/GetLatestBlock RPC
+// method.
 message GetLatestBlockRequest {}
 
-// GetLatestBlockResponse is the response type for the Query/GetLatestBlock RPC method.
+// GetLatestBlockResponse is the response type for the Query/GetLatestBlock RPC
+// method.
 message GetLatestBlockResponse {
   .tendermint.types.BlockID block_id = 1;
 
@@ -136,18 +145,18 @@ message GetNodeInfoRequest {}
 
 // GetNodeInfoResponse is the response type for the Query/GetNodeInfo RPC method.
 message GetNodeInfoResponse {
-  .tendermint.p2p.DefaultNodeInfo default_node_info = 1;
-  VersionInfo application_version = 2;
+  .tendermint.p2p.DefaultNodeInfo default_node_info   = 1;
+  VersionInfo                     application_version = 2;
 }
 
 // VersionInfo is the type for the GetNodeInfoResponse message.
 message VersionInfo {
-  string name = 1;
-  string app_name = 2;
-  string version = 3;
-  string git_commit = 4;
-  string build_tags = 5;
-  string go_version = 6;
+  string          name       = 1;
+  string          app_name   = 2;
+  string          version    = 3;
+  string          git_commit = 4;
+  string          build_tags = 5;
+  string          go_version = 6;
   repeated Module build_deps = 7;
   // Since: cosmos-sdk 0.43
   string cosmos_sdk_version = 8;
@@ -165,10 +174,10 @@ message Module {
 
 // ABCIQueryRequest defines the request structure for the ABCIQuery gRPC query.
 message ABCIQueryRequest {
-  bytes data = 1;
-  string path = 2;
-  int64 height = 3;
-  bool prove = 4;
+  bytes  data   = 1;
+  string path   = 2;
+  int64  height = 3;
+  bool   prove  = 4;
 }
 
 // ABCIQueryResponse defines the response structure for the ABCIQuery gRPC query.
@@ -179,33 +188,32 @@ message ABCIQueryResponse {
   uint32 code = 1;
   // DEPRECATED: use "value" instead
   reserved 2;
-  string log = 3; // nondeterministic
-  string info = 4; // nondeterministic
-  int64 index = 5;
-  bytes key = 6;
-  bytes value = 7;
+  string   log       = 3;  // nondeterministic
+  string   info      = 4;  // nondeterministic
+  int64    index     = 5;
+  bytes    key       = 6;
+  bytes    value     = 7;
   ProofOps proof_ops = 8;
-  int64 height = 9;
-  string codespace = 10;
+  int64    height    = 9;
+  string   codespace = 10;
 }
 
 // ProofOp defines an operation used for calculating Merkle root. The data could
 // be arbitrary format, providing necessary data for example neighbouring node
 // hash.
 //
-// Note: This type is a duplicate of the ProofOp proto type defined in Tendermint.
+// Note: This type is a duplicate of the ProofOp proto type defined in
+// Tendermint.
 message ProofOp {
   string type = 1;
-  bytes key = 2;
-  bytes data = 3;
+  bytes  key  = 2;
+  bytes  data = 3;
 }
 
 // ProofOps is Merkle proof defined by the list of ProofOps.
 //
-// Note: This type is a duplicate of the ProofOps proto type defined in Tendermint.
+// Note: This type is a duplicate of the ProofOps proto type defined in
+// Tendermint.
 message ProofOps {
-  repeated ProofOp ops = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated ProofOp ops = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/base/tendermint/v1beta1/types.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/tendermint/v1beta1/types.proto
@@ -13,58 +13,43 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/client/grpc
 // Block is tendermint type Block, with the Header proposer address
 // field converted to bech32 string.
 message Block {
-  Header header = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  .tendermint.types.Data data = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  .tendermint.types.EvidenceList evidence = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Header                 header = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  .tendermint.types.Data data   = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  .tendermint.types.EvidenceList evidence = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   .tendermint.types.Commit last_commit = 4;
 }
 
 // Header defines the structure of a Tendermint block header.
 message Header {
   // basic block info
-  .tendermint.version.Consensus version = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  string chain_id = 2 [(gogoproto.customname) = "ChainID"];
-  int64 height = 3;
-  google.protobuf.Timestamp time = 4 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
-    (gogoproto.stdtime) = true
-  ];
+  .tendermint.version.Consensus version = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  string                    chain_id = 2 [(gogoproto.customname) = "ChainID"];
+  int64                     height   = 3;
+  google.protobuf.Timestamp time     = 4
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true, (gogoproto.stdtime) = true];
 
   // prev block info
-  .tendermint.types.BlockID last_block_id = 5 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  .tendermint.types.BlockID last_block_id = 5
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // hashes of block data
-  bytes last_commit_hash = 6; // commit from validators from the last block
-  bytes data_hash = 7; // transactions
+  bytes last_commit_hash = 6;  // commit from validators from the last block
+  bytes data_hash        = 7;  // transactions
 
   // hashes from the app output from the prev block
-  bytes validators_hash = 8; // validators for the current block
-  bytes next_validators_hash = 9; // validators for the next block
-  bytes consensus_hash = 10; // consensus params for current block
-  bytes app_hash = 11; // state after txs from the previous block
-  bytes last_results_hash = 12; // root hash of all results from the txs from the previous block
+  bytes validators_hash      = 8;   // validators for the current block
+  bytes next_validators_hash = 9;   // validators for the next block
+  bytes consensus_hash       = 10;  // consensus params for current block
+  bytes app_hash             = 11;  // state after txs from the previous block
+  bytes last_results_hash    = 12;  // root hash of all results from the txs from the previous block
 
   // consensus info
-  bytes evidence_hash = 13; // evidence included in the block
+  bytes evidence_hash = 13;  // evidence included in the block
 
-  // proposer_address is the original block proposer address, formatted as a Bech32 string.
-  // In Tendermint, this type is `bytes`, but in the SDK, we convert it to a Bech32 string
-  // for better UX.
-  string proposer_address = 14; // original proposer of the block
+  // proposer_address is the original block proposer address, formatted as a
+  // Bech32 string. In Tendermint, this type is `bytes`, but in the SDK, we
+  // convert it to a Bech32 string for better UX.
+  string proposer_address = 14;  // original proposer of the block
 }

--- a/lib/cosmos-sdk/proto/cosmos/base/v1beta1/coin.proto
+++ b/lib/cosmos-sdk/proto/cosmos/base/v1beta1/coin.proto
@@ -5,9 +5,9 @@ import "amino/amino.proto";
 import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types";
+option go_package                       = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types";
 option (gogoproto.goproto_stringer_all) = false;
-option (gogoproto.stringer_all) = false;
+option (gogoproto.stringer_all)         = false;
 
 // Coin defines a token with a denomination and an amount.
 //
@@ -16,11 +16,11 @@ option (gogoproto.stringer_all) = false;
 message Coin {
   option (gogoproto.equal) = true;
 
-  string denom = 1;
+  string denom  = 1;
   string amount = 2 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "Int",
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
 }
@@ -32,28 +32,28 @@ message Coin {
 message DecCoin {
   option (gogoproto.equal) = true;
 
-  string denom = 1;
+  string denom  = 1;
   string amount = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 
 // IntProto defines a Protobuf wrapper around an Int object.
 message IntProto {
   string int = 1 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 
 // DecProto defines a Protobuf wrapper around a Dec object.
 message DecProto {
   string dec = 1 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }

--- a/lib/cosmos-sdk/proto/cosmos/capability/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/capability/module/v1/module.proto
@@ -6,10 +6,12 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the capability module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/capability"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/capability"
+  };
 
-  // seal_keeper defines if keeper.Seal() will run on BeginBlock() to prevent further modules from creating a scoped
-  // keeper. For more details check x/capability/keeper.go.
+  // seal_keeper defines if keeper.Seal() will run on BeginBlock() to prevent
+  // further modules from creating a scoped keeper. For more details check
+  // x/capability/keeper.go.
   bool seal_keeper = 1;
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/capability/v1beta1/capability.proto
+++ b/lib/cosmos-sdk/proto/cosmos/capability/v1beta1/capability.proto
@@ -18,17 +18,14 @@ message Capability {
 // capability and the module name.
 message Owner {
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)  = false;
 
   string module = 1;
-  string name = 2;
+  string name   = 2;
 }
 
 // CapabilityOwners defines a set of owners of a single Capability. The set of
 // owners must be unique.
 message CapabilityOwners {
-  repeated Owner owners = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Owner owners = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/capability/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/capability/v1beta1/genesis.proto
@@ -13,10 +13,7 @@ message GenesisOwners {
   uint64 index = 1;
 
   // index_owners are the owners at the given index.
-  CapabilityOwners index_owners = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  CapabilityOwners index_owners = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // GenesisState defines the capability module's genesis state.
@@ -26,8 +23,5 @@ message GenesisState {
 
   // owners represents a map from index to owners of the capability index
   // index key is string to allow amino marshalling.
-  repeated GenesisOwners owners = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated GenesisOwners owners = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/consensus/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/consensus/module/v1/module.proto
@@ -6,8 +6,11 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the consensus module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/consensus"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/consensus"
+  };
 
-  // authority defines the custom module authority. If not set, defaults to the governance module.
+  // authority defines the custom module authority. If not set, defaults to the
+  // governance module.
   string authority = 1;
 }

--- a/lib/cosmos-sdk/proto/cosmos/consensus/v1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/consensus/v1/query.proto
@@ -15,10 +15,12 @@ service Query {
   }
 }
 
-// QueryParamsRequest defines the request type for querying x/consensus parameters.
+// QueryParamsRequest defines the request type for querying x/consensus
+// parameters.
 message QueryParamsRequest {}
 
-// QueryParamsResponse defines the response type for querying x/consensus parameters.
+// QueryParamsResponse defines the response type for querying x/consensus
+// parameters.
 message QueryParamsResponse {
   // params are the tendermint consensus params stored in the consensus module.
   // Please note that `params.version` is not populated in this response, it is

--- a/lib/cosmos-sdk/proto/cosmos/consensus/v1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/consensus/v1/tx.proto
@@ -10,8 +10,8 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/consensus
 
 // Msg defines the bank Msg service.
 service Msg {
-  // UpdateParams defines a governance operation for updating the x/consensus_param module parameters.
-  // The authority is defined in the keeper.
+  // UpdateParams defines a governance operation for updating the
+  // x/consensus_param module parameters. The authority is defined in the keeper.
   //
   // Since: cosmos-sdk 0.47
   rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
@@ -21,7 +21,8 @@ service Msg {
 message MsgUpdateParams {
   option (cosmos.msg.v1.signer) = "authority";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // params defines the x/consensus parameters to update.
@@ -29,8 +30,8 @@ message MsgUpdateParams {
   // separarately in x/upgrade.
   //
   // NOTE: All parameters must be supplied.
-  tendermint.types.BlockParams block = 2;
-  tendermint.types.EvidenceParams evidence = 3;
+  tendermint.types.BlockParams     block     = 2;
+  tendermint.types.EvidenceParams  evidence  = 3;
   tendermint.types.ValidatorParams validator = 4;
 }
 

--- a/lib/cosmos-sdk/proto/cosmos/crisis/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/crisis/module/v1/module.proto
@@ -6,12 +6,14 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the crisis module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/crisis"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/crisis"
+  };
 
   // fee_collector_name is the name of the FeeCollector ModuleAccount.
   string fee_collector_name = 1;
 
-  // authority defines the custom module authority. If not set, defaults to the governance module.
+  // authority defines the custom module authority. If not set, defaults to the
+  // governance module.
   string authority = 2;
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/crisis/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/crisis/v1beta1/genesis.proto
@@ -11,8 +11,6 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/crisis/ty
 message GenesisState {
   // constant_fee is the fee used to verify the invariant in the crisis
   // module.
-  cosmos.base.v1beta1.Coin constant_fee = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  cosmos.base.v1beta1.Coin constant_fee = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/crisis/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/crisis/v1beta1/tx.proto
@@ -16,8 +16,8 @@ service Msg {
   // VerifyInvariant defines a method to verify a particular invariant.
   rpc VerifyInvariant(MsgVerifyInvariant) returns (MsgVerifyInvariantResponse);
 
-  // UpdateParams defines a governance operation for updating the x/crisis module
-  // parameters. The authority is defined in the keeper.
+  // UpdateParams defines a governance operation for updating the x/crisis
+  // module parameters. The authority is defined in the keeper.
   //
   // Since: cosmos-sdk 0.47
   rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
@@ -26,12 +26,13 @@ service Msg {
 // MsgVerifyInvariant represents a message to verify a particular invariance.
 message MsgVerifyInvariant {
   option (cosmos.msg.v1.signer) = "sender";
-  option (amino.name) = "cosmos-sdk/MsgVerifyInvariant";
+  option (amino.name)           = "cosmos-sdk/MsgVerifyInvariant";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  // sender is the account address of private key to send coins to fee collector account.
+  // sender is the account address of private key to send coins to fee collector
+  // account.
   string sender = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // name of the invariant module.
@@ -49,16 +50,15 @@ message MsgVerifyInvariantResponse {}
 // Since: cosmos-sdk 0.47
 message MsgUpdateParams {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/x/crisis/MsgUpdateParams";
+  option (amino.name)           = "cosmos-sdk/x/crisis/MsgUpdateParams";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // constant_fee defines the x/crisis parameter.
-  cosmos.base.v1beta1.Coin constant_fee = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  cosmos.base.v1beta1.Coin constant_fee = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a

--- a/lib/cosmos-sdk/proto/cosmos/crypto/ed25519/keys.proto
+++ b/lib/cosmos-sdk/proto/cosmos/crypto/ed25519/keys.proto
@@ -8,9 +8,10 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/crypto/keys
 
 // PubKey is an ed25519 public key for handling Tendermint keys in SDK.
 // It's needed for Any serialization and SDK compatibility.
-// It must not be used in a non Tendermint key context because it doesn't implement
-// ADR-28. Nevertheless, you will like to use ed25519 in app user level
-// then you must create a new proto message and follow ADR-28 for Address construction.
+// It must not be used in a non Tendermint key context because it doesn't
+// implement ADR-28. Nevertheless, you will like to use ed25519 in app user
+// level then you must create a new proto message and follow ADR-28 for Address
+// construction.
 message PubKey {
   option (amino.name) = "tendermint/PubKeyEd25519";
   // The Amino encoding is simply the inner bytes field, and not the Amino
@@ -23,16 +24,17 @@ message PubKey {
   // Then we have:
   // out == `"MQ=="`
   // out != `{"key":"MQ=="}`
-  option (amino.message_encoding) = "key_field";
+  option (amino.message_encoding)     = "key_field";
   option (gogoproto.goproto_stringer) = false;
 
   bytes key = 1 [(gogoproto.casttype) = "crypto/ed25519.PublicKey"];
 }
 
 // Deprecated: PrivKey defines a ed25519 private key.
-// NOTE: ed25519 keys must not be used in SDK apps except in a tendermint validator context.
+// NOTE: ed25519 keys must not be used in SDK apps except in a tendermint
+// validator context.
 message PrivKey {
-  option (amino.name) = "tendermint/PrivKeyEd25519";
+  option (amino.name)             = "tendermint/PrivKeyEd25519";
   option (amino.message_encoding) = "key_field";
 
   bytes key = 1 [(gogoproto.casttype) = "crypto/ed25519.PrivateKey"];

--- a/lib/cosmos-sdk/proto/cosmos/crypto/hd/v1/hd.proto
+++ b/lib/cosmos-sdk/proto/cosmos/crypto/hd/v1/hd.proto
@@ -13,14 +13,15 @@ message BIP44Params {
   option (amino.name) = "crypto/keys/hd/BIP44Params";
 
   option (gogoproto.goproto_stringer) = false;
-  // purpose is a constant set to 44' (or 0x8000002C) following the BIP43 recommendation
+  // purpose is a constant set to 44' (or 0x8000002C) following the BIP43
+  // recommendation
   uint32 purpose = 1;
   // coin_type is a constant that improves privacy
   uint32 coin_type = 2;
   // account splits the key space into independent user identities
   uint32 account = 3;
-  // change is a constant used for public derivation. Constant 0 is used for external chain and constant 1 for internal
-  // chain.
+  // change is a constant used for public derivation. Constant 0 is used for
+  // external chain and constant 1 for internal chain.
   bool change = 4;
   // address_index is used as child index in BIP32 derivation
   uint32 address_index = 5;

--- a/lib/cosmos-sdk/proto/cosmos/crypto/keyring/v1/record.proto
+++ b/lib/cosmos-sdk/proto/cosmos/crypto/keyring/v1/record.proto
@@ -7,7 +7,7 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 
 option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/crypto/keyring";
-option (gogoproto.gogoproto_import) = false;
+option (gogoproto.gogoproto_import)    = false;
 option (gogoproto.goproto_getters_all) = false;
 
 // Record is used for representing a key in the keyring.

--- a/lib/cosmos-sdk/proto/cosmos/crypto/multisig/keys.proto
+++ b/lib/cosmos-sdk/proto/cosmos/crypto/multisig/keys.proto
@@ -22,12 +22,10 @@ message LegacyAminoPubKey {
   // by default marshal uint32 as a number).
   // 2. The `public_keys` field is renamed to `pubkeys`, which is also
   // reflected in the `amino.field_name` annotation.
-  option (amino.message_encoding) = "threshold_string";
+  option (amino.message_encoding)    = "threshold_string";
   option (gogoproto.goproto_getters) = false;
 
-  uint32 threshold = 1;
-  repeated google.protobuf.Any public_keys = 2 [
-    (gogoproto.customname) = "PubKeys",
-    (amino.field_name) = "pubkeys"
-  ];
+  uint32   threshold                       = 1;
+  repeated google.protobuf.Any public_keys = 2
+      [(gogoproto.customname) = "PubKeys", (amino.field_name) = "pubkeys"];
 }

--- a/lib/cosmos-sdk/proto/cosmos/crypto/multisig/v1beta1/multisig.proto
+++ b/lib/cosmos-sdk/proto/cosmos/crypto/multisig/v1beta1/multisig.proto
@@ -10,7 +10,7 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/crypto/type
 // signed and with which modes.
 message MultiSignature {
   option (gogoproto.goproto_unrecognized) = true;
-  repeated bytes signatures = 1;
+  repeated bytes signatures               = 1;
 }
 
 // CompactBitArray is an implementation of a space efficient bit array.
@@ -21,5 +21,5 @@ message CompactBitArray {
   option (gogoproto.goproto_stringer) = false;
 
   uint32 extra_bits_stored = 1;
-  bytes elems = 2;
+  bytes  elems             = 2;
 }

--- a/lib/cosmos-sdk/proto/cosmos/crypto/secp256k1/keys.proto
+++ b/lib/cosmos-sdk/proto/cosmos/crypto/secp256k1/keys.proto
@@ -7,10 +7,10 @@ import "gogoproto/gogo.proto";
 option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/crypto/keys/secp256k1";
 
 // PubKey defines a secp256k1 public key
-// Key is the compressed form of the pubkey. The first byte depends is a 0x02 byte
-// if the y-coordinate is the lexicographically largest of the two associated with
-// the x-coordinate. Otherwise the first byte is a 0x03.
-// This prefix is followed with the x-coordinate.
+// Key is the compressed form of the pubkey. The first byte depends is a 0x02
+// byte if the y-coordinate is the lexicographically largest of the two
+// associated with the x-coordinate. Otherwise the first byte is a 0x03. This
+// prefix is followed with the x-coordinate.
 message PubKey {
   option (amino.name) = "tendermint/PubKeySecp256k1";
   // The Amino encoding is simply the inner bytes field, and not the Amino
@@ -23,7 +23,7 @@ message PubKey {
   // Then we have:
   // out == `"MQ=="`
   // out != `{"key":"MQ=="}`
-  option (amino.message_encoding) = "key_field";
+  option (amino.message_encoding)     = "key_field";
   option (gogoproto.goproto_stringer) = false;
 
   bytes key = 1;
@@ -31,7 +31,7 @@ message PubKey {
 
 // PrivKey defines a secp256k1 private key.
 message PrivKey {
-  option (amino.name) = "tendermint/PrivKeySecp256k1";
+  option (amino.name)             = "tendermint/PrivKeySecp256k1";
   option (amino.message_encoding) = "key_field";
 
   bytes key = 1;

--- a/lib/cosmos-sdk/proto/cosmos/crypto/secp256r1/keys.proto
+++ b/lib/cosmos-sdk/proto/cosmos/crypto/secp256r1/keys.proto
@@ -5,14 +5,15 @@ package cosmos.crypto.secp256r1;
 import "gogoproto/gogo.proto";
 
 option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/crypto/keys/secp256r1";
-option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.goproto_getters_all)  = false;
 option (gogoproto.goproto_stringer_all) = false;
-option (gogoproto.messagename_all) = true;
+option (gogoproto.messagename_all)      = true;
 
 // PubKey defines a secp256r1 ECDSA public key.
 message PubKey {
-  // Point on secp256r1 curve in a compressed representation as specified in section
-  // 4.3.6 of ANSI X9.62: https://webstore.ansi.org/standards/ascx9/ansix9621998
+  // Point on secp256r1 curve in a compressed representation as specified in
+  // section 4.3.6 of ANSI X9.62:
+  // https://webstore.ansi.org/standards/ascx9/ansix9621998
   bytes key = 1 [(gogoproto.customtype) = "ecdsaPK"];
 }
 

--- a/lib/cosmos-sdk/proto/cosmos/distribution/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/distribution/module/v1/module.proto
@@ -6,11 +6,13 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the distribution module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/distribution"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/distribution"
+  };
 
   string fee_collector_name = 1;
 
-  // authority defines the custom module authority. If not set, defaults to the governance module.
+  // authority defines the custom module authority. If not set, defaults to the
+  // governance module.
   string authority = 2;
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/distribution/v1beta1/distribution.proto
+++ b/lib/cosmos-sdk/proto/cosmos/distribution/v1beta1/distribution.proto
@@ -11,31 +11,31 @@ option (gogoproto.equal_all) = true;
 
 // Params defines the set of params for the distribution module.
 message Params {
-  option (amino.name) = "cosmos-sdk/x/distribution/Params";
+  option (amino.name)                 = "cosmos-sdk/x/distribution/Params";
   option (gogoproto.goproto_stringer) = false;
 
   string community_tax = 1 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
-  // Deprecated: The base_proposer_reward field is deprecated and is no longer used
-  // in the x/distribution module's reward mechanism.
+  // Deprecated: The base_proposer_reward field is deprecated and is no longer
+  // used in the x/distribution module's reward mechanism.
   string base_proposer_reward = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false,
-    deprecated = true
+    (gogoproto.nullable)   = false,
+    deprecated             = true
   ];
 
-  // Deprecated: The bonus_proposer_reward field is deprecated and is no longer used
-  // in the x/distribution module's reward mechanism.
+  // Deprecated: The bonus_proposer_reward field is deprecated and is no longer
+  // used in the x/distribution module's reward mechanism.
   string bonus_proposer_reward = 3 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false,
-    deprecated = true
+    (gogoproto.nullable)   = false,
+    deprecated             = true
   ];
 
   bool withdraw_addr_enabled = 4;
@@ -56,8 +56,8 @@ message Params {
 message ValidatorHistoricalRewards {
   repeated cosmos.base.v1beta1.DecCoin cumulative_reward_ratio = 1 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
   uint32 reference_count = 2;
 }
@@ -68,8 +68,8 @@ message ValidatorHistoricalRewards {
 message ValidatorCurrentRewards {
   repeated cosmos.base.v1beta1.DecCoin rewards = 1 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
   uint64 period = 2;
 }
@@ -79,8 +79,8 @@ message ValidatorCurrentRewards {
 message ValidatorAccumulatedCommission {
   repeated cosmos.base.v1beta1.DecCoin commission = 1 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
 }
 
@@ -89,8 +89,8 @@ message ValidatorAccumulatedCommission {
 message ValidatorOutstandingRewards {
   repeated cosmos.base.v1beta1.DecCoin rewards = 1 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
 }
 
@@ -100,27 +100,25 @@ message ValidatorOutstandingRewards {
 // for delegations which are withdrawn after a slash has occurred.
 message ValidatorSlashEvent {
   uint64 validator_period = 1;
-  string fraction = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+  string fraction         = 2 [
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 
 // ValidatorSlashEvents is a collection of ValidatorSlashEvent messages.
 message ValidatorSlashEvents {
-  option (gogoproto.goproto_stringer) = false;
-  repeated ValidatorSlashEvent validator_slash_events = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  option (gogoproto.goproto_stringer)                 = false;
+  repeated ValidatorSlashEvent validator_slash_events = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // FeePool is the global fee pool for distribution.
 message FeePool {
   repeated cosmos.base.v1beta1.DecCoin community_pool = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins"
   ];
 }
@@ -134,18 +132,18 @@ message FeePool {
 // pool funds, a simple MsgCommunityPoolSpend can be invoked from the x/gov
 // module via a v1 governance proposal.
 message CommunityPoolSpendProposal {
-  option deprecated = true;
-  option (gogoproto.equal) = false;
-  option (gogoproto.goproto_getters) = false;
-  option (gogoproto.goproto_stringer) = false;
+  option deprecated                          = true;
+  option (gogoproto.equal)                   = false;
+  option (gogoproto.goproto_getters)         = false;
+  option (gogoproto.goproto_stringer)        = false;
   option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
 
-  string title = 1;
-  string description = 2;
-  string recipient = 3;
+  string   title                           = 1;
+  string   description                     = 2;
+  string   recipient                       = 3;
   repeated cosmos.base.v1beta1.Coin amount = 4 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -158,14 +156,14 @@ message CommunityPoolSpendProposal {
 // thus sdk.Dec is used.
 message DelegatorStartingInfo {
   uint64 previous_period = 1;
-  string stake = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+  string stake           = 2 [
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   uint64 height = 3 [
-    (gogoproto.jsontag) = "creation_height",
-    (amino.field_name) = "creation_height",
+    (gogoproto.jsontag)    = "creation_height",
+    (amino.field_name)     = "creation_height",
     (amino.dont_omitempty) = true
   ];
 }
@@ -173,28 +171,28 @@ message DelegatorStartingInfo {
 // DelegationDelegatorReward represents the properties
 // of a delegator's delegation reward.
 message DelegationDelegatorReward {
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = true;
 
   string validator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   repeated cosmos.base.v1beta1.DecCoin reward = 2 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
 }
 
 // CommunityPoolSpendProposalWithDeposit defines a CommunityPoolSpendProposal
 // with a deposit
 message CommunityPoolSpendProposalWithDeposit {
-  option (gogoproto.goproto_getters) = false;
-  option (gogoproto.goproto_stringer) = true;
+  option (gogoproto.goproto_getters)         = false;
+  option (gogoproto.goproto_stringer)        = true;
   option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
 
-  string title = 1;
+  string title       = 1;
   string description = 2;
-  string recipient = 3;
-  string amount = 4;
-  string deposit = 5;
+  string recipient   = 3;
+  string amount      = 4;
+  string deposit     = 5;
 }

--- a/lib/cosmos-sdk/proto/cosmos/distribution/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/distribution/v1beta1/genesis.proto
@@ -14,7 +14,7 @@ option (gogoproto.equal_all) = true;
 // withdrawn to by default this struct is only used at genesis to feed in
 // default withdraw addresses.
 message DelegatorWithdrawInfo {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_address is the address of the delegator.
@@ -26,7 +26,7 @@ message DelegatorWithdrawInfo {
 
 // ValidatorOutstandingRewardsRecord is used for import/export via genesis json.
 message ValidatorOutstandingRewardsRecord {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // validator_address is the address of the validator.
@@ -35,31 +35,29 @@ message ValidatorOutstandingRewardsRecord {
   // outstanding_rewards represents the outstanding rewards of a validator.
   repeated cosmos.base.v1beta1.DecCoin outstanding_rewards = 2 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
 }
 
 // ValidatorAccumulatedCommissionRecord is used for import / export via genesis
 // json.
 message ValidatorAccumulatedCommissionRecord {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // validator_address is the address of the validator.
   string validator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // accumulated is the accumulated commission of a validator.
-  ValidatorAccumulatedCommission accumulated = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  ValidatorAccumulatedCommission accumulated = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // ValidatorHistoricalRewardsRecord is used for import / export via genesis
 // json.
 message ValidatorHistoricalRewardsRecord {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // validator_address is the address of the validator.
@@ -69,30 +67,25 @@ message ValidatorHistoricalRewardsRecord {
   uint64 period = 2;
 
   // rewards defines the historical rewards of a validator.
-  ValidatorHistoricalRewards rewards = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  ValidatorHistoricalRewards rewards = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // ValidatorCurrentRewardsRecord is used for import / export via genesis json.
 message ValidatorCurrentRewardsRecord {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // validator_address is the address of the validator.
   string validator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // rewards defines the current rewards of a validator.
-  ValidatorCurrentRewards rewards = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  ValidatorCurrentRewards rewards = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // DelegatorStartingInfoRecord used for import / export via genesis json.
 message DelegatorStartingInfoRecord {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_address is the address of the delegator.
@@ -102,15 +95,13 @@ message DelegatorStartingInfoRecord {
   string validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // starting_info defines the starting info of a delegator.
-  DelegatorStartingInfo starting_info = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  DelegatorStartingInfo starting_info = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // ValidatorSlashEventRecord is used for import / export via genesis json.
 message ValidatorSlashEventRecord {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // validator_address is the address of the validator.
@@ -120,71 +111,49 @@ message ValidatorSlashEventRecord {
   // period is the period of the slash event.
   uint64 period = 3;
   // validator_slash_event describes the slash event.
-  ValidatorSlashEvent validator_slash_event = 4 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  ValidatorSlashEvent validator_slash_event = 4
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // GenesisState defines the distribution module's genesis state.
 message GenesisState {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // params defines all the parameters of the module.
-  Params params = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // fee_pool defines the fee pool at genesis.
-  FeePool fee_pool = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  FeePool fee_pool = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // fee_pool defines the delegator withdraw infos at genesis.
-  repeated DelegatorWithdrawInfo delegator_withdraw_infos = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated DelegatorWithdrawInfo delegator_withdraw_infos = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // fee_pool defines the previous proposer at genesis.
   string previous_proposer = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // fee_pool defines the outstanding rewards of all validators at genesis.
-  repeated ValidatorOutstandingRewardsRecord outstanding_rewards = 5 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated ValidatorOutstandingRewardsRecord outstanding_rewards = 5
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // fee_pool defines the accumulated commissions of all validators at genesis.
-  repeated ValidatorAccumulatedCommissionRecord validator_accumulated_commissions = 6 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated ValidatorAccumulatedCommissionRecord validator_accumulated_commissions = 6
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // fee_pool defines the historical rewards of all validators at genesis.
-  repeated ValidatorHistoricalRewardsRecord validator_historical_rewards = 7 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated ValidatorHistoricalRewardsRecord validator_historical_rewards = 7
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // fee_pool defines the current rewards of all validators at genesis.
-  repeated ValidatorCurrentRewardsRecord validator_current_rewards = 8 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated ValidatorCurrentRewardsRecord validator_current_rewards = 8
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // fee_pool defines the delegator starting infos at genesis.
-  repeated DelegatorStartingInfoRecord delegator_starting_infos = 9 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated DelegatorStartingInfoRecord delegator_starting_infos = 9
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // fee_pool defines the validator slash events at genesis.
-  repeated ValidatorSlashEventRecord validator_slash_events = 10 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated ValidatorSlashEventRecord validator_slash_events = 10
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/distribution/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/distribution/v1beta1/query.proto
@@ -18,55 +18,60 @@ service Query {
     option (google.api.http).get = "/cosmos/distribution/v1beta1/params";
   }
 
-  // ValidatorDistributionInfo queries validator commission and self-delegation rewards for validator
-  rpc ValidatorDistributionInfo(QueryValidatorDistributionInfoRequest) returns (QueryValidatorDistributionInfoResponse) {
+  // ValidatorDistributionInfo queries validator commission and self-delegation
+  // rewards for validator
+  rpc ValidatorDistributionInfo(QueryValidatorDistributionInfoRequest)
+      returns (QueryValidatorDistributionInfoResponse) {
     option (google.api.http).get = "/cosmos/distribution/v1beta1/validators/{validator_address}";
   }
 
   // ValidatorOutstandingRewards queries rewards of a validator address.
-  rpc ValidatorOutstandingRewards(QueryValidatorOutstandingRewardsRequest) returns (QueryValidatorOutstandingRewardsResponse) {
-    option (google.api.http).get =
-      "/cosmos/distribution/v1beta1/validators/"
-      "{validator_address}/outstanding_rewards";
+  rpc ValidatorOutstandingRewards(QueryValidatorOutstandingRewardsRequest)
+      returns (QueryValidatorOutstandingRewardsResponse) {
+    option (google.api.http).get = "/cosmos/distribution/v1beta1/validators/"
+                                   "{validator_address}/outstanding_rewards";
   }
 
   // ValidatorCommission queries accumulated commission for a validator.
-  rpc ValidatorCommission(QueryValidatorCommissionRequest) returns (QueryValidatorCommissionResponse) {
-    option (google.api.http).get =
-      "/cosmos/distribution/v1beta1/validators/"
-      "{validator_address}/commission";
+  rpc ValidatorCommission(QueryValidatorCommissionRequest)
+      returns (QueryValidatorCommissionResponse) {
+    option (google.api.http).get = "/cosmos/distribution/v1beta1/validators/"
+                                   "{validator_address}/commission";
   }
 
   // ValidatorSlashes queries slash events of a validator.
   rpc ValidatorSlashes(QueryValidatorSlashesRequest) returns (QueryValidatorSlashesResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/validators/{validator_address}/slashes";
+    option (google.api.http).get =
+        "/cosmos/distribution/v1beta1/validators/{validator_address}/slashes";
   }
 
   // DelegationRewards queries the total rewards accrued by a delegation.
   rpc DelegationRewards(QueryDelegationRewardsRequest) returns (QueryDelegationRewardsResponse) {
     option (google.api.http).get =
-      "/cosmos/distribution/v1beta1/delegators/{delegator_address}/rewards/"
-      "{validator_address}";
+        "/cosmos/distribution/v1beta1/delegators/{delegator_address}/rewards/"
+        "{validator_address}";
   }
 
   // DelegationTotalRewards queries the total rewards accrued by a each
   // validator.
-  rpc DelegationTotalRewards(QueryDelegationTotalRewardsRequest) returns (QueryDelegationTotalRewardsResponse) {
-    option (google.api.http).get = "/cosmos/distribution/v1beta1/delegators/{delegator_address}/rewards";
+  rpc DelegationTotalRewards(QueryDelegationTotalRewardsRequest)
+      returns (QueryDelegationTotalRewardsResponse) {
+    option (google.api.http).get =
+        "/cosmos/distribution/v1beta1/delegators/{delegator_address}/rewards";
   }
 
   // DelegatorValidators queries the validators of a delegator.
-  rpc DelegatorValidators(QueryDelegatorValidatorsRequest) returns (QueryDelegatorValidatorsResponse) {
-    option (google.api.http).get =
-      "/cosmos/distribution/v1beta1/delegators/"
-      "{delegator_address}/validators";
+  rpc DelegatorValidators(QueryDelegatorValidatorsRequest)
+      returns (QueryDelegatorValidatorsResponse) {
+    option (google.api.http).get = "/cosmos/distribution/v1beta1/delegators/"
+                                   "{delegator_address}/validators";
   }
 
   // DelegatorWithdrawAddress queries withdraw address of a delegator.
-  rpc DelegatorWithdrawAddress(QueryDelegatorWithdrawAddressRequest) returns (QueryDelegatorWithdrawAddressResponse) {
-    option (google.api.http).get =
-      "/cosmos/distribution/v1beta1/delegators/"
-      "{delegator_address}/withdraw_address";
+  rpc DelegatorWithdrawAddress(QueryDelegatorWithdrawAddressRequest)
+      returns (QueryDelegatorWithdrawAddressResponse) {
+    option (google.api.http).get = "/cosmos/distribution/v1beta1/delegators/"
+                                   "{delegator_address}/withdraw_address";
   }
 
   // CommunityPool queries the community pool coins.
@@ -81,32 +86,31 @@ message QueryParamsRequest {}
 // QueryParamsResponse is the response type for the Query/Params RPC method.
 message QueryParamsResponse {
   // params defines the parameters of the module.
-  Params params = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
-// QueryValidatorDistributionInfoRequest is the request type for the Query/ValidatorDistributionInfo RPC method.
+// QueryValidatorDistributionInfoRequest is the request type for the
+// Query/ValidatorDistributionInfo RPC method.
 message QueryValidatorDistributionInfoRequest {
   // validator_address defines the validator address to query for.
   string validator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
 
-// QueryValidatorDistributionInfoResponse is the response type for the Query/ValidatorDistributionInfo RPC method.
+// QueryValidatorDistributionInfoResponse is the response type for the
+// Query/ValidatorDistributionInfo RPC method.
 message QueryValidatorDistributionInfoResponse {
   // operator_address defines the validator operator address.
   string operator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // self_bond_rewards defines the self delegations rewards.
   repeated cosmos.base.v1beta1.DecCoin self_bond_rewards = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins"
   ];
   // commission defines the commission the validator received.
   repeated cosmos.base.v1beta1.DecCoin commission = 3 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)     = false
   ];
 }
 
@@ -120,10 +124,8 @@ message QueryValidatorOutstandingRewardsRequest {
 // QueryValidatorOutstandingRewardsResponse is the response type for the
 // Query/ValidatorOutstandingRewards RPC method.
 message QueryValidatorOutstandingRewardsResponse {
-  ValidatorOutstandingRewards rewards = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  ValidatorOutstandingRewards rewards = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryValidatorCommissionRequest is the request type for the
@@ -137,16 +139,14 @@ message QueryValidatorCommissionRequest {
 // Query/ValidatorCommission RPC method
 message QueryValidatorCommissionResponse {
   // commission defines the commission the validator received.
-  ValidatorAccumulatedCommission commission = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  ValidatorAccumulatedCommission commission = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryValidatorSlashesRequest is the request type for the
 // Query/ValidatorSlashes RPC method
 message QueryValidatorSlashesRequest {
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = true;
 
   // validator_address defines the validator address to query for.
@@ -163,10 +163,8 @@ message QueryValidatorSlashesRequest {
 // Query/ValidatorSlashes RPC method.
 message QueryValidatorSlashesResponse {
   // slashes defines the slashes the validator received.
-  repeated ValidatorSlashEvent slashes = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated ValidatorSlashEvent slashes = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -175,7 +173,7 @@ message QueryValidatorSlashesResponse {
 // QueryDelegationRewardsRequest is the request type for the
 // Query/DelegationRewards RPC method.
 message QueryDelegationRewardsRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_address defines the delegator address to query for.
@@ -189,8 +187,8 @@ message QueryDelegationRewardsRequest {
 message QueryDelegationRewardsResponse {
   // rewards defines the rewards accrued by a delegation.
   repeated cosmos.base.v1beta1.DecCoin rewards = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins"
   ];
 }
@@ -198,7 +196,7 @@ message QueryDelegationRewardsResponse {
 // QueryDelegationTotalRewardsRequest is the request type for the
 // Query/DelegationTotalRewards RPC method.
 message QueryDelegationTotalRewardsRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
   // delegator_address defines the delegator address to query for.
   string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -208,14 +206,12 @@ message QueryDelegationTotalRewardsRequest {
 // Query/DelegationTotalRewards RPC method.
 message QueryDelegationTotalRewardsResponse {
   // rewards defines all the rewards accrued by a delegator.
-  repeated DelegationDelegatorReward rewards = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated DelegationDelegatorReward rewards = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // total defines the sum of all the rewards.
   repeated cosmos.base.v1beta1.DecCoin total = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins"
   ];
 }
@@ -223,7 +219,7 @@ message QueryDelegationTotalRewardsResponse {
 // QueryDelegatorValidatorsRequest is the request type for the
 // Query/DelegatorValidators RPC method.
 message QueryDelegatorValidatorsRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_address defines the delegator address to query for.
@@ -233,7 +229,7 @@ message QueryDelegatorValidatorsRequest {
 // QueryDelegatorValidatorsResponse is the response type for the
 // Query/DelegatorValidators RPC method.
 message QueryDelegatorValidatorsResponse {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // validators defines the validators a delegator is delegating for.
@@ -243,7 +239,7 @@ message QueryDelegatorValidatorsResponse {
 // QueryDelegatorWithdrawAddressRequest is the request type for the
 // Query/DelegatorWithdrawAddress RPC method.
 message QueryDelegatorWithdrawAddressRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_address defines the delegator address to query for.
@@ -253,7 +249,7 @@ message QueryDelegatorWithdrawAddressRequest {
 // QueryDelegatorWithdrawAddressResponse is the response type for the
 // Query/DelegatorWithdrawAddress RPC method.
 message QueryDelegatorWithdrawAddressResponse {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // withdraw_address defines the delegator address to query for.
@@ -270,7 +266,7 @@ message QueryCommunityPoolResponse {
   // pool defines community pool's coins.
   repeated cosmos.base.v1beta1.DecCoin pool = 1 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
 }

--- a/lib/cosmos-sdk/proto/cosmos/distribution/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/distribution/v1beta1/tx.proto
@@ -21,11 +21,13 @@ service Msg {
 
   // WithdrawDelegatorReward defines a method to withdraw rewards of delegator
   // from a single validator.
-  rpc WithdrawDelegatorReward(MsgWithdrawDelegatorReward) returns (MsgWithdrawDelegatorRewardResponse);
+  rpc WithdrawDelegatorReward(MsgWithdrawDelegatorReward)
+      returns (MsgWithdrawDelegatorRewardResponse);
 
   // WithdrawValidatorCommission defines a method to withdraw the
   // full commission to the validator address.
-  rpc WithdrawValidatorCommission(MsgWithdrawValidatorCommission) returns (MsgWithdrawValidatorCommissionResponse);
+  rpc WithdrawValidatorCommission(MsgWithdrawValidatorCommission)
+      returns (MsgWithdrawValidatorCommissionResponse);
 
   // FundCommunityPool defines a method to allow an account to directly
   // fund the community pool.
@@ -50,13 +52,13 @@ service Msg {
 // a delegator (or validator self-delegation).
 message MsgSetWithdrawAddress {
   option (cosmos.msg.v1.signer) = "delegator_address";
-  option (amino.name) = "cosmos-sdk/MsgModifyWithdrawAddress";
+  option (amino.name)           = "cosmos-sdk/MsgModifyWithdrawAddress";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string withdraw_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string withdraw_address  = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
 
 // MsgSetWithdrawAddressResponse defines the Msg/SetWithdrawAddress response
@@ -67,9 +69,9 @@ message MsgSetWithdrawAddressResponse {}
 // from a single validator.
 message MsgWithdrawDelegatorReward {
   option (cosmos.msg.v1.signer) = "delegator_address";
-  option (amino.name) = "cosmos-sdk/MsgWithdrawDelegationReward";
+  option (amino.name)           = "cosmos-sdk/MsgWithdrawDelegationReward";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -81,8 +83,8 @@ message MsgWithdrawDelegatorReward {
 message MsgWithdrawDelegatorRewardResponse {
   // Since: cosmos-sdk 0.46
   repeated cosmos.base.v1beta1.Coin amount = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -91,9 +93,9 @@ message MsgWithdrawDelegatorRewardResponse {
 // address.
 message MsgWithdrawValidatorCommission {
   option (cosmos.msg.v1.signer) = "validator_address";
-  option (amino.name) = "cosmos-sdk/MsgWithdrawValCommission";
+  option (amino.name)           = "cosmos-sdk/MsgWithdrawValCommission";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   string validator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -104,8 +106,8 @@ message MsgWithdrawValidatorCommission {
 message MsgWithdrawValidatorCommissionResponse {
   // Since: cosmos-sdk 0.46
   repeated cosmos.base.v1beta1.Coin amount = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -114,14 +116,14 @@ message MsgWithdrawValidatorCommissionResponse {
 // fund the community pool.
 message MsgFundCommunityPool {
   option (cosmos.msg.v1.signer) = "depositor";
-  option (amino.name) = "cosmos-sdk/MsgFundCommunityPool";
+  option (amino.name)           = "cosmos-sdk/MsgFundCommunityPool";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   repeated cosmos.base.v1beta1.Coin amount = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
   string depositor = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -135,18 +137,16 @@ message MsgFundCommunityPoolResponse {}
 // Since: cosmos-sdk 0.47
 message MsgUpdateParams {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/distribution/MsgUpdateParams";
+  option (amino.name)           = "cosmos-sdk/distribution/MsgUpdateParams";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // params defines the x/distribution parameters to update.
   //
   // NOTE: All parameters must be supplied.
-  Params params = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a
@@ -162,14 +162,15 @@ message MsgUpdateParamsResponse {}
 // Since: cosmos-sdk 0.47
 message MsgCommunityPoolSpend {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/distr/MsgCommunityPoolSpend";
+  option (amino.name)           = "cosmos-sdk/distr/MsgCommunityPoolSpend";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
-  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string recipient = 2;
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
+  string   authority                       = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string   recipient                       = 2;
   repeated cosmos.base.v1beta1.Coin amount = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }

--- a/lib/cosmos-sdk/proto/cosmos/evidence/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/evidence/module/v1/module.proto
@@ -6,6 +6,7 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the evidence module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/evidence"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/evidence"
+  };
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/evidence/v1beta1/evidence.proto
+++ b/lib/cosmos-sdk/proto/cosmos/evidence/v1beta1/evidence.proto
@@ -6,26 +6,23 @@ import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/evidence/types";
+option go_package            = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/evidence/types";
 option (gogoproto.equal_all) = true;
 
 // Equivocation implements the Evidence interface and defines evidence of double
 // signing misbehavior.
 message Equivocation {
-  option (amino.name) = "cosmos-sdk/Equivocation";
+  option (amino.name)                 = "cosmos-sdk/Equivocation";
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.goproto_getters) = false;
-  option (gogoproto.equal) = false;
+  option (gogoproto.goproto_getters)  = false;
+  option (gogoproto.equal)            = false;
 
   // height is the equivocation height.
   int64 height = 1;
 
   // time is the equivocation time.
-  google.protobuf.Timestamp time = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
-    (gogoproto.stdtime) = true
-  ];
+  google.protobuf.Timestamp time = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true, (gogoproto.stdtime) = true];
 
   // power is the equivocation validator power.
   int64 power = 3;
@@ -33,4 +30,3 @@ message Equivocation {
   // consensus_address is the equivocation validator consensus address.
   string consensus_address = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/evidence/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/evidence/v1beta1/query.proto
@@ -26,7 +26,7 @@ message QueryEvidenceRequest {
   // evidence_hash defines the hash of the requested evidence.
   // Deprecated: Use hash, a HEX encoded string, instead.
   bytes evidence_hash = 1 [
-    deprecated = true,
+    deprecated           = true,
     (gogoproto.casttype) = "github.com/cometbft/cometbft/libs/bytes.HexBytes"
   ];
 

--- a/lib/cosmos-sdk/proto/cosmos/evidence/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/evidence/v1beta1/tx.proto
@@ -7,15 +7,15 @@ import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/evidence/types";
+option go_package            = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/evidence/types";
 option (gogoproto.equal_all) = true;
 
 // Msg defines the evidence Msg service.
 service Msg {
   option (cosmos.msg.v1.service) = true;
 
-  // SubmitEvidence submits an arbitrary Evidence of misbehavior such as equivocation or
-  // counterfactual signing.
+  // SubmitEvidence submits an arbitrary Evidence of misbehavior such as
+  // equivocation or counterfactual signing.
   rpc SubmitEvidence(MsgSubmitEvidence) returns (MsgSubmitEvidenceResponse);
 }
 
@@ -23,16 +23,17 @@ service Msg {
 // Evidence of misbehavior such as equivocation or counterfactual signing.
 message MsgSubmitEvidence {
   option (cosmos.msg.v1.signer) = "submitter";
-  option (amino.name) = "cosmos-sdk/MsgSubmitEvidence";
+  option (amino.name)           = "cosmos-sdk/MsgSubmitEvidence";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // submitter is the signer account address of evidence.
   string submitter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // evidence defines the evidence of misbehavior.
-  google.protobuf.Any evidence = 2 [(cosmos_proto.accepts_interface) = "cosmos.evidence.v1beta1.Evidence"];
+  google.protobuf.Any evidence = 2
+      [(cosmos_proto.accepts_interface) = "cosmos.evidence.v1beta1.Evidence"];
 }
 
 // MsgSubmitEvidenceResponse defines the Msg/SubmitEvidence response type.

--- a/lib/cosmos-sdk/proto/cosmos/feegrant/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/feegrant/module/v1/module.proto
@@ -6,6 +6,7 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the feegrant module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/feegrant"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/feegrant"
+  };
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/feegrant/v1beta1/feegrant.proto
+++ b/lib/cosmos-sdk/proto/cosmos/feegrant/v1beta1/feegrant.proto
@@ -16,14 +16,14 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/feegrant"
 // that optionally expires. The grantee can use up to SpendLimit to cover fees.
 message BasicAllowance {
   option (cosmos_proto.implements_interface) = "cosmos.feegrant.v1beta1.FeeAllowanceI";
-  option (amino.name) = "cosmos-sdk/BasicAllowance";
+  option (amino.name)                        = "cosmos-sdk/BasicAllowance";
 
   // spend_limit specifies the maximum amount of coins that can be spent
   // by this allowance and will be updated as coins are spent. If it is
   // empty, there is no spend limit and any amount of coins can be spent.
   repeated cosmos.base.v1beta1.Coin spend_limit = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 
@@ -35,55 +35,48 @@ message BasicAllowance {
 // as well as a limit per time period.
 message PeriodicAllowance {
   option (cosmos_proto.implements_interface) = "cosmos.feegrant.v1beta1.FeeAllowanceI";
-  option (amino.name) = "cosmos-sdk/PeriodicAllowance";
+  option (amino.name)                        = "cosmos-sdk/PeriodicAllowance";
 
   // basic specifies a struct of `BasicAllowance`
-  BasicAllowance basic = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  BasicAllowance basic = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // period specifies the time duration in which period_spend_limit coins can
   // be spent before that allowance is reset
-  google.protobuf.Duration period = 2 [
-    (gogoproto.stdduration) = true,
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  google.protobuf.Duration period = 2
+      [(gogoproto.stdduration) = true, (gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // period_spend_limit specifies the maximum number of coins that can be spent
   // in the period
   repeated cosmos.base.v1beta1.Coin period_spend_limit = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 
-  // period_can_spend is the number of coins left to be spent before the period_reset time
+  // period_can_spend is the number of coins left to be spent before the
+  // period_reset time
   repeated cosmos.base.v1beta1.Coin period_can_spend = 4 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 
   // period_reset is the time at which this period resets and a new one begins,
   // it is calculated from the start time of the first transaction after the
   // last period ended
-  google.protobuf.Timestamp period_reset = 5 [
-    (gogoproto.stdtime) = true,
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  google.protobuf.Timestamp period_reset = 5
+      [(gogoproto.stdtime) = true, (gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // AllowedMsgAllowance creates allowance only for specified message types.
 message AllowedMsgAllowance {
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)         = false;
   option (cosmos_proto.implements_interface) = "cosmos.feegrant.v1beta1.FeeAllowanceI";
-  option (amino.name) = "cosmos-sdk/AllowedMsgAllowance";
+  option (amino.name)                        = "cosmos-sdk/AllowedMsgAllowance";
 
   // allowance can be any of basic and periodic fee allowance.
-  google.protobuf.Any allowance = 1 [(cosmos_proto.accepts_interface) = "cosmos.feegrant.v1beta1.FeeAllowanceI"];
+  google.protobuf.Any allowance = 1
+      [(cosmos_proto.accepts_interface) = "cosmos.feegrant.v1beta1.FeeAllowanceI"];
 
   // allowed_messages are the messages for which the grantee has the access.
   repeated string allowed_messages = 2;
@@ -94,9 +87,11 @@ message Grant {
   // granter is the address of the user granting an allowance of their funds.
   string granter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
-  // grantee is the address of the user being granted an allowance of another user's funds.
+  // grantee is the address of the user being granted an allowance of another
+  // user's funds.
   string grantee = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // allowance can be any of basic, periodic, allowed fee allowance.
-  google.protobuf.Any allowance = 3 [(cosmos_proto.accepts_interface) = "cosmos.feegrant.v1beta1.FeeAllowanceI"];
+  google.protobuf.Any allowance = 3
+      [(cosmos_proto.accepts_interface) = "cosmos.feegrant.v1beta1.FeeAllowanceI"];
 }

--- a/lib/cosmos-sdk/proto/cosmos/feegrant/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/feegrant/v1beta1/genesis.proto
@@ -10,8 +10,5 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/feegrant"
 
 // GenesisState contains a set of fee allowances, persisted from the store
 message GenesisState {
-  repeated Grant allowances = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Grant allowances = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/feegrant/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/feegrant/v1beta1/query.proto
@@ -24,7 +24,8 @@ service Query {
   // AllowancesByGranter returns all the grants given by an address
   //
   // Since: cosmos-sdk 0.46
-  rpc AllowancesByGranter(QueryAllowancesByGranterRequest) returns (QueryAllowancesByGranterResponse) {
+  rpc AllowancesByGranter(QueryAllowancesByGranterRequest)
+      returns (QueryAllowancesByGranterResponse) {
     option (google.api.http).get = "/cosmos/feegrant/v1beta1/issued/{granter}";
   }
 }
@@ -34,17 +35,20 @@ message QueryAllowanceRequest {
   // granter is the address of the user granting an allowance of their funds.
   string granter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
-  // grantee is the address of the user being granted an allowance of another user's funds.
+  // grantee is the address of the user being granted an allowance of another
+  // user's funds.
   string grantee = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
 
-// QueryAllowanceResponse is the response type for the Query/Allowance RPC method.
+// QueryAllowanceResponse is the response type for the Query/Allowance RPC
+// method.
 message QueryAllowanceResponse {
   // allowance is a allowance granted for grantee by granter.
   cosmos.feegrant.v1beta1.Grant allowance = 1;
 }
 
-// QueryAllowancesRequest is the request type for the Query/Allowances RPC method.
+// QueryAllowancesRequest is the request type for the Query/Allowances RPC
+// method.
 message QueryAllowancesRequest {
   string grantee = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
@@ -52,7 +56,8 @@ message QueryAllowancesRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// QueryAllowancesResponse is the response type for the Query/Allowances RPC method.
+// QueryAllowancesResponse is the response type for the Query/Allowances RPC
+// method.
 message QueryAllowancesResponse {
   // allowances are allowance's granted for grantee by granter.
   repeated cosmos.feegrant.v1beta1.Grant allowances = 1;
@@ -61,7 +66,8 @@ message QueryAllowancesResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QueryAllowancesByGranterRequest is the request type for the Query/AllowancesByGranter RPC method.
+// QueryAllowancesByGranterRequest is the request type for the
+// Query/AllowancesByGranter RPC method.
 //
 // Since: cosmos-sdk 0.46
 message QueryAllowancesByGranterRequest {
@@ -71,7 +77,8 @@ message QueryAllowancesByGranterRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// QueryAllowancesByGranterResponse is the response type for the Query/AllowancesByGranter RPC method.
+// QueryAllowancesByGranterResponse is the response type for the
+// Query/AllowancesByGranter RPC method.
 //
 // Since: cosmos-sdk 0.46
 message QueryAllowancesByGranterResponse {

--- a/lib/cosmos-sdk/proto/cosmos/feegrant/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/feegrant/v1beta1/tx.proto
@@ -26,32 +26,37 @@ service Msg {
 // of fees from the account of Granter.
 message MsgGrantAllowance {
   option (cosmos.msg.v1.signer) = "granter";
-  option (amino.name) = "cosmos-sdk/MsgGrantAllowance";
+  option (amino.name)           = "cosmos-sdk/MsgGrantAllowance";
 
   // granter is the address of the user granting an allowance of their funds.
   string granter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
-  // grantee is the address of the user being granted an allowance of another user's funds.
+  // grantee is the address of the user being granted an allowance of another
+  // user's funds.
   string grantee = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // allowance can be any of basic, periodic, allowed fee allowance.
-  google.protobuf.Any allowance = 3 [(cosmos_proto.accepts_interface) = "cosmos.feegrant.v1beta1.FeeAllowanceI"];
+  google.protobuf.Any allowance = 3
+      [(cosmos_proto.accepts_interface) = "cosmos.feegrant.v1beta1.FeeAllowanceI"];
 }
 
-// MsgGrantAllowanceResponse defines the Msg/GrantAllowanceResponse response type.
+// MsgGrantAllowanceResponse defines the Msg/GrantAllowanceResponse response
+// type.
 message MsgGrantAllowanceResponse {}
 
 // MsgRevokeAllowance removes any existing Allowance from Granter to Grantee.
 message MsgRevokeAllowance {
   option (cosmos.msg.v1.signer) = "granter";
-  option (amino.name) = "cosmos-sdk/MsgRevokeAllowance";
+  option (amino.name)           = "cosmos-sdk/MsgRevokeAllowance";
 
   // granter is the address of the user granting an allowance of their funds.
   string granter = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
-  // grantee is the address of the user being granted an allowance of another user's funds.
+  // grantee is the address of the user being granted an allowance of another
+  // user's funds.
   string grantee = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
 
-// MsgRevokeAllowanceResponse defines the Msg/RevokeAllowanceResponse response type.
+// MsgRevokeAllowanceResponse defines the Msg/RevokeAllowanceResponse response
+// type.
 message MsgRevokeAllowanceResponse {}

--- a/lib/cosmos-sdk/proto/cosmos/genutil/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/genutil/module/v1/module.proto
@@ -6,6 +6,7 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object for the genutil module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/genutil"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/genutil"
+  };
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/genutil/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/genutil/v1beta1/genesis.proto
@@ -10,9 +10,9 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/genutil/t
 message GenesisState {
   // gen_txs defines the genesis transactions.
   repeated bytes gen_txs = 1 [
-    (gogoproto.casttype) = "encoding/json.RawMessage",
-    (gogoproto.jsontag) = "gentxs",
-    (amino.field_name) = "gentxs",
+    (gogoproto.casttype)   = "encoding/json.RawMessage",
+    (gogoproto.jsontag)    = "gentxs",
+    (amino.field_name)     = "gentxs",
     (amino.dont_omitempty) = true
   ];
 }

--- a/lib/cosmos-sdk/proto/cosmos/gov/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/gov/module/v1/module.proto
@@ -6,13 +6,15 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the gov module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/gov"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/gov"
+  };
 
   // max_metadata_len defines the maximum proposal metadata length.
   // Defaults to 255 if not explicitly set.
   uint64 max_metadata_len = 1;
 
-  // authority defines the custom module authority. If not set, defaults to the governance module.
+  // authority defines the custom module authority. If not set, defaults to the
+  // governance module.
   string authority = 2;
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/gov/v1/gov.proto
+++ b/lib/cosmos-sdk/proto/cosmos/gov/v1/gov.proto
@@ -28,7 +28,8 @@ enum VoteOption {
 
 // WeightedVoteOption defines a unit of vote for vote split.
 message WeightedVoteOption {
-  // option defines the valid vote options, it must not contain duplicate vote options.
+  // option defines the valid vote options, it must not contain duplicate vote
+  // options.
   VoteOption option = 1;
 
   // weight is the vote weight associated with the vote option.
@@ -45,10 +46,8 @@ message Deposit {
   string depositor = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // amount to be deposited by depositor.
-  repeated cosmos.base.v1beta1.Coin amount = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated cosmos.base.v1beta1.Coin amount = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // Proposal defines the core field members of a governance proposal.
@@ -74,10 +73,8 @@ message Proposal {
   google.protobuf.Timestamp deposit_end_time = 6 [(gogoproto.stdtime) = true];
 
   // total_deposit is the total deposit on the proposal.
-  repeated cosmos.base.v1beta1.Coin total_deposit = 7 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated cosmos.base.v1beta1.Coin total_deposit = 7
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // voting_start_time is the starting time to vote on a proposal.
   google.protobuf.Timestamp voting_start_time = 8 [(gogoproto.stdtime) = true];
@@ -158,17 +155,13 @@ message Vote {
 // DepositParams defines the params for deposits on governance proposals.
 message DepositParams {
   // Minimum deposit for a proposal to enter voting period.
-  repeated cosmos.base.v1beta1.Coin min_deposit = 1 [
-    (gogoproto.nullable) = false,
-    (gogoproto.jsontag) = "min_deposit,omitempty"
-  ];
+  repeated cosmos.base.v1beta1.Coin min_deposit = 1
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "min_deposit,omitempty"];
 
   // Maximum period for Atom holders to deposit on a proposal. Initial value: 2
   // months.
-  google.protobuf.Duration max_deposit_period = 2 [
-    (gogoproto.stdduration) = true,
-    (gogoproto.jsontag) = "max_deposit_period,omitempty"
-  ];
+  google.protobuf.Duration max_deposit_period = 2
+      [(gogoproto.stdduration) = true, (gogoproto.jsontag) = "max_deposit_period,omitempty"];
 }
 
 // VotingParams defines the params for voting on governance proposals.
@@ -196,10 +189,8 @@ message TallyParams {
 // Since: cosmos-sdk 0.47
 message Params {
   // Minimum deposit for a proposal to enter voting period.
-  repeated cosmos.base.v1beta1.Coin min_deposit = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated cosmos.base.v1beta1.Coin min_deposit = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // Maximum period for Atom holders to deposit on a proposal. Initial value: 2
   // months.
@@ -219,7 +210,8 @@ message Params {
   //  vetoed. Default value: 1/3.
   string veto_threshold = 6 [(cosmos_proto.scalar) = "cosmos.Dec"];
 
-  //  The ratio representing the proportion of the deposit value that must be paid at proposal submission.
+  //  The ratio representing the proportion of the deposit value that must be
+  //  paid at proposal submission.
   string min_initial_deposit_ratio = 7 [(cosmos_proto.scalar) = "cosmos.Dec"];
 
   // burn deposits if a proposal does not meet quorum

--- a/lib/cosmos-sdk/proto/cosmos/gov/v1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/gov/v1/tx.proto
@@ -26,7 +26,8 @@ service Msg {
   // Vote defines a method to add a vote on a specific proposal.
   rpc Vote(MsgVote) returns (MsgVoteResponse);
 
-  // VoteWeighted defines a method to add a weighted vote on a specific proposal.
+  // VoteWeighted defines a method to add a weighted vote on a specific
+  // proposal.
   rpc VoteWeighted(MsgVoteWeighted) returns (MsgVoteWeightedResponse);
 
   // Deposit defines a method to add deposit on a specific proposal.
@@ -43,16 +44,15 @@ service Msg {
 // proposal Content.
 message MsgSubmitProposal {
   option (cosmos.msg.v1.signer) = "proposer";
-  option (amino.name) = "cosmos-sdk/v1/MsgSubmitProposal";
+  option (amino.name)           = "cosmos-sdk/v1/MsgSubmitProposal";
 
   // messages are the arbitrary messages to be executed if proposal passes.
   repeated google.protobuf.Any messages = 1;
 
-  // initial_deposit is the deposit value that must be paid at proposal submission.
-  repeated cosmos.base.v1beta1.Coin initial_deposit = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  // initial_deposit is the deposit value that must be paid at proposal
+  // submission.
+  repeated cosmos.base.v1beta1.Coin initial_deposit = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // proposer is the account address of the proposer.
   string proposer = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -81,7 +81,7 @@ message MsgSubmitProposalResponse {
 // This ensures backwards compatibility with v1beta1.MsgSubmitProposal.
 message MsgExecLegacyContent {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/v1/MsgExecLegacyContent";
+  option (amino.name)           = "cosmos-sdk/v1/MsgExecLegacyContent";
 
   // content is the proposal's content.
   google.protobuf.Any content = 1 [(cosmos_proto.accepts_interface) = "cosmos.gov.v1beta1.Content"];
@@ -95,13 +95,10 @@ message MsgExecLegacyContentResponse {}
 // MsgVote defines a message to cast a vote.
 message MsgVote {
   option (cosmos.msg.v1.signer) = "voter";
-  option (amino.name) = "cosmos-sdk/v1/MsgVote";
+  option (amino.name)           = "cosmos-sdk/v1/MsgVote";
 
   // proposal_id defines the unique id of the proposal.
-  uint64 proposal_id = 1 [
-    (gogoproto.jsontag) = "proposal_id",
-    (amino.dont_omitempty) = true
-  ];
+  uint64 proposal_id = 1 [(gogoproto.jsontag) = "proposal_id", (amino.dont_omitempty) = true];
 
   // voter is the voter address for the proposal.
   string voter = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -119,13 +116,10 @@ message MsgVoteResponse {}
 // MsgVoteWeighted defines a message to cast a vote.
 message MsgVoteWeighted {
   option (cosmos.msg.v1.signer) = "voter";
-  option (amino.name) = "cosmos-sdk/v1/MsgVoteWeighted";
+  option (amino.name)           = "cosmos-sdk/v1/MsgVoteWeighted";
 
   // proposal_id defines the unique id of the proposal.
-  uint64 proposal_id = 1 [
-    (gogoproto.jsontag) = "proposal_id",
-    (amino.dont_omitempty) = true
-  ];
+  uint64 proposal_id = 1 [(gogoproto.jsontag) = "proposal_id", (amino.dont_omitempty) = true];
 
   // voter is the voter address for the proposal.
   string voter = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -143,22 +137,17 @@ message MsgVoteWeightedResponse {}
 // MsgDeposit defines a message to submit a deposit to an existing proposal.
 message MsgDeposit {
   option (cosmos.msg.v1.signer) = "depositor";
-  option (amino.name) = "cosmos-sdk/v1/MsgDeposit";
+  option (amino.name)           = "cosmos-sdk/v1/MsgDeposit";
 
   // proposal_id defines the unique id of the proposal.
-  uint64 proposal_id = 1 [
-    (gogoproto.jsontag) = "proposal_id",
-    (amino.dont_omitempty) = true
-  ];
+  uint64 proposal_id = 1 [(gogoproto.jsontag) = "proposal_id", (amino.dont_omitempty) = true];
 
   // depositor defines the deposit addresses from the proposals.
   string depositor = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // amount to be deposited by depositor.
-  repeated cosmos.base.v1beta1.Coin amount = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated cosmos.base.v1beta1.Coin amount = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgDepositResponse defines the Msg/Deposit response type.
@@ -169,18 +158,16 @@ message MsgDepositResponse {}
 // Since: cosmos-sdk 0.47
 message MsgUpdateParams {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/x/gov/v1/MsgUpdateParams";
+  option (amino.name)           = "cosmos-sdk/x/gov/v1/MsgUpdateParams";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // params defines the x/gov parameters to update.
   //
   // NOTE: All parameters must be supplied.
-  Params params = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a

--- a/lib/cosmos-sdk/proto/cosmos/gov/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/gov/v1beta1/genesis.proto
@@ -15,34 +15,25 @@ message GenesisState {
   // deposits defines all the deposits present at genesis.
   repeated Deposit deposits = 2 [
     (gogoproto.castrepeated) = "Deposits",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
   // votes defines all the votes present at genesis.
   repeated Vote votes = 3 [
     (gogoproto.castrepeated) = "Votes",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
   // proposals defines all the proposals present at genesis.
   repeated Proposal proposals = 4 [
     (gogoproto.castrepeated) = "Proposals",
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true
   ];
   // params defines all the parameters of related to deposit.
-  DepositParams deposit_params = 5 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  DepositParams deposit_params = 5 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // params defines all the parameters of related to voting.
-  VotingParams voting_params = 6 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  VotingParams voting_params = 6 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // params defines all the parameters of related to tally.
-  TallyParams tally_params = 7 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  TallyParams tally_params = 7 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/gov/v1beta1/gov.proto
+++ b/lib/cosmos-sdk/proto/cosmos/gov/v1beta1/gov.proto
@@ -10,9 +10,9 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/gov/types/v1beta1";
-option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.goproto_getters_all)  = false;
 option (gogoproto.goproto_stringer_all) = false;
-option (gogoproto.stringer_all) = false;
+option (gogoproto.stringer_all)         = false;
 
 // VoteOption enumerates the valid vote options for a given governance proposal.
 enum VoteOption {
@@ -34,14 +34,15 @@ enum VoteOption {
 //
 // Since: cosmos-sdk 0.43
 message WeightedVoteOption {
-  // option defines the valid vote options, it must not contain duplicate vote options.
+  // option defines the valid vote options, it must not contain duplicate vote
+  // options.
   VoteOption option = 1;
 
   // weight is the vote weight associated with the vote option.
   string weight = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 
@@ -49,7 +50,7 @@ message WeightedVoteOption {
 // manually updated in case of approval.
 message TextProposal {
   option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
-  option (amino.name) = "cosmos-sdk/TextProposal";
+  option (amino.name)                        = "cosmos-sdk/TextProposal";
 
   option (gogoproto.equal) = true;
 
@@ -64,7 +65,7 @@ message TextProposal {
 // proposal.
 message Deposit {
   option (gogoproto.goproto_getters) = false;
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
 
   // proposal_id defines the unique id of the proposal.
   uint64 proposal_id = 1;
@@ -74,8 +75,8 @@ message Deposit {
 
   // amount to be deposited by depositor.
   repeated cosmos.base.v1beta1.Coin amount = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -95,45 +96,30 @@ message Proposal {
   // final_tally_result is the final tally result of the proposal. When
   // querying a proposal via gRPC, this field is not populated until the
   // proposal's voting period has ended.
-  TallyResult final_tally_result = 4 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  TallyResult final_tally_result = 4 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // submit_time is the time of proposal submission.
-  google.protobuf.Timestamp submit_time = 5 [
-    (gogoproto.stdtime) = true,
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  google.protobuf.Timestamp submit_time = 5
+      [(gogoproto.stdtime) = true, (gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // deposit_end_time is the end time for deposition.
-  google.protobuf.Timestamp deposit_end_time = 6 [
-    (gogoproto.stdtime) = true,
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  google.protobuf.Timestamp deposit_end_time = 6
+      [(gogoproto.stdtime) = true, (gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // total_deposit is the total deposit on the proposal.
   repeated cosmos.base.v1beta1.Coin total_deposit = 7 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 
   // voting_start_time is the starting time to vote on a proposal.
-  google.protobuf.Timestamp voting_start_time = 8 [
-    (gogoproto.stdtime) = true,
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  google.protobuf.Timestamp voting_start_time = 8
+      [(gogoproto.stdtime) = true, (gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // voting_end_time is the end time of voting on a proposal.
-  google.protobuf.Timestamp voting_end_time = 9 [
-    (gogoproto.stdtime) = true,
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  google.protobuf.Timestamp voting_end_time = 9
+      [(gogoproto.stdtime) = true, (gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // ProposalStatus enumerates the valid statuses of a proposal.
@@ -165,30 +151,30 @@ message TallyResult {
 
   // yes is the number of yes votes on a proposal.
   string yes = 1 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // abstain is the number of abstain votes on a proposal.
   string abstain = 2 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // no is the number of no votes on a proposal.
   string no = 3 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // no_with_veto is the number of no with veto votes on a proposal.
   string no_with_veto = 4 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 
@@ -196,14 +182,11 @@ message TallyResult {
 // A Vote consists of a proposal ID, the voter, and the vote option.
 message Vote {
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)            = false;
 
   // proposal_id defines the unique id of the proposal.
-  uint64 proposal_id = 1 [
-    (gogoproto.jsontag) = "id",
-    (amino.field_name) = "id",
-    (amino.dont_omitempty) = true
-  ];
+  uint64 proposal_id = 1
+      [(gogoproto.jsontag) = "id", (amino.field_name) = "id", (amino.dont_omitempty) = true];
 
   // voter is the voter address of the proposal.
   string voter = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -215,27 +198,25 @@ message Vote {
   // options is the weighted vote options.
   //
   // Since: cosmos-sdk 0.43
-  repeated WeightedVoteOption options = 4 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated WeightedVoteOption options = 4
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // DepositParams defines the params for deposits on governance proposals.
 message DepositParams {
   // Minimum deposit for a proposal to enter voting period.
   repeated cosmos.base.v1beta1.Coin min_deposit = 1 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)     = false,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins",
-    (gogoproto.jsontag) = "min_deposit,omitempty"
+    (gogoproto.jsontag)      = "min_deposit,omitempty"
   ];
 
   // Maximum period for Atom holders to deposit on a proposal. Initial value: 2
   // months.
   google.protobuf.Duration max_deposit_period = 2 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)    = false,
     (gogoproto.stdduration) = true,
-    (gogoproto.jsontag) = "max_deposit_period,omitempty"
+    (gogoproto.jsontag)     = "max_deposit_period,omitempty"
   ];
 }
 
@@ -243,9 +224,9 @@ message DepositParams {
 message VotingParams {
   // Duration of the voting period.
   google.protobuf.Duration voting_period = 1 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)    = false,
     (gogoproto.stdduration) = true,
-    (gogoproto.jsontag) = "voting_period,omitempty"
+    (gogoproto.jsontag)     = "voting_period,omitempty"
   ];
 }
 
@@ -255,22 +236,22 @@ message TallyParams {
   // considered valid.
   bytes quorum = 1 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false,
-    (gogoproto.jsontag) = "quorum,omitempty"
+    (gogoproto.nullable)   = false,
+    (gogoproto.jsontag)    = "quorum,omitempty"
   ];
 
   // Minimum proportion of Yes votes for proposal to pass. Default value: 0.5.
   bytes threshold = 2 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false,
-    (gogoproto.jsontag) = "threshold,omitempty"
+    (gogoproto.nullable)   = false,
+    (gogoproto.jsontag)    = "threshold,omitempty"
   ];
 
   // Minimum value of Veto votes to Total votes ratio for proposal to be
   // vetoed. Default value: 1/3.
   bytes veto_threshold = 3 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false,
-    (gogoproto.jsontag) = "veto_threshold,omitempty"
+    (gogoproto.nullable)   = false,
+    (gogoproto.jsontag)    = "veto_threshold,omitempty"
   ];
 }

--- a/lib/cosmos-sdk/proto/cosmos/gov/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/gov/v1beta1/query.proto
@@ -39,7 +39,8 @@ service Query {
 
   // Deposit queries single deposit information based proposalID, depositAddr.
   rpc Deposit(QueryDepositRequest) returns (QueryDepositResponse) {
-    option (google.api.http).get = "/cosmos/gov/v1beta1/proposals/{proposal_id}/deposits/{depositor}";
+    option (google.api.http).get =
+        "/cosmos/gov/v1beta1/proposals/{proposal_id}/deposits/{depositor}";
   }
 
   // Deposits queries all deposits of a single proposal.
@@ -61,15 +62,12 @@ message QueryProposalRequest {
 
 // QueryProposalResponse is the response type for the Query/Proposal RPC method.
 message QueryProposalResponse {
-  Proposal proposal = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Proposal proposal = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryProposalsRequest is the request type for the Query/Proposals RPC method.
 message QueryProposalsRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // proposal_status defines the status of the proposals.
@@ -89,10 +87,7 @@ message QueryProposalsRequest {
 // method.
 message QueryProposalsResponse {
   // proposals defines all the requested governance proposals.
-  repeated Proposal proposals = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Proposal proposals = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -100,7 +95,7 @@ message QueryProposalsResponse {
 
 // QueryVoteRequest is the request type for the Query/Vote RPC method.
 message QueryVoteRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // proposal_id defines the unique id of the proposal.
@@ -113,10 +108,7 @@ message QueryVoteRequest {
 // QueryVoteResponse is the response type for the Query/Vote RPC method.
 message QueryVoteResponse {
   // vote defines the queried vote.
-  Vote vote = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Vote vote = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryVotesRequest is the request type for the Query/Votes RPC method.
@@ -131,10 +123,7 @@ message QueryVotesRequest {
 // QueryVotesResponse is the response type for the Query/Votes RPC method.
 message QueryVotesResponse {
   // votes defines the queried votes.
-  repeated Vote votes = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Vote votes = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -150,26 +139,17 @@ message QueryParamsRequest {
 // QueryParamsResponse is the response type for the Query/Params RPC method.
 message QueryParamsResponse {
   // voting_params defines the parameters related to voting.
-  VotingParams voting_params = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  VotingParams voting_params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // deposit_params defines the parameters related to deposit.
-  DepositParams deposit_params = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  DepositParams deposit_params = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // tally_params defines the parameters related to tally.
-  TallyParams tally_params = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  TallyParams tally_params = 3 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryDepositRequest is the request type for the Query/Deposit RPC method.
 message QueryDepositRequest {
   option (gogoproto.goproto_getters) = false;
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
 
   // proposal_id defines the unique id of the proposal.
   uint64 proposal_id = 1;
@@ -181,10 +161,7 @@ message QueryDepositRequest {
 // QueryDepositResponse is the response type for the Query/Deposit RPC method.
 message QueryDepositResponse {
   // deposit defines the requested deposit.
-  Deposit deposit = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Deposit deposit = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryDepositsRequest is the request type for the Query/Deposits RPC method.
@@ -199,10 +176,7 @@ message QueryDepositsRequest {
 // QueryDepositsResponse is the response type for the Query/Deposits RPC method.
 message QueryDepositsResponse {
   // deposits defines the requested deposits.
-  repeated Deposit deposits = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Deposit deposits = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -217,8 +191,5 @@ message QueryTallyResultRequest {
 // QueryTallyResultResponse is the response type for the Query/Tally RPC method.
 message QueryTallyResultResponse {
   // tally defines the requested tally.
-  TallyResult tally = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  TallyResult tally = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/gov/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/gov/v1beta1/tx.proto
@@ -21,7 +21,8 @@ service Msg {
   // Vote defines a method to add a vote on a specific proposal.
   rpc Vote(MsgVote) returns (MsgVoteResponse);
 
-  // VoteWeighted defines a method to add a weighted vote on a specific proposal.
+  // VoteWeighted defines a method to add a weighted vote on a specific
+  // proposal.
   //
   // Since: cosmos-sdk 0.43
   rpc VoteWeighted(MsgVoteWeighted) returns (MsgVoteWeightedResponse);
@@ -34,19 +35,20 @@ service Msg {
 // proposal Content.
 message MsgSubmitProposal {
   option (cosmos.msg.v1.signer) = "proposer";
-  option (amino.name) = "cosmos-sdk/MsgSubmitProposal";
+  option (amino.name)           = "cosmos-sdk/MsgSubmitProposal";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)            = false;
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.stringer) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.stringer)         = false;
+  option (gogoproto.goproto_getters)  = false;
 
   // content is the proposal's content.
   google.protobuf.Any content = 1 [(cosmos_proto.accepts_interface) = "cosmos.gov.v1beta1.Content"];
-  // initial_deposit is the deposit value that must be paid at proposal submission.
+  // initial_deposit is the deposit value that must be paid at proposal
+  // submission.
   repeated cosmos.base.v1beta1.Coin initial_deposit = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 
@@ -57,21 +59,18 @@ message MsgSubmitProposal {
 // MsgSubmitProposalResponse defines the Msg/SubmitProposal response type.
 message MsgSubmitProposalResponse {
   // proposal_id defines the unique id of the proposal.
-  uint64 proposal_id = 1 [
-    (gogoproto.jsontag) = "proposal_id",
-    (amino.dont_omitempty) = true
-  ];
+  uint64 proposal_id = 1 [(gogoproto.jsontag) = "proposal_id", (amino.dont_omitempty) = true];
 }
 
 // MsgVote defines a message to cast a vote.
 message MsgVote {
   option (cosmos.msg.v1.signer) = "voter";
-  option (amino.name) = "cosmos-sdk/MsgVote";
+  option (amino.name)           = "cosmos-sdk/MsgVote";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)            = false;
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.stringer) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.stringer)         = false;
+  option (gogoproto.goproto_getters)  = false;
 
   // proposal_id defines the unique id of the proposal.
   uint64 proposal_id = 1;
@@ -91,27 +90,22 @@ message MsgVoteResponse {}
 // Since: cosmos-sdk 0.43
 message MsgVoteWeighted {
   option (cosmos.msg.v1.signer) = "voter";
-  option (amino.name) = "cosmos-sdk/MsgVoteWeighted";
+  option (amino.name)           = "cosmos-sdk/MsgVoteWeighted";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)            = false;
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.stringer) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.stringer)         = false;
+  option (gogoproto.goproto_getters)  = false;
 
   // proposal_id defines the unique id of the proposal.
-  uint64 proposal_id = 1 [
-    (gogoproto.jsontag) = "proposal_id",
-    (amino.dont_omitempty) = true
-  ];
+  uint64 proposal_id = 1 [(gogoproto.jsontag) = "proposal_id", (amino.dont_omitempty) = true];
 
   // voter is the voter address for the proposal.
   string voter = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // options defines the weighted vote options.
-  repeated WeightedVoteOption options = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated WeightedVoteOption options = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgVoteWeightedResponse defines the Msg/VoteWeighted response type.
@@ -122,26 +116,23 @@ message MsgVoteWeightedResponse {}
 // MsgDeposit defines a message to submit a deposit to an existing proposal.
 message MsgDeposit {
   option (cosmos.msg.v1.signer) = "depositor";
-  option (amino.name) = "cosmos-sdk/MsgDeposit";
+  option (amino.name)           = "cosmos-sdk/MsgDeposit";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)            = false;
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.stringer) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.stringer)         = false;
+  option (gogoproto.goproto_getters)  = false;
 
   // proposal_id defines the unique id of the proposal.
-  uint64 proposal_id = 1 [
-    (gogoproto.jsontag) = "proposal_id",
-    (amino.dont_omitempty) = true
-  ];
+  uint64 proposal_id = 1 [(gogoproto.jsontag) = "proposal_id", (amino.dont_omitempty) = true];
 
   // depositor defines the deposit addresses from the proposals.
   string depositor = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // amount to be deposited by depositor.
   repeated cosmos.base.v1beta1.Coin amount = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }

--- a/lib/cosmos-sdk/proto/cosmos/msg/v1/msg.proto
+++ b/lib/cosmos-sdk/proto/cosmos/msg/v1/msg.proto
@@ -4,8 +4,9 @@ package cosmos.msg.v1;
 
 import "google/protobuf/descriptor.proto";
 
-// TODO(fdymylja): once we fully migrate to protov2 the go_package needs to be updated.
-// We need this right now because gogoproto codegen needs to import the extension.
+// TODO(fdymylja): once we fully migrate to protov2 the go_package needs to be
+// updated. We need this right now because gogoproto codegen needs to import the
+// extension.
 option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types/msgservice";
 
 extend google.protobuf.ServiceOptions {

--- a/lib/cosmos-sdk/proto/cosmos/params/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/params/module/v1/module.proto
@@ -6,5 +6,7 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the params module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/params"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/params"
+  };
 }

--- a/lib/cosmos-sdk/proto/cosmos/params/v1beta1/params.proto
+++ b/lib/cosmos-sdk/proto/cosmos/params/v1beta1/params.proto
@@ -10,17 +10,14 @@ option (gogoproto.equal_all) = true;
 
 // ParameterChangeProposal defines a proposal to change one or more parameters.
 message ParameterChangeProposal {
-  option (gogoproto.goproto_getters) = false;
-  option (gogoproto.goproto_stringer) = false;
+  option (gogoproto.goproto_getters)         = false;
+  option (gogoproto.goproto_stringer)        = false;
   option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
-  option (amino.name) = "cosmos-sdk/ParameterChangeProposal";
+  option (amino.name)                        = "cosmos-sdk/ParameterChangeProposal";
 
-  string title = 1;
-  string description = 2;
-  repeated ParamChange changes = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  string               title       = 1;
+  string               description = 2;
+  repeated ParamChange changes = 3 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // ParamChange defines an individual parameter change, for use in
@@ -29,6 +26,6 @@ message ParamChange {
   option (gogoproto.goproto_stringer) = false;
 
   string subspace = 1;
-  string key = 2;
-  string value = 3;
+  string key      = 2;
+  string value    = 3;
 }

--- a/lib/cosmos-sdk/proto/cosmos/params/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/params/v1beta1/query.proto
@@ -36,10 +36,7 @@ message QueryParamsRequest {
 // QueryParamsResponse is response type for the Query/Params RPC method.
 message QueryParamsResponse {
   // param defines the queried parameter.
-  ParamChange param = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  ParamChange param = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QuerySubspacesRequest defines a request type for querying for all registered
@@ -61,6 +58,6 @@ message QuerySubspacesResponse {
 //
 // Since: cosmos-sdk 0.46
 message Subspace {
-  string subspace = 1;
-  repeated string keys = 2;
+  string          subspace = 1;
+  repeated string keys     = 2;
 }

--- a/lib/cosmos-sdk/proto/cosmos/query/v1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/query/v1/query.proto
@@ -5,7 +5,8 @@ package cosmos.query.v1;
 import "google/protobuf/descriptor.proto";
 
 // TODO: once we fully migrate to protov2 the go_package needs to be updated.
-// We need this right now because gogoproto codegen needs to import the extension.
+// We need this right now because gogoproto codegen needs to import the
+// extension.
 option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types/query";
 
 extend google.protobuf.MethodOptions {
@@ -33,4 +34,3 @@ extend google.protobuf.MethodOptions {
   // When set to true, the query can safely be called
   bool module_query_safe = 11110001;
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/reflection/v1/reflection.proto
+++ b/lib/cosmos-sdk/proto/cosmos/reflection/v1/reflection.proto
@@ -12,7 +12,8 @@ service ReflectionService {
   // to enable easier generation of dynamic clients.
   rpc FileDescriptors(FileDescriptorsRequest) returns (FileDescriptorsResponse) {
     // NOTE: file descriptors SHOULD NOT be part of consensus because they
-    // include changes to doc commands and module_query_safe should be kept as false.
+    // include changes to doc commands and module_query_safe should be kept as
+    // false.
     option (cosmos.query.v1.module_query_safe) = false;
   }
 }

--- a/lib/cosmos-sdk/proto/cosmos/slashing/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/slashing/module/v1/module.proto
@@ -6,8 +6,11 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the slashing module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/slashing"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/slashing"
+  };
 
-  // authority defines the custom module authority. If not set, defaults to the governance module.
+  // authority defines the custom module authority. If not set, defaults to the
+  // governance module.
   string authority = 1;
 }

--- a/lib/cosmos-sdk/proto/cosmos/slashing/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/slashing/v1beta1/genesis.proto
@@ -11,24 +11,17 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/slashing/
 // GenesisState defines the slashing module's genesis state.
 message GenesisState {
   // params defines all the parameters of the module.
-  Params params = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // signing_infos represents a map between validator addresses and their
   // signing infos.
-  repeated SigningInfo signing_infos = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated SigningInfo signing_infos = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // missed_blocks represents a map between validator addresses and their
   // missed blocks.
-  repeated ValidatorMissedBlocks missed_blocks = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated ValidatorMissedBlocks missed_blocks = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // SigningInfo stores validator signing info of corresponding address.
@@ -36,10 +29,8 @@ message SigningInfo {
   // address is the validator address.
   string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // validator_signing_info represents the signing info of this validator.
-  ValidatorSigningInfo validator_signing_info = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  ValidatorSigningInfo validator_signing_info = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // ValidatorMissedBlocks contains array of missed blocks of corresponding
@@ -48,10 +39,8 @@ message ValidatorMissedBlocks {
   // address is the validator address.
   string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // missed_blocks is an array of missed blocks by the validator.
-  repeated MissedBlock missed_blocks = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated MissedBlock missed_blocks = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MissedBlock contains height and missed status as boolean.

--- a/lib/cosmos-sdk/proto/cosmos/slashing/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/slashing/v1beta1/query.proto
@@ -33,10 +33,7 @@ message QueryParamsRequest {}
 
 // QueryParamsResponse is the response type for the Query/Params RPC method
 message QueryParamsResponse {
-  Params params = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QuerySigningInfoRequest is the request type for the Query/SigningInfo RPC
@@ -50,10 +47,8 @@ message QuerySigningInfoRequest {
 // method
 message QuerySigningInfoResponse {
   // val_signing_info is the signing info of requested val cons address
-  ValidatorSigningInfo val_signing_info = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  ValidatorSigningInfo val_signing_info = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QuerySigningInfosRequest is the request type for the Query/SigningInfos RPC
@@ -66,9 +61,7 @@ message QuerySigningInfosRequest {
 // method
 message QuerySigningInfosResponse {
   // info is the signing info of all validators
-  repeated cosmos.slashing.v1beta1.ValidatorSigningInfo info = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated cosmos.slashing.v1beta1.ValidatorSigningInfo info = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }

--- a/lib/cosmos-sdk/proto/cosmos/slashing/v1beta1/slashing.proto
+++ b/lib/cosmos-sdk/proto/cosmos/slashing/v1beta1/slashing.proto
@@ -7,30 +7,29 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/slashing/types";
+option go_package            = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/slashing/types";
 option (gogoproto.equal_all) = true;
 
 // ValidatorSigningInfo defines a validator's signing info for monitoring their
 // liveness activity.
 message ValidatorSigningInfo {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
 
   string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // Height at which validator was first a candidate OR was unjailed
   int64 start_height = 2;
   // Index which is incremented each time the validator was a bonded
-  // in a block and may have signed a precommit or not. This in conjunction with the
-  // `SignedBlocksWindow` param determines the index in the `MissedBlocksBitArray`.
+  // in a block and may have signed a precommit or not. This in conjunction with
+  // the `SignedBlocksWindow` param determines the index in the
+  // `MissedBlocksBitArray`.
   int64 index_offset = 3;
   // Timestamp until which the validator is jailed due to liveness downtime.
-  google.protobuf.Timestamp jailed_until = 4 [
-    (gogoproto.stdtime) = true,
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  // Whether or not a validator has been tombstoned (killed out of validator set). It is set
-  // once the validator commits an equivocation or for any other configured misbehiavor.
+  google.protobuf.Timestamp jailed_until = 4
+      [(gogoproto.stdtime) = true, (gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  // Whether or not a validator has been tombstoned (killed out of validator
+  // set). It is set once the validator commits an equivocation or for any other
+  // configured misbehiavor.
   bool tombstoned = 5;
   // A counter kept to avoid unnecessary array reads.
   // Note that `Sum(MissedBlocksBitArray)` always equals `MissedBlocksCounter`.
@@ -41,25 +40,22 @@ message ValidatorSigningInfo {
 message Params {
   option (amino.name) = "cosmos-sdk/x/slashing/Params";
 
-  int64 signed_blocks_window = 1;
+  int64 signed_blocks_window  = 1;
   bytes min_signed_per_window = 2 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
-  google.protobuf.Duration downtime_jail_duration = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
-    (gogoproto.stdduration) = true
-  ];
+  google.protobuf.Duration downtime_jail_duration = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true, (gogoproto.stdduration) = true];
   bytes slash_fraction_double_sign = 4 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
   bytes slash_fraction_downtime = 5 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
 }

--- a/lib/cosmos-sdk/proto/cosmos/slashing/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/slashing/v1beta1/tx.proto
@@ -7,7 +7,7 @@ import "cosmos/slashing/v1beta1/slashing.proto";
 import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/slashing/types";
+option go_package            = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/slashing/types";
 option (gogoproto.equal_all) = true;
 
 // Msg defines the slashing Msg service.
@@ -19,8 +19,8 @@ service Msg {
   // and rewards again.
   rpc Unjail(MsgUnjail) returns (MsgUnjailResponse);
 
-  // UpdateParams defines a governance operation for updating the x/slashing module
-  // parameters. The authority defaults to the x/gov module account.
+  // UpdateParams defines a governance operation for updating the x/slashing
+  // module parameters. The authority defaults to the x/gov module account.
   //
   // Since: cosmos-sdk 0.47
   rpc UpdateParams(MsgUpdateParams) returns (MsgUpdateParamsResponse);
@@ -29,15 +29,15 @@ service Msg {
 // MsgUnjail defines the Msg/Unjail request type
 message MsgUnjail {
   option (cosmos.msg.v1.signer) = "validator_addr";
-  option (amino.name) = "cosmos-sdk/MsgUnjail";
+  option (amino.name)           = "cosmos-sdk/MsgUnjail";
 
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = true;
 
   string validator_addr = 1 [
-    (cosmos_proto.scalar) = "cosmos.AddressString",
-    (gogoproto.jsontag) = "address",
-    (amino.field_name) = "address",
+    (cosmos_proto.scalar)  = "cosmos.AddressString",
+    (gogoproto.jsontag)    = "address",
+    (amino.field_name)     = "address",
     (amino.dont_omitempty) = true
   ];
 }
@@ -50,18 +50,16 @@ message MsgUnjailResponse {}
 // Since: cosmos-sdk 0.47
 message MsgUpdateParams {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/x/slashing/MsgUpdateParams";
+  option (amino.name)           = "cosmos-sdk/x/slashing/MsgUpdateParams";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // params defines the x/slashing parameters to update.
   //
   // NOTE: All parameters must be supplied.
-  Params params = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a

--- a/lib/cosmos-sdk/proto/cosmos/staking/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/staking/module/v1/module.proto
@@ -6,13 +6,16 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the staking module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/staking"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/staking"
+  };
 
   // hooks_order specifies the order of staking hooks and should be a list
   // of module names which provide a staking hooks instance. If no order is
   // provided, then hooks will be applied in alphabetical order of module names.
   repeated string hooks_order = 1;
 
-  // authority defines the custom module authority. If not set, defaults to the governance module.
+  // authority defines the custom module authority. If not set, defaults to the
+  // governance module.
   string authority = 2;
 }

--- a/lib/cosmos-sdk/proto/cosmos/staking/v1beta1/authz.proto
+++ b/lib/cosmos-sdk/proto/cosmos/staking/v1beta1/authz.proto
@@ -13,17 +13,20 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/staking/t
 // Since: cosmos-sdk 0.43
 message StakeAuthorization {
   option (cosmos_proto.implements_interface) = "cosmos.authz.v1beta1.Authorization";
-  option (amino.name) = "cosmos-sdk/StakeAuthorization";
+  option (amino.name)                        = "cosmos-sdk/StakeAuthorization";
 
-  // max_tokens specifies the maximum amount of tokens can be delegate to a validator. If it is
-  // empty, there is no spend limit and any amount of coins can be delegated.
-  cosmos.base.v1beta1.Coin max_tokens = 1 [(gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coin"];
+  // max_tokens specifies the maximum amount of tokens can be delegate to a
+  // validator. If it is empty, there is no spend limit and any amount of coins
+  // can be delegated.
+  cosmos.base.v1beta1.Coin max_tokens = 1
+      [(gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coin"];
   // validators is the oneof that represents either allow_list or deny_list
   oneof validators {
-    // allow_list specifies list of validator addresses to whom grantee can delegate tokens on behalf of granter's
-    // account.
+    // allow_list specifies list of validator addresses to whom grantee can
+    // delegate tokens on behalf of granter's account.
     Validators allow_list = 2;
-    // deny_list specifies list of validator addresses to whom grantee can not delegate tokens.
+    // deny_list specifies list of validator addresses to whom grantee can not
+    // delegate tokens.
     Validators deny_list = 3;
   }
   // Validators defines list of validator addresses.
@@ -42,8 +45,10 @@ enum AuthorizationType {
   AUTHORIZATION_TYPE_UNSPECIFIED = 0;
   // AUTHORIZATION_TYPE_DELEGATE defines an authorization type for Msg/Delegate
   AUTHORIZATION_TYPE_DELEGATE = 1;
-  // AUTHORIZATION_TYPE_UNDELEGATE defines an authorization type for Msg/Undelegate
+  // AUTHORIZATION_TYPE_UNDELEGATE defines an authorization type for
+  // Msg/Undelegate
   AUTHORIZATION_TYPE_UNDELEGATE = 2;
-  // AUTHORIZATION_TYPE_REDELEGATE defines an authorization type for Msg/BeginRedelegate
+  // AUTHORIZATION_TYPE_REDELEGATE defines an authorization type for
+  // Msg/BeginRedelegate
   AUTHORIZATION_TYPE_REDELEGATE = 3;
 }

--- a/lib/cosmos-sdk/proto/cosmos/staking/v1beta1/genesis.proto
+++ b/lib/cosmos-sdk/proto/cosmos/staking/v1beta1/genesis.proto
@@ -11,56 +11,41 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/staking/t
 // GenesisState defines the staking module's genesis state.
 message GenesisState {
   // params defines all the parameters of related to deposit.
-  Params params = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // last_total_power tracks the total amounts of bonded tokens recorded during
   // the previous end block.
   bytes last_total_power = 2 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
 
   // last_validator_powers is a special index that provides a historical list
   // of the last-block's bonded validators.
-  repeated LastValidatorPower last_validator_powers = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated LastValidatorPower last_validator_powers = 3
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // delegations defines the validator set at genesis.
-  repeated Validator validators = 4 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Validator validators = 4 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // delegations defines the delegations active at genesis.
-  repeated Delegation delegations = 5 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Delegation delegations = 5 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // unbonding_delegations defines the unbonding delegations active at genesis.
-  repeated UnbondingDelegation unbonding_delegations = 6 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated UnbondingDelegation unbonding_delegations = 6
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // redelegations defines the redelegations active at genesis.
-  repeated Redelegation redelegations = 7 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Redelegation redelegations = 7
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   bool exported = 8;
 }
 
 // LastValidatorPower required for validator set update logic.
 message LastValidatorPower {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the address of the validator.

--- a/lib/cosmos-sdk/proto/cosmos/staking/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/staking/v1beta1/query.proto
@@ -19,7 +19,7 @@ service Query {
   // gas if the pagination field is incorrectly set.
   rpc Validators(QueryValidatorsRequest) returns (QueryValidatorsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/staking/v1beta1/validators";
+    option (google.api.http).get               = "/cosmos/staking/v1beta1/validators";
   }
 
   // Validator queries validator info for given validator address.
@@ -32,44 +32,48 @@ service Query {
   //
   // When called from another module, this query might consume a high amount of
   // gas if the pagination field is incorrectly set.
-  rpc ValidatorDelegations(QueryValidatorDelegationsRequest) returns (QueryValidatorDelegationsResponse) {
+  rpc ValidatorDelegations(QueryValidatorDelegationsRequest)
+      returns (QueryValidatorDelegationsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/staking/v1beta1/validators/{validator_addr}/delegations";
+    option (google.api.http).get =
+        "/cosmos/staking/v1beta1/validators/{validator_addr}/delegations";
   }
 
   // ValidatorUnbondingDelegations queries unbonding delegations of a validator.
   //
   // When called from another module, this query might consume a high amount of
   // gas if the pagination field is incorrectly set.
-  rpc ValidatorUnbondingDelegations(QueryValidatorUnbondingDelegationsRequest) returns (QueryValidatorUnbondingDelegationsResponse) {
+  rpc ValidatorUnbondingDelegations(QueryValidatorUnbondingDelegationsRequest)
+      returns (QueryValidatorUnbondingDelegationsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get =
-      "/cosmos/staking/v1beta1/validators/"
-      "{validator_addr}/unbonding_delegations";
+    option (google.api.http).get               = "/cosmos/staking/v1beta1/validators/"
+                                                 "{validator_addr}/unbonding_delegations";
   }
 
   // Delegation queries delegate info for given validator delegator pair.
   rpc Delegation(QueryDelegationRequest) returns (QueryDelegationResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
     option (google.api.http).get =
-      "/cosmos/staking/v1beta1/validators/{validator_addr}/delegations/"
-      "{delegator_addr}";
+        "/cosmos/staking/v1beta1/validators/{validator_addr}/delegations/"
+        "{delegator_addr}";
   }
 
   // UnbondingDelegation queries unbonding info for given validator delegator
   // pair.
-  rpc UnbondingDelegation(QueryUnbondingDelegationRequest) returns (QueryUnbondingDelegationResponse) {
+  rpc UnbondingDelegation(QueryUnbondingDelegationRequest)
+      returns (QueryUnbondingDelegationResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
     option (google.api.http).get =
-      "/cosmos/staking/v1beta1/validators/{validator_addr}/delegations/"
-      "{delegator_addr}/unbonding_delegation";
+        "/cosmos/staking/v1beta1/validators/{validator_addr}/delegations/"
+        "{delegator_addr}/unbonding_delegation";
   }
 
   // DelegatorDelegations queries all delegations of a given delegator address.
   //
   // When called from another module, this query might consume a high amount of
   // gas if the pagination field is incorrectly set.
-  rpc DelegatorDelegations(QueryDelegatorDelegationsRequest) returns (QueryDelegatorDelegationsResponse) {
+  rpc DelegatorDelegations(QueryDelegatorDelegationsRequest)
+      returns (QueryDelegatorDelegationsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
     option (google.api.http).get = "/cosmos/staking/v1beta1/delegations/{delegator_addr}";
   }
@@ -79,11 +83,11 @@ service Query {
   //
   // When called from another module, this query might consume a high amount of
   // gas if the pagination field is incorrectly set.
-  rpc DelegatorUnbondingDelegations(QueryDelegatorUnbondingDelegationsRequest) returns (QueryDelegatorUnbondingDelegationsResponse) {
+  rpc DelegatorUnbondingDelegations(QueryDelegatorUnbondingDelegationsRequest)
+      returns (QueryDelegatorUnbondingDelegationsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get =
-      "/cosmos/staking/v1beta1/delegators/"
-      "{delegator_addr}/unbonding_delegations";
+    option (google.api.http).get               = "/cosmos/staking/v1beta1/delegators/"
+                                                 "{delegator_addr}/unbonding_delegations";
   }
 
   // Redelegations queries redelegations of given address.
@@ -92,7 +96,8 @@ service Query {
   // gas if the pagination field is incorrectly set.
   rpc Redelegations(QueryRedelegationsRequest) returns (QueryRedelegationsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/staking/v1beta1/delegators/{delegator_addr}/redelegations";
+    option (google.api.http).get =
+        "/cosmos/staking/v1beta1/delegators/{delegator_addr}/redelegations";
   }
 
   // DelegatorValidators queries all validators info for given delegator
@@ -100,7 +105,8 @@ service Query {
   //
   // When called from another module, this query might consume a high amount of
   // gas if the pagination field is incorrectly set.
-  rpc DelegatorValidators(QueryDelegatorValidatorsRequest) returns (QueryDelegatorValidatorsResponse) {
+  rpc DelegatorValidators(QueryDelegatorValidatorsRequest)
+      returns (QueryDelegatorValidatorsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
     option (google.api.http).get = "/cosmos/staking/v1beta1/delegators/{delegator_addr}/validators";
   }
@@ -109,27 +115,26 @@ service Query {
   // pair.
   rpc DelegatorValidator(QueryDelegatorValidatorRequest) returns (QueryDelegatorValidatorResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get =
-      "/cosmos/staking/v1beta1/delegators/{delegator_addr}/validators/"
-      "{validator_addr}";
+    option (google.api.http).get = "/cosmos/staking/v1beta1/delegators/{delegator_addr}/validators/"
+                                   "{validator_addr}";
   }
 
   // HistoricalInfo queries the historical info for given height.
   rpc HistoricalInfo(QueryHistoricalInfoRequest) returns (QueryHistoricalInfoResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/staking/v1beta1/historical_info/{height}";
+    option (google.api.http).get               = "/cosmos/staking/v1beta1/historical_info/{height}";
   }
 
   // Pool queries the pool info.
   rpc Pool(QueryPoolRequest) returns (QueryPoolResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/staking/v1beta1/pool";
+    option (google.api.http).get               = "/cosmos/staking/v1beta1/pool";
   }
 
   // Parameters queries the staking parameters.
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
-    option (google.api.http).get = "/cosmos/staking/v1beta1/params";
+    option (google.api.http).get               = "/cosmos/staking/v1beta1/params";
   }
 }
 
@@ -145,10 +150,7 @@ message QueryValidatorsRequest {
 // QueryValidatorsResponse is response type for the Query/Validators RPC method
 message QueryValidatorsResponse {
   // validators contains all the queried validators.
-  repeated Validator validators = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Validator validators = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -163,10 +165,7 @@ message QueryValidatorRequest {
 // QueryValidatorResponse is response type for the Query/Validator RPC method
 message QueryValidatorResponse {
   // validator defines the validator info.
-  Validator validator = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Validator validator = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryValidatorDelegationsRequest is request type for the
@@ -183,8 +182,8 @@ message QueryValidatorDelegationsRequest {
 // Query/ValidatorDelegations RPC method
 message QueryValidatorDelegationsResponse {
   repeated DelegationResponse delegation_responses = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "DelegationResponses"
   ];
 
@@ -205,10 +204,8 @@ message QueryValidatorUnbondingDelegationsRequest {
 // QueryValidatorUnbondingDelegationsResponse is response type for the
 // Query/ValidatorUnbondingDelegations RPC method.
 message QueryValidatorUnbondingDelegationsResponse {
-  repeated UnbondingDelegation unbonding_responses = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated UnbondingDelegation unbonding_responses = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -216,7 +213,7 @@ message QueryValidatorUnbondingDelegationsResponse {
 
 // QueryDelegationRequest is request type for the Query/Delegation RPC method.
 message QueryDelegationRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_addr defines the delegator address to query for.
@@ -235,7 +232,7 @@ message QueryDelegationResponse {
 // QueryUnbondingDelegationRequest is request type for the
 // Query/UnbondingDelegation RPC method.
 message QueryUnbondingDelegationRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_addr defines the delegator address to query for.
@@ -249,16 +246,13 @@ message QueryUnbondingDelegationRequest {
 // RPC method.
 message QueryUnbondingDelegationResponse {
   // unbond defines the unbonding information of a delegation.
-  UnbondingDelegation unbond = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  UnbondingDelegation unbond = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryDelegatorDelegationsRequest is request type for the
 // Query/DelegatorDelegations RPC method.
 message QueryDelegatorDelegationsRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_addr defines the delegator address to query for.
@@ -272,10 +266,8 @@ message QueryDelegatorDelegationsRequest {
 // Query/DelegatorDelegations RPC method.
 message QueryDelegatorDelegationsResponse {
   // delegation_responses defines all the delegations' info of a delegator.
-  repeated DelegationResponse delegation_responses = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated DelegationResponse delegation_responses = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -284,7 +276,7 @@ message QueryDelegatorDelegationsResponse {
 // QueryDelegatorUnbondingDelegationsRequest is request type for the
 // Query/DelegatorUnbondingDelegations RPC method.
 message QueryDelegatorUnbondingDelegationsRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_addr defines the delegator address to query for.
@@ -297,10 +289,8 @@ message QueryDelegatorUnbondingDelegationsRequest {
 // QueryUnbondingDelegatorDelegationsResponse is response type for the
 // Query/UnbondingDelegatorDelegations RPC method.
 message QueryDelegatorUnbondingDelegationsResponse {
-  repeated UnbondingDelegation unbonding_responses = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated UnbondingDelegation unbonding_responses = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -309,7 +299,7 @@ message QueryDelegatorUnbondingDelegationsResponse {
 // QueryRedelegationsRequest is request type for the Query/Redelegations RPC
 // method.
 message QueryRedelegationsRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_addr defines the delegator address to query for.
@@ -328,10 +318,8 @@ message QueryRedelegationsRequest {
 // QueryRedelegationsResponse is response type for the Query/Redelegations RPC
 // method.
 message QueryRedelegationsResponse {
-  repeated RedelegationResponse redelegation_responses = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated RedelegationResponse redelegation_responses = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -340,7 +328,7 @@ message QueryRedelegationsResponse {
 // QueryDelegatorValidatorsRequest is request type for the
 // Query/DelegatorValidators RPC method.
 message QueryDelegatorValidatorsRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_addr defines the delegator address to query for.
@@ -354,10 +342,7 @@ message QueryDelegatorValidatorsRequest {
 // Query/DelegatorValidators RPC method.
 message QueryDelegatorValidatorsResponse {
   // validators defines the validators' info of a delegator.
-  repeated Validator validators = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated Validator validators = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
@@ -366,7 +351,7 @@ message QueryDelegatorValidatorsResponse {
 // QueryDelegatorValidatorRequest is request type for the
 // Query/DelegatorValidator RPC method.
 message QueryDelegatorValidatorRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // delegator_addr defines the delegator address to query for.
@@ -380,10 +365,7 @@ message QueryDelegatorValidatorRequest {
 // Query/DelegatorValidator RPC method.
 message QueryDelegatorValidatorResponse {
   // validator defines the validator info.
-  Validator validator = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Validator validator = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryHistoricalInfoRequest is request type for the Query/HistoricalInfo RPC
@@ -406,10 +388,7 @@ message QueryPoolRequest {}
 // QueryPoolResponse is response type for the Query/Pool RPC method.
 message QueryPoolResponse {
   // pool defines the pool info.
-  Pool pool = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Pool pool = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryParamsRequest is request type for the Query/Params RPC method.
@@ -418,8 +397,5 @@ message QueryParamsRequest {}
 // QueryParamsResponse is response type for the Query/Params RPC method.
 message QueryParamsResponse {
   // params holds all the parameters of this module.
-  Params params = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/staking/v1beta1/staking.proto
+++ b/lib/cosmos-sdk/proto/cosmos/staking/v1beta1/staking.proto
@@ -18,64 +18,55 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/staking/t
 // recent HistoricalInfo
 // (`n` is set by the staking module's `historical_entries` parameter).
 message HistoricalInfo {
-  tendermint.types.Header header = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  repeated Validator valset = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  tendermint.types.Header header = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  repeated Validator      valset = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // CommissionRates defines the initial commission rates to be used for creating
 // a validator.
 message CommissionRates {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
 
   // rate is the commission rate charged to delegators, as a fraction.
   string rate = 1 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
-  // max_rate defines the maximum commission rate which validator can ever charge, as a fraction.
+  // max_rate defines the maximum commission rate which validator can ever
+  // charge, as a fraction.
   string max_rate = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
-  // max_change_rate defines the maximum daily increase of the validator commission, as a fraction.
+  // max_change_rate defines the maximum daily increase of the validator
+  // commission, as a fraction.
   string max_change_rate = 3 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 
 // Commission defines commission parameters for a given validator.
 message Commission {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
 
-  // commission_rates defines the initial commission rates to be used for creating a validator.
-  CommissionRates commission_rates = 1 [
-    (gogoproto.embed) = true,
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  // commission_rates defines the initial commission rates to be used for
+  // creating a validator.
+  CommissionRates commission_rates = 1
+      [(gogoproto.embed) = true, (gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // update_time is the last time the commission rate was changed.
-  google.protobuf.Timestamp update_time = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
-    (gogoproto.stdtime) = true
-  ];
+  google.protobuf.Timestamp update_time = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true, (gogoproto.stdtime) = true];
 }
 
 // Description defines a validator description.
 message Description {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
 
   // moniker defines a human-readable name for the validator.
@@ -99,61 +90,61 @@ message Description {
 // exchange rate. Voting power can be calculated as total bonded shares
 // multiplied by exchange rate.
 message Validator {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)            = false;
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)  = false;
 
-  // operator_address defines the address of the validator's operator; bech encoded in JSON.
+  // operator_address defines the address of the validator's operator; bech
+  // encoded in JSON.
   string operator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // consensus_pubkey is the consensus public key of the validator, as a Protobuf Any.
-  google.protobuf.Any consensus_pubkey = 2 [(cosmos_proto.accepts_interface) = "cosmos.crypto.PubKey"];
-  // jailed defined whether the validator has been jailed from bonded status or not.
+  // consensus_pubkey is the consensus public key of the validator, as a
+  // Protobuf Any.
+  google.protobuf.Any consensus_pubkey = 2
+      [(cosmos_proto.accepts_interface) = "cosmos.crypto.PubKey"];
+  // jailed defined whether the validator has been jailed from bonded status or
+  // not.
   bool jailed = 3;
   // status is the validator status (bonded/unbonding/unbonded).
   BondStatus status = 4;
   // tokens define the delegated tokens (incl. self-delegation).
   string tokens = 5 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // delegator_shares defines total shares issued to a validator's delegators.
   string delegator_shares = 6 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // description defines the description terms for the validator.
-  Description description = 7 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  // unbonding_height defines, if unbonding, the height at which this validator has begun unbonding.
+  Description description = 7 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  // unbonding_height defines, if unbonding, the height at which this validator
+  // has begun unbonding.
   int64 unbonding_height = 8;
-  // unbonding_time defines, if unbonding, the min time for the validator to complete unbonding.
-  google.protobuf.Timestamp unbonding_time = 9 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
-    (gogoproto.stdtime) = true
-  ];
+  // unbonding_time defines, if unbonding, the min time for the validator to
+  // complete unbonding.
+  google.protobuf.Timestamp unbonding_time = 9
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true, (gogoproto.stdtime) = true];
   // commission defines the commission parameters.
-  Commission commission = 10 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  // min_self_delegation is the validator's self declared minimum self delegation.
+  Commission commission = 10 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  // min_self_delegation is the validator's self declared minimum self
+  // delegation.
   //
   // Since: cosmos-sdk 0.46
   string min_self_delegation = 11 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
-  // strictly positive if this validator's unbonding has been stopped by external modules
+  // strictly positive if this validator's unbonding has been stopped by
+  // external modules
   int64 unbonding_on_hold_ref_count = 12;
 
-  // list of unbonding ids, each uniquely identifing an unbonding of this validator
+  // list of unbonding ids, each uniquely identifing an unbonding of this
+  // validator
   repeated uint64 unbonding_ids = 13;
 }
 
@@ -174,7 +165,7 @@ enum BondStatus {
 // ValAddresses defines a repeated set of validator addresses.
 message ValAddresses {
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.stringer) = true;
+  option (gogoproto.stringer)         = true;
 
   repeated string addresses = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
@@ -183,8 +174,8 @@ message ValAddresses {
 // It is intended to be used as a marshalable pointer. For example, a DVPair can
 // be used to construct the key to getting an UnbondingDelegation from state.
 message DVPair {
-  option (gogoproto.equal) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = false;
 
   string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
@@ -193,10 +184,7 @@ message DVPair {
 
 // DVPairs defines an array of DVPair objects.
 message DVPairs {
-  repeated DVPair pairs = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated DVPair pairs = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // DVVTriplet is struct that just has a delegator-validator-validator triplet
@@ -204,29 +192,26 @@ message DVPairs {
 // example, a DVVTriplet can be used to construct the key to getting a
 // Redelegation from state.
 message DVVTriplet {
-  option (gogoproto.equal) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = false;
 
-  string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string delegator_address     = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   string validator_src_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   string validator_dst_address = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
 
 // DVVTriplets defines an array of DVVTriplet objects.
 message DVVTriplets {
-  repeated DVVTriplet triplets = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated DVVTriplet triplets = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // Delegation represents the bond with tokens held by an account. It is
 // owned by one delegator, and is associated with the voting power of one
 // validator.
 message Delegation {
-  option (gogoproto.equal) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = false;
 
   // delegator_address is the bech32-encoded address of the delegator.
@@ -235,17 +220,17 @@ message Delegation {
   string validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // shares define the delegation shares received.
   string shares = 3 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 
 // UnbondingDelegation stores all of a single delegator's unbonding bonds
 // for a single validator in an time-ordered list.
 message UnbondingDelegation {
-  option (gogoproto.equal) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = false;
 
   // delegator_address is the bech32-encoded address of the delegator.
@@ -254,138 +239,131 @@ message UnbondingDelegation {
   string validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // entries are the unbonding delegation entries.
   repeated UnbondingDelegationEntry entries = 3 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
-  ]; // unbonding delegation entries
+  ];  // unbonding delegation entries
 }
 
 // UnbondingDelegationEntry defines an unbonding object with relevant metadata.
 message UnbondingDelegationEntry {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
 
   // creation_height is the height which the unbonding took place.
   int64 creation_height = 1;
   // completion_time is the unix time for unbonding completion.
-  google.protobuf.Timestamp completion_time = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
-    (gogoproto.stdtime) = true
-  ];
-  // initial_balance defines the tokens initially scheduled to receive at completion.
+  google.protobuf.Timestamp completion_time = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true, (gogoproto.stdtime) = true];
+  // initial_balance defines the tokens initially scheduled to receive at
+  // completion.
   string initial_balance = 3 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // balance defines the tokens to receive at completion.
   string balance = 4 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // Incrementing id that uniquely identifies this entry
   uint64 unbonding_id = 5;
 
-  // Strictly positive if this entry's unbonding has been stopped by external modules
+  // Strictly positive if this entry's unbonding has been stopped by external
+  // modules
   int64 unbonding_on_hold_ref_count = 6;
 }
 
 // RedelegationEntry defines a redelegation object with relevant metadata.
 message RedelegationEntry {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
 
   // creation_height  defines the height which the redelegation took place.
   int64 creation_height = 1;
   // completion_time defines the unix time for redelegation completion.
-  google.protobuf.Timestamp completion_time = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
-    (gogoproto.stdtime) = true
-  ];
+  google.protobuf.Timestamp completion_time = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true, (gogoproto.stdtime) = true];
   // initial_balance defines the initial balance when redelegation started.
   string initial_balance = 3 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
-  // shares_dst is the amount of destination-validator shares created by redelegation.
+  // shares_dst is the amount of destination-validator shares created by
+  // redelegation.
   string shares_dst = 4 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // Incrementing id that uniquely identifies this entry
   uint64 unbonding_id = 5;
 
-  // Strictly positive if this entry's unbonding has been stopped by external modules
+  // Strictly positive if this entry's unbonding has been stopped by external
+  // modules
   int64 unbonding_on_hold_ref_count = 6;
 }
 
 // Redelegation contains the list of a particular delegator's redelegating bonds
 // from a particular source validator to a particular destination validator.
 message Redelegation {
-  option (gogoproto.equal) = false;
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.equal)            = false;
+  option (gogoproto.goproto_getters)  = false;
   option (gogoproto.goproto_stringer) = false;
 
   // delegator_address is the bech32-encoded address of the delegator.
   string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // validator_src_address is the validator redelegation source operator address.
+  // validator_src_address is the validator redelegation source operator
+  // address.
   string validator_src_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  // validator_dst_address is the validator redelegation destination operator address.
+  // validator_dst_address is the validator redelegation destination operator
+  // address.
   string validator_dst_address = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // entries are the redelegation entries.
-  repeated RedelegationEntry entries = 4 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ]; // redelegation entries
+  repeated RedelegationEntry entries = 4
+      [(gogoproto.nullable)   = false,
+       (amino.dont_omitempty) = true];  // redelegation entries
 }
 
 // Params defines the parameters for the x/staking module.
 message Params {
-  option (amino.name) = "cosmos-sdk/x/staking/Params";
-  option (gogoproto.equal) = true;
+  option (amino.name)                 = "cosmos-sdk/x/staking/Params";
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
 
   // unbonding_time is the time duration of unbonding.
-  google.protobuf.Duration unbonding_time = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
-    (gogoproto.stdduration) = true
-  ];
+  google.protobuf.Duration unbonding_time = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true, (gogoproto.stdduration) = true];
   // max_validators is the maximum number of validators.
   uint32 max_validators = 2;
-  // max_entries is the max entries for either unbonding delegation or redelegation (per pair/trio).
+  // max_entries is the max entries for either unbonding delegation or
+  // redelegation (per pair/trio).
   uint32 max_entries = 3;
   // historical_entries is the number of historical entries to persist.
   uint32 historical_entries = 4;
   // bond_denom defines the bondable coin denomination.
   string bond_denom = 5;
-  // min_commission_rate is the chain-wide minimum commission rate that a validator can charge their delegators
+  // min_commission_rate is the chain-wide minimum commission rate that a
+  // validator can charge their delegators
   string min_commission_rate = 6 [
-    (gogoproto.moretags) = "yaml:\"min_commission_rate\"",
+    (gogoproto.moretags)   = "yaml:\"min_commission_rate\"",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 
 // DelegationResponse is equivalent to Delegation except that it contains a
 // balance in addition to shares which is more suitable for client responses.
 message DelegationResponse {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)            = false;
   option (gogoproto.goproto_stringer) = false;
 
-  Delegation delegation = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Delegation delegation = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 
-  cosmos.base.v1beta1.Coin balance = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  cosmos.base.v1beta1.Coin balance = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // RedelegationEntryResponse is equivalent to a RedelegationEntry except that it
@@ -394,14 +372,12 @@ message DelegationResponse {
 message RedelegationEntryResponse {
   option (gogoproto.equal) = true;
 
-  RedelegationEntry redelegation_entry = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  RedelegationEntry redelegation_entry = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   string balance = 4 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 
@@ -411,33 +387,28 @@ message RedelegationEntryResponse {
 message RedelegationResponse {
   option (gogoproto.equal) = false;
 
-  Redelegation redelegation = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  repeated RedelegationEntryResponse entries = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Redelegation redelegation = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  repeated RedelegationEntryResponse entries = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // Pool is used for tracking bonded and not-bonded token supply of the bond
 // denomination.
 message Pool {
   option (gogoproto.description) = true;
-  option (gogoproto.equal) = true;
-  string not_bonded_tokens = 1 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+  option (gogoproto.equal)       = true;
+  string not_bonded_tokens       = 1 [
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false,
-    (gogoproto.jsontag) = "not_bonded_tokens",
+    (gogoproto.nullable)   = false,
+    (gogoproto.jsontag)    = "not_bonded_tokens",
     (amino.dont_omitempty) = true
   ];
   string bonded_tokens = 2 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false,
-    (gogoproto.jsontag) = "bonded_tokens",
+    (gogoproto.nullable)   = false,
+    (gogoproto.jsontag)    = "bonded_tokens",
     (amino.dont_omitempty) = true
   ];
 }
@@ -453,10 +424,9 @@ enum Infraction {
 }
 
 // ValidatorUpdates defines an array of abci.ValidatorUpdate objects.
-// TODO: explore moving this to proto/cosmos/base to separate modules from tendermint dependence
+// TODO: explore moving this to proto/cosmos/base to separate modules from
+// tendermint dependence
 message ValidatorUpdates {
-  repeated tendermint.abci.ValidatorUpdate updates = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated tendermint.abci.ValidatorUpdate updates = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/lib/cosmos-sdk/proto/cosmos/staking/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/staking/v1beta1/tx.proto
@@ -34,11 +34,12 @@ service Msg {
   // delegate and a validator.
   rpc Undelegate(MsgUndelegate) returns (MsgUndelegateResponse);
 
-  // CancelUnbondingDelegation defines a method for performing canceling the unbonding delegation
-  // and delegate back to previous validator.
+  // CancelUnbondingDelegation defines a method for performing canceling the
+  // unbonding delegation and delegate back to previous validator.
   //
   // Since: cosmos-sdk 0.46
-  rpc CancelUnbondingDelegation(MsgCancelUnbondingDelegation) returns (MsgCancelUnbondingDelegationResponse);
+  rpc CancelUnbondingDelegation(MsgCancelUnbondingDelegation)
+      returns (MsgCancelUnbondingDelegationResponse);
 
   // UpdateParams defines an operation for updating the x/staking module
   // parameters.
@@ -53,31 +54,22 @@ message MsgCreateValidator {
   // is expected to sign, otherwise both are.
   option (cosmos.msg.v1.signer) = "delegator_address";
   option (cosmos.msg.v1.signer) = "validator_address";
-  option (amino.name) = "cosmos-sdk/MsgCreateValidator";
+  option (amino.name)           = "cosmos-sdk/MsgCreateValidator";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  Description description = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  CommissionRates commission = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  string min_self_delegation = 3 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+  Description     description = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  CommissionRates commission  = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  string          min_self_delegation = 3 [
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
-  string delegator_address = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string validator_address = 5 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  google.protobuf.Any pubkey = 6 [(cosmos_proto.accepts_interface) = "cosmos.crypto.PubKey"];
-  cosmos.base.v1beta1.Coin value = 7 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  string                   delegator_address = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string                   validator_address = 5 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  google.protobuf.Any      pubkey = 6 [(cosmos_proto.accepts_interface) = "cosmos.crypto.PubKey"];
+  cosmos.base.v1beta1.Coin value  = 7 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgCreateValidatorResponse defines the Msg/CreateValidator response type.
@@ -86,27 +78,24 @@ message MsgCreateValidatorResponse {}
 // MsgEditValidator defines a SDK message for editing an existing validator.
 message MsgEditValidator {
   option (cosmos.msg.v1.signer) = "validator_address";
-  option (amino.name) = "cosmos-sdk/MsgEditValidator";
+  option (amino.name)           = "cosmos-sdk/MsgEditValidator";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  Description description = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
-  string validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  Description description       = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  string      validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // We pass a reference to the new commission rate and min self delegation as
   // it's not mandatory to update. If not updated, the deserialized rate will be
   // zero with no way to distinguish if an update was intended.
   // REF: #2373
   string commission_rate = 3 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Dec"
   ];
   string min_self_delegation = 4 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Int"
   ];
 }
@@ -118,17 +107,14 @@ message MsgEditValidatorResponse {}
 // from a delegator to a validator.
 message MsgDelegate {
   option (cosmos.msg.v1.signer) = "delegator_address";
-  option (amino.name) = "cosmos-sdk/MsgDelegate";
+  option (amino.name)           = "cosmos-sdk/MsgDelegate";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  cosmos.base.v1beta1.Coin amount = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  string                   delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string                   validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  cosmos.base.v1beta1.Coin amount = 3 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgDelegateResponse defines the Msg/Delegate response type.
@@ -138,71 +124,57 @@ message MsgDelegateResponse {}
 // of coins from a delegator and source validator to a destination validator.
 message MsgBeginRedelegate {
   option (cosmos.msg.v1.signer) = "delegator_address";
-  option (amino.name) = "cosmos-sdk/MsgBeginRedelegate";
+  option (amino.name)           = "cosmos-sdk/MsgBeginRedelegate";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string validator_src_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string validator_dst_address = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  cosmos.base.v1beta1.Coin amount = 4 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  string delegator_address        = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string validator_src_address    = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string validator_dst_address    = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  cosmos.base.v1beta1.Coin amount = 4 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgBeginRedelegateResponse defines the Msg/BeginRedelegate response type.
 message MsgBeginRedelegateResponse {
-  google.protobuf.Timestamp completion_time = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
-    (gogoproto.stdtime) = true
-  ];
+  google.protobuf.Timestamp completion_time = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true, (gogoproto.stdtime) = true];
 }
 
 // MsgUndelegate defines a SDK message for performing an undelegation from a
 // delegate and a validator.
 message MsgUndelegate {
   option (cosmos.msg.v1.signer) = "delegator_address";
-  option (amino.name) = "cosmos-sdk/MsgUndelegate";
+  option (amino.name)           = "cosmos-sdk/MsgUndelegate";
 
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  cosmos.base.v1beta1.Coin amount = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  string                   delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string                   validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  cosmos.base.v1beta1.Coin amount = 3 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgUndelegateResponse defines the Msg/Undelegate response type.
 message MsgUndelegateResponse {
-  google.protobuf.Timestamp completion_time = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
-    (gogoproto.stdtime) = true
-  ];
+  google.protobuf.Timestamp completion_time = 1
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true, (gogoproto.stdtime) = true];
 }
 
-// MsgCancelUnbondingDelegation defines the SDK message for performing a cancel unbonding delegation for delegator
+// MsgCancelUnbondingDelegation defines the SDK message for performing a cancel
+// unbonding delegation for delegator
 //
 // Since: cosmos-sdk 0.46
 message MsgCancelUnbondingDelegation {
-  option (cosmos.msg.v1.signer) = "delegator_address";
-  option (amino.name) = "cosmos-sdk/MsgCancelUnbondingDelegation";
-  option (gogoproto.equal) = false;
+  option (cosmos.msg.v1.signer)      = "delegator_address";
+  option (amino.name)                = "cosmos-sdk/MsgCancelUnbondingDelegation";
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   string delegator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   string validator_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // amount is always less than or equal to unbonding delegation entry balance
-  cosmos.base.v1beta1.Coin amount = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  cosmos.base.v1beta1.Coin amount = 3 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // creation_height is the height which the unbonding took place.
   int64 creation_height = 4;
 }
@@ -217,17 +189,15 @@ message MsgCancelUnbondingDelegationResponse {}
 // Since: cosmos-sdk 0.47
 message MsgUpdateParams {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/x/staking/MsgUpdateParams";
+  option (amino.name)           = "cosmos-sdk/x/staking/MsgUpdateParams";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // params defines the x/staking parameters to update.
   //
   // NOTE: All parameters must be supplied.
-  Params params = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a

--- a/lib/cosmos-sdk/proto/cosmos/tx/config/v1/config.proto
+++ b/lib/cosmos-sdk/proto/cosmos/tx/config/v1/config.proto
@@ -6,14 +6,15 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Config is the config object of the x/auth/tx package.
 message Config {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/auth/tx"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/auth/tx"
+  };
 
-  // skip_ante_handler defines whether the ante handler registration should be skipped in case an app wants to override
-  // this functionality.
+  // skip_ante_handler defines whether the ante handler registration should be
+  // skipped in case an app wants to override this functionality.
   bool skip_ante_handler = 1;
 
-  // skip_post_handler defines whether the post handler registration should be skipped in case an app wants to override
-  // this functionality.
+  // skip_post_handler defines whether the post handler registration should be
+  // skipped in case an app wants to override this functionality.
   bool skip_post_handler = 2;
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/tx/signing/v1beta1/signing.proto
+++ b/lib/cosmos-sdk/proto/cosmos/tx/signing/v1beta1/signing.proto
@@ -70,13 +70,14 @@ message SignatureDescriptor {
   Data data = 2;
 
   // sequence is the sequence of the account, which describes the
-  // number of committed transactions signed by a given address. It is used to prevent
-  // replay attacks.
+  // number of committed transactions signed by a given address. It is used to
+  // prevent replay attacks.
   uint64 sequence = 3;
 
   // Data represents signature data
   message Data {
-    // sum is the oneof that specifies whether this represents single or multi-signature data
+    // sum is the oneof that specifies whether this represents single or
+    // multi-signature data
     oneof sum {
       // single represents a single signer
       Single single = 1;

--- a/lib/cosmos-sdk/proto/cosmos/tx/v1beta1/service.proto
+++ b/lib/cosmos-sdk/proto/cosmos/tx/v1beta1/service.proto
@@ -88,7 +88,8 @@ message GetTxsEventRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 2 [deprecated = true];
 
   OrderBy order_by = 3;
-  // page is the page number to query, starts at 1. If not provided, will default to first page.
+  // page is the page number to query, starts at 1. If not provided, will default
+  // to first page.
   uint64 page = 4;
   // limit is the total number of results to be returned in the result page.
   // If left empty it will default to a value to be set by each app.
@@ -97,7 +98,8 @@ message GetTxsEventRequest {
 
 // OrderBy defines the sorting order
 enum OrderBy {
-  // ORDER_BY_UNSPECIFIED specifies an unknown sorting order. OrderBy defaults to ASC in this case.
+  // ORDER_BY_UNSPECIFIED specifies an unknown sorting order. OrderBy defaults to
+  // ASC in this case.
   ORDER_BY_UNSPECIFIED = 0;
   // ORDER_BY_ASC defines ascending order
   ORDER_BY_ASC = 1;
@@ -123,19 +125,20 @@ message GetTxsEventResponse {
 // RPC method.
 message BroadcastTxRequest {
   // tx_bytes is the raw transaction.
-  bytes tx_bytes = 1;
-  BroadcastMode mode = 2;
+  bytes         tx_bytes = 1;
+  BroadcastMode mode     = 2;
 }
 
-// BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC method.
+// BroadcastMode specifies the broadcast mode for the TxService.Broadcast RPC
+// method.
 enum BroadcastMode {
   // zero-value for mode ordering
   BROADCAST_MODE_UNSPECIFIED = 0;
   // DEPRECATED: use BROADCAST_MODE_SYNC instead,
   // BROADCAST_MODE_BLOCK is not supported by the SDK from v0.47.x onwards.
   BROADCAST_MODE_BLOCK = 1 [deprecated = true];
-  // BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits for
-  // a CheckTx execution response only.
+  // BROADCAST_MODE_SYNC defines a tx broadcasting mode where the client waits
+  // for a CheckTx execution response only.
   BROADCAST_MODE_SYNC = 2;
   // BROADCAST_MODE_ASYNC defines a tx broadcasting mode where the client returns
   // immediately.
@@ -196,14 +199,15 @@ message GetBlockWithTxsRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
 
-// GetBlockWithTxsResponse is the response type for the Service.GetBlockWithTxs method.
+// GetBlockWithTxsResponse is the response type for the Service.GetBlockWithTxs
+// method.
 //
 // Since: cosmos-sdk 0.45.2
 message GetBlockWithTxsResponse {
   // txs are the transactions in the block.
-  repeated cosmos.tx.v1beta1.Tx txs = 1;
-  .tendermint.types.BlockID block_id = 2;
-  .tendermint.types.Block block = 3;
+  repeated cosmos.tx.v1beta1.Tx txs      = 1;
+  .tendermint.types.BlockID     block_id = 2;
+  .tendermint.types.Block       block    = 3;
   // pagination defines a pagination for the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 4;
 }

--- a/lib/cosmos-sdk/proto/cosmos/tx/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/tx/v1beta1/tx.proto
@@ -109,7 +109,8 @@ message TxBody {
 
   // memo is any arbitrary note/comment to be added to the transaction.
   // WARNING: in clients, any publicly exposed text should not be called memo,
-  // but should be called `note` instead (see https://github.com/cosmos/cosmos-sdk/issues/9122).
+  // but should be called `note` instead (see
+  // https://github.com/cosmos/cosmos-sdk/issues/9122).
   string memo = 2;
 
   // timeout is the block height after which this transaction will not
@@ -206,7 +207,7 @@ message ModeInfo {
 message Fee {
   // amount is the amount of coins to be paid as a fee
   repeated cosmos.base.v1beta1.Coin amount = 1 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)     = false,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 
@@ -214,14 +215,16 @@ message Fee {
   // before an out of gas error occurs
   uint64 gas_limit = 2;
 
-  // if unset, the first signer is responsible for paying the fees. If set, the specified account must pay the fees.
-  // the payer must be a tx signer (and thus have signed this field in AuthInfo).
-  // setting this field does *not* change the ordering of required signers for the transaction.
+  // if unset, the first signer is responsible for paying the fees. If set, the
+  // specified account must pay the fees. the payer must be a tx signer (and thus
+  // have signed this field in AuthInfo). setting this field does *not* change
+  // the ordering of required signers for the transaction.
   string payer = 3 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
-  // if set, the fee payer (either the first signer or the value of the payer field) requests that a fee grant be used
-  // to pay fees instead of the fee payer's own balance. If an appropriate fee grant does not exist or the chain does
-  // not support fee grants, this will fail
+  // if set, the fee payer (either the first signer or the value of the payer
+  // field) requests that a fee grant be used to pay fees instead of the fee
+  // payer's own balance. If an appropriate fee grant does not exist or the chain
+  // does not support fee grants, this will fail
   string granter = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
 
@@ -231,7 +234,7 @@ message Fee {
 message Tip {
   // amount is the amount of the tip
   repeated cosmos.base.v1beta1.Coin amount = 1 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)     = false,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
   // tipper is the address of the account paying for the tip

--- a/lib/cosmos-sdk/proto/cosmos/upgrade/module/v1/module.proto
+++ b/lib/cosmos-sdk/proto/cosmos/upgrade/module/v1/module.proto
@@ -6,9 +6,11 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the upgrade module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/upgrade"};
+  option (cosmos.app.v1alpha1.module) = {
+    go_import: "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/upgrade"
+  };
 
-  // authority defines the custom module authority. If not set, defaults to the governance module.
+  // authority defines the custom module authority. If not set, defaults to the
+  // governance module.
   string authority = 1;
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/upgrade/v1beta1/query.proto
+++ b/lib/cosmos-sdk/proto/cosmos/upgrade/v1beta1/query.proto
@@ -24,8 +24,9 @@ service Query {
   // UpgradedConsensusState RPC not supported with legacy querier
   // This rpc is deprecated now that IBC has its own replacement
   // (https://github.com/cosmos/ibc-go/blob/2c880a22e9f9cc75f62b527ca94aa75ce1106001/proto/ibc/core/client/v1/query.proto#L54)
-  rpc UpgradedConsensusState(QueryUpgradedConsensusStateRequest) returns (QueryUpgradedConsensusStateResponse) {
-    option deprecated = true;
+  rpc UpgradedConsensusState(QueryUpgradedConsensusStateRequest)
+      returns (QueryUpgradedConsensusStateResponse) {
+    option deprecated            = true;
     option (google.api.http).get = "/cosmos/upgrade/v1beta1/upgraded_consensus_state/{last_height}";
   }
 
@@ -69,8 +70,8 @@ message QueryAppliedPlanResponse {
   int64 height = 1;
 }
 
-// QueryUpgradedConsensusStateRequest is the request type for the Query/UpgradedConsensusState
-// RPC method.
+// QueryUpgradedConsensusStateRequest is the request type for the
+// Query/UpgradedConsensusState RPC method.
 message QueryUpgradedConsensusStateRequest {
   option deprecated = true;
 
@@ -79,8 +80,8 @@ message QueryUpgradedConsensusStateRequest {
   int64 last_height = 1;
 }
 
-// QueryUpgradedConsensusStateResponse is the response type for the Query/UpgradedConsensusState
-// RPC method.
+// QueryUpgradedConsensusStateResponse is the response type for the
+// Query/UpgradedConsensusState RPC method.
 message QueryUpgradedConsensusStateResponse {
   option deprecated = true;
   reserved 1;
@@ -120,4 +121,3 @@ message QueryAuthorityRequest {}
 message QueryAuthorityResponse {
   string address = 1;
 }
-

--- a/lib/cosmos-sdk/proto/cosmos/upgrade/v1beta1/tx.proto
+++ b/lib/cosmos-sdk/proto/cosmos/upgrade/v1beta1/tx.proto
@@ -31,16 +31,14 @@ service Msg {
 // Since: cosmos-sdk 0.46
 message MsgSoftwareUpgrade {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/MsgSoftwareUpgrade";
+  option (amino.name)           = "cosmos-sdk/MsgSoftwareUpgrade";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // plan is the upgrade plan.
-  Plan plan = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Plan plan = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgSoftwareUpgradeResponse is the Msg/SoftwareUpgrade response type.
@@ -53,9 +51,10 @@ message MsgSoftwareUpgradeResponse {}
 // Since: cosmos-sdk 0.46
 message MsgCancelUpgrade {
   option (cosmos.msg.v1.signer) = "authority";
-  option (amino.name) = "cosmos-sdk/MsgCancelUpgrade";
+  option (amino.name)           = "cosmos-sdk/MsgCancelUpgrade";
 
-  // authority is the address that controls the module (defaults to x/gov unless overwritten).
+  // authority is the address that controls the module (defaults to x/gov unless
+  // overwritten).
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
 

--- a/lib/cosmos-sdk/proto/cosmos/upgrade/v1beta1/upgrade.proto
+++ b/lib/cosmos-sdk/proto/cosmos/upgrade/v1beta1/upgrade.proto
@@ -12,8 +12,8 @@ option (gogoproto.goproto_getters_all) = false;
 
 // Plan specifies information about a planned upgrade and when it should occur.
 message Plan {
-  option (amino.name) = "cosmos-sdk/Plan";
-  option (gogoproto.equal) = true;
+  option (amino.name)                 = "cosmos-sdk/Plan";
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = false;
 
   // Sets the name for the upgrade. This name will be used by the upgraded
@@ -25,13 +25,13 @@ message Plan {
   // reached and the software will exit.
   string name = 1;
 
-  // Deprecated: Time based upgrades have been deprecated. Time based upgrade logic
-  // has been removed from the SDK.
-  // If this field is not empty, an error will be thrown.
+  // Deprecated: Time based upgrades have been deprecated. Time based upgrade
+  // logic has been removed from the SDK. If this field is not empty, an error
+  // will be thrown.
   google.protobuf.Timestamp time = 2 [
-    deprecated = true,
-    (gogoproto.stdtime) = true,
-    (gogoproto.nullable) = false,
+    deprecated             = true,
+    (gogoproto.stdtime)    = true,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
 
@@ -42,9 +42,9 @@ message Plan {
   // such as a git commit that validators could automatically upgrade to
   string info = 4;
 
-  // Deprecated: UpgradedClientState field has been deprecated. IBC upgrade logic has been
-  // moved to the IBC module in the sub module 02-client.
-  // If this field is not empty, an error will be thrown.
+  // Deprecated: UpgradedClientState field has been deprecated. IBC upgrade logic
+  // has been moved to the IBC module in the sub module 02-client. If this field
+  // is not empty, an error will be thrown.
   google.protobuf.Any upgraded_client_state = 5 [deprecated = true];
 }
 
@@ -53,11 +53,11 @@ message Plan {
 // Deprecated: This legacy proposal is deprecated in favor of Msg-based gov
 // proposals, see MsgSoftwareUpgrade.
 message SoftwareUpgradeProposal {
-  option deprecated = true;
+  option deprecated                          = true;
   option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
-  option (amino.name) = "cosmos-sdk/SoftwareUpgradeProposal";
-  option (gogoproto.equal) = true;
-  option (gogoproto.goproto_stringer) = false;
+  option (amino.name)                        = "cosmos-sdk/SoftwareUpgradeProposal";
+  option (gogoproto.equal)                   = true;
+  option (gogoproto.goproto_stringer)        = false;
 
   // title of the proposal
   string title = 1;
@@ -66,10 +66,7 @@ message SoftwareUpgradeProposal {
   string description = 2;
 
   // plan of the proposal
-  Plan plan = 3 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true
-  ];
+  Plan plan = 3 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // CancelSoftwareUpgradeProposal is a gov Content type for cancelling a software
@@ -77,11 +74,11 @@ message SoftwareUpgradeProposal {
 // Deprecated: This legacy proposal is deprecated in favor of Msg-based gov
 // proposals, see MsgCancelUpgrade.
 message CancelSoftwareUpgradeProposal {
-  option deprecated = true;
+  option deprecated                          = true;
   option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
-  option (amino.name) = "cosmos-sdk/CancelSoftwareUpgradeProposal";
-  option (gogoproto.equal) = true;
-  option (gogoproto.goproto_stringer) = false;
+  option (amino.name)                        = "cosmos-sdk/CancelSoftwareUpgradeProposal";
+  option (gogoproto.equal)                   = true;
+  option (gogoproto.goproto_stringer)        = false;
 
   // title of the proposal
   string title = 1;
@@ -94,7 +91,7 @@ message CancelSoftwareUpgradeProposal {
 //
 // Since: cosmos-sdk 0.43
 message ModuleVersion {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = true;
 
   // name of the app module

--- a/lib/cosmos-sdk/proto/tendermint/abci/types.proto
+++ b/lib/cosmos-sdk/proto/tendermint/abci/types.proto
@@ -55,8 +55,8 @@ message RequestInfo {
 }
 
 message RequestInitChain {
-  google.protobuf.Timestamp        time             = 1 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
-  string                           chain_id         = 2;
+  google.protobuf.Timestamp time     = 1 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  string                    chain_id = 2;
   tendermint.types.ConsensusParams consensus_params = 3;
   repeated ValidatorUpdate         validators       = 4 [(gogoproto.nullable) = false];
   bytes                            app_state_bytes  = 5;
@@ -102,8 +102,8 @@ message RequestListSnapshots {}
 
 // offers a snapshot to the application
 message RequestOfferSnapshot {
-  Snapshot snapshot = 1; // snapshot offered by peers
-  bytes    app_hash = 2; // light client-verified app hash for snapshot height
+  Snapshot snapshot = 1;  // snapshot offered by peers
+  bytes    app_hash = 2;  // light client-verified app hash for snapshot height
 }
 
 // loads a snapshot chunk
@@ -125,11 +125,11 @@ message RequestPrepareProposal {
   int64 max_tx_bytes = 1;
   // txs is an array of transactions that will be included in a block,
   // sent to the app for possible modifications.
-  repeated bytes            txs                  = 2;
-  ExtendedCommitInfo        local_last_commit    = 3 [(gogoproto.nullable) = false];
-  repeated Misbehavior      misbehavior          = 4 [(gogoproto.nullable) = false];
-  int64                     height               = 5;
-  google.protobuf.Timestamp time                 = 6 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  repeated bytes            txs               = 2;
+  ExtendedCommitInfo        local_last_commit = 3 [(gogoproto.nullable) = false];
+  repeated Misbehavior      misbehavior       = 4 [(gogoproto.nullable) = false];
+  int64                     height            = 5;
+  google.protobuf.Timestamp time = 6 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
   bytes                     next_validators_hash = 7;
   // address of the public key of the validator proposing the block.
   bytes proposer_address = 8;
@@ -140,9 +140,9 @@ message RequestProcessProposal {
   CommitInfo           proposed_last_commit = 2 [(gogoproto.nullable) = false];
   repeated Misbehavior misbehavior          = 3 [(gogoproto.nullable) = false];
   // hash is the merkle root hash of the fields of the proposed block.
-  bytes                     hash                 = 4;
-  int64                     height               = 5;
-  google.protobuf.Timestamp time                 = 6 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  bytes                     hash   = 4;
+  int64                     height = 5;
+  google.protobuf.Timestamp time   = 6 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
   bytes                     next_validators_hash = 7;
   // address of the public key of the original proposer of the block.
   bytes proposer_address = 8;
@@ -204,8 +204,8 @@ message ResponseInitChain {
 message ResponseQuery {
   uint32 code = 1;
   // bytes data = 2; // use "value" instead.
-  string                     log       = 3; // nondeterministic
-  string                     info      = 4; // nondeterministic
+  string                     log       = 3;  // nondeterministic
+  string                     info      = 4;  // nondeterministic
   int64                      index     = 5;
   bytes                      key       = 6;
   bytes                      value     = 7;
@@ -215,20 +215,22 @@ message ResponseQuery {
 }
 
 message ResponseBeginBlock {
-  repeated Event events = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
+  repeated Event events = 1
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
 }
 
 message ResponseCheckTx {
   uint32         code       = 1;
   bytes          data       = 2;
-  string         log        = 3; // nondeterministic
-  string         info       = 4; // nondeterministic
+  string         log        = 3;  // nondeterministic
+  string         info       = 4;  // nondeterministic
   int64          gas_wanted = 5 [json_name = "gas_wanted"];
   int64          gas_used   = 6 [json_name = "gas_used"];
-  repeated Event events     = 7 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
-  string         codespace  = 8;
-  string         sender     = 9;
-  int64          priority   = 10;
+  repeated Event events     = 7
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
+  string codespace = 8;
+  string sender    = 9;
+  int64  priority  = 10;
 
   // mempool_error is set by CometBFT.
   // ABCI applictions creating a ResponseCheckTX should not set mempool_error.
@@ -238,20 +240,21 @@ message ResponseCheckTx {
 message ResponseDeliverTx {
   uint32         code       = 1;
   bytes          data       = 2;
-  string         log        = 3; // nondeterministic
-  string         info       = 4; // nondeterministic
+  string         log        = 3;  // nondeterministic
+  string         info       = 4;  // nondeterministic
   int64          gas_wanted = 5 [json_name = "gas_wanted"];
   int64          gas_used   = 6 [json_name = "gas_used"];
   repeated Event events     = 7
       [(gogoproto.nullable) = false,
-       (gogoproto.jsontag)  = "events,omitempty"]; // nondeterministic
+       (gogoproto.jsontag)  = "events,omitempty"];  // nondeterministic
   string codespace = 8;
 }
 
 message ResponseEndBlock {
   repeated ValidatorUpdate         validator_updates       = 1 [(gogoproto.nullable) = false];
   tendermint.types.ConsensusParams consensus_param_updates = 2;
-  repeated Event                   events = 3 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
+  repeated Event                   events                  = 3
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "events,omitempty"];
 }
 
 message ResponseCommit {
@@ -268,12 +271,12 @@ message ResponseOfferSnapshot {
   Result result = 1;
 
   enum Result {
-    UNKNOWN       = 0; // Unknown result, abort all snapshot restoration
-    ACCEPT        = 1; // Snapshot accepted, apply chunks
-    ABORT         = 2; // Abort all snapshot restoration
-    REJECT        = 3; // Reject this specific snapshot, try others
-    REJECT_FORMAT = 4; // Reject all snapshots of this format, try others
-    REJECT_SENDER = 5; // Reject all snapshots from the sender(s), try others
+    UNKNOWN       = 0;  // Unknown result, abort all snapshot restoration
+    ACCEPT        = 1;  // Snapshot accepted, apply chunks
+    ABORT         = 2;  // Abort all snapshot restoration
+    REJECT        = 3;  // Reject this specific snapshot, try others
+    REJECT_FORMAT = 4;  // Reject all snapshots of this format, try others
+    REJECT_SENDER = 5;  // Reject all snapshots from the sender(s), try others
   }
 }
 
@@ -283,16 +286,16 @@ message ResponseLoadSnapshotChunk {
 
 message ResponseApplySnapshotChunk {
   Result          result         = 1;
-  repeated uint32 refetch_chunks = 2; // Chunks to refetch and reapply
-  repeated string reject_senders = 3; // Chunk senders to reject and ban
+  repeated uint32 refetch_chunks = 2;  // Chunks to refetch and reapply
+  repeated string reject_senders = 3;  // Chunk senders to reject and ban
 
   enum Result {
-    UNKNOWN         = 0; // Unknown result, abort all snapshot restoration
-    ACCEPT          = 1; // Chunk successfully accepted
-    ABORT           = 2; // Abort all snapshot restoration
-    RETRY           = 3; // Retry chunk (combine with refetch and reject)
-    RETRY_SNAPSHOT  = 4; // Retry snapshot (combine with refetch and reject)
-    REJECT_SNAPSHOT = 5; // Reject this snapshot, try others
+    UNKNOWN         = 0;  // Unknown result, abort all snapshot restoration
+    ACCEPT          = 1;  // Chunk successfully accepted
+    ABORT           = 2;  // Abort all snapshot restoration
+    RETRY           = 3;  // Retry chunk (combine with refetch and reject)
+    RETRY_SNAPSHOT  = 4;  // Retry snapshot (combine with refetch and reject)
+    REJECT_SNAPSHOT = 5;  // Reject this snapshot, try others
   }
 }
 
@@ -331,14 +334,15 @@ message ExtendedCommitInfo {
 // Later, transactions may be queried using these events.
 message Event {
   string                  type       = 1;
-  repeated EventAttribute attributes = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "attributes,omitempty"];
+  repeated EventAttribute attributes = 2
+      [(gogoproto.nullable) = false, (gogoproto.jsontag) = "attributes,omitempty"];
 }
 
 // EventAttribute is a single key-value pair, associated with an event.
 message EventAttribute {
   string key   = 1;
   string value = 2;
-  bool   index = 3; // nondeterministic
+  bool   index = 3;  // nondeterministic
 }
 
 // TxResult contains results of executing the transaction.
@@ -356,9 +360,9 @@ message TxResult {
 
 // Validator
 message Validator {
-  bytes address = 1; // The first 20 bytes of SHA256(public key)
+  bytes address = 1;  // The first 20 bytes of SHA256(public key)
   // PubKey pub_key = 2 [(gogoproto.nullable)=false];
-  int64 power = 3; // The voting power
+  int64 power = 3;  // The voting power
 }
 
 // ValidatorUpdate
@@ -376,7 +380,7 @@ message VoteInfo {
 message ExtendedVoteInfo {
   Validator validator         = 1 [(gogoproto.nullable) = false];
   bool      signed_last_block = 2;
-  bytes     vote_extension    = 3; // Reserved for future use
+  bytes     vote_extension    = 3;  // Reserved for future use
 }
 
 enum MisbehaviorType {
@@ -403,11 +407,11 @@ message Misbehavior {
 // State Sync Types
 
 message Snapshot {
-  uint64 height   = 1; // The height at which the snapshot was taken
-  uint32 format   = 2; // The application-specific snapshot format
-  uint32 chunks   = 3; // Number of chunks in the snapshot
-  bytes  hash     = 4; // Arbitrary snapshot hash, equal only if identical
-  bytes  metadata = 5; // Arbitrary application metadata
+  uint64 height   = 1;  // The height at which the snapshot was taken
+  uint32 format   = 2;  // The application-specific snapshot format
+  uint32 chunks   = 3;  // Number of chunks in the snapshot
+  bytes  hash     = 4;  // Arbitrary snapshot hash, equal only if identical
+  bytes  metadata = 5;  // Arbitrary application metadata
 }
 
 //----------------------------------------

--- a/lib/cosmos-sdk/proto/tendermint/types/evidence.proto
+++ b/lib/cosmos-sdk/proto/tendermint/types/evidence.proto
@@ -15,22 +15,26 @@ message Evidence {
   }
 }
 
-// DuplicateVoteEvidence contains evidence of a validator signed two conflicting votes.
+// DuplicateVoteEvidence contains evidence of a validator signed two conflicting
+// votes.
 message DuplicateVoteEvidence {
   tendermint.types.Vote     vote_a             = 1;
   tendermint.types.Vote     vote_b             = 2;
   int64                     total_voting_power = 3;
   int64                     validator_power    = 4;
-  google.protobuf.Timestamp timestamp          = 5 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  google.protobuf.Timestamp timestamp          = 5
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
 }
 
-// LightClientAttackEvidence contains evidence of a set of validators attempting to mislead a light client.
+// LightClientAttackEvidence contains evidence of a set of validators attempting
+// to mislead a light client.
 message LightClientAttackEvidence {
   tendermint.types.LightBlock conflicting_block            = 1;
   int64                       common_height                = 2;
   repeated tendermint.types.Validator byzantine_validators = 3;
   int64                               total_voting_power   = 4;
-  google.protobuf.Timestamp           timestamp = 5 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  google.protobuf.Timestamp           timestamp            = 5
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
 }
 
 message EvidenceList {

--- a/lib/cosmos-sdk/proto/tendermint/types/params.proto
+++ b/lib/cosmos-sdk/proto/tendermint/types/params.proto
@@ -26,7 +26,8 @@ message BlockParams {
   // Note: must be greater or equal to -1
   int64 max_gas = 2;
 
-  reserved 3; // was TimeIotaMs see https://github.com/cometbft/cometbft/pull/5792
+  reserved 3;  // was TimeIotaMs see
+               // https://github.com/cometbft/cometbft/pull/5792
 }
 
 // EvidenceParams determine how we handle evidence of malfeasance.
@@ -42,10 +43,11 @@ message EvidenceParams {
   // It should correspond with an app's "unbonding period" or other similar
   // mechanism for handling [Nothing-At-Stake
   // attacks](https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed).
-  google.protobuf.Duration max_age_duration = 2 [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
+  google.protobuf.Duration max_age_duration = 2
+      [(gogoproto.nullable) = false, (gogoproto.stdduration) = true];
 
-  // This sets the maximum size of total evidence in bytes that can be committed in a single block.
-  // and should fall comfortably under the max block bytes.
+  // This sets the maximum size of total evidence in bytes that can be committed
+  // in a single block. and should fall comfortably under the max block bytes.
   // Default is 1048576 or 1MB
   int64 max_bytes = 3;
 }

--- a/lib/cosmos-sdk/proto/tendermint/types/types.proto
+++ b/lib/cosmos-sdk/proto/tendermint/types/types.proto
@@ -60,25 +60,25 @@ message Header {
   tendermint.version.Consensus version  = 1 [(gogoproto.nullable) = false];
   string                       chain_id = 2 [(gogoproto.customname) = "ChainID"];
   int64                        height   = 3;
-  google.protobuf.Timestamp    time     = 4 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  google.protobuf.Timestamp    time = 4 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
 
   // prev block info
   BlockID last_block_id = 5 [(gogoproto.nullable) = false];
 
   // hashes of block data
-  bytes last_commit_hash = 6; // commit from validators from the last block
-  bytes data_hash        = 7; // transactions
+  bytes last_commit_hash = 6;  // commit from validators from the last block
+  bytes data_hash        = 7;  // transactions
 
   // hashes from the app output from the prev block
-  bytes validators_hash      = 8;  // validators for the current block
-  bytes next_validators_hash = 9;  // validators for the next block
-  bytes consensus_hash       = 10; // consensus params for current block
-  bytes app_hash             = 11; // state after txs from the previous block
-  bytes last_results_hash    = 12; // root hash of all results from the txs from the previous block
+  bytes validators_hash      = 8;   // validators for the current block
+  bytes next_validators_hash = 9;   // validators for the next block
+  bytes consensus_hash       = 10;  // consensus params for current block
+  bytes app_hash             = 11;  // state after txs from the previous block
+  bytes last_results_hash    = 12;  // root hash of all results from the txs from the previous block
 
   // consensus info
-  bytes evidence_hash    = 13; // evidence included in the block
-  bytes proposer_address = 14; // original proposer of the block
+  bytes evidence_hash    = 13;  // evidence included in the block
+  bytes proposer_address = 14;  // original proposer of the block
 }
 
 // Data contains the set of transactions included in the block
@@ -95,18 +95,22 @@ message Vote {
   SignedMsgType type     = 1;
   int64         height   = 2;
   int32         round    = 3;
-  BlockID       block_id = 4 [(gogoproto.nullable) = false, (gogoproto.customname) = "BlockID"]; // zero if vote is nil.
-  google.protobuf.Timestamp timestamp         = 5 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
-  bytes                     validator_address = 6;
-  int32                     validator_index   = 7;
-  bytes                     signature         = 8;
+  BlockID       block_id = 4
+      [(gogoproto.nullable)   = false,
+       (gogoproto.customname) = "BlockID"];  // zero if vote is nil.
+  google.protobuf.Timestamp timestamp = 5
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  bytes validator_address = 6;
+  int32 validator_index   = 7;
+  bytes signature         = 8;
 }
 
-// Commit contains the evidence that a block was committed by a set of validators.
+// Commit contains the evidence that a block was committed by a set of
+// validators.
 message Commit {
-  int64              height     = 1;
-  int32              round      = 2;
-  BlockID            block_id   = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "BlockID"];
+  int64   height   = 1;
+  int32   round    = 2;
+  BlockID block_id = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "BlockID"];
   repeated CommitSig signatures = 4 [(gogoproto.nullable) = false];
 }
 
@@ -114,18 +118,20 @@ message Commit {
 message CommitSig {
   BlockIDFlag               block_id_flag     = 1;
   bytes                     validator_address = 2;
-  google.protobuf.Timestamp timestamp         = 3 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
-  bytes                     signature         = 4;
+  google.protobuf.Timestamp timestamp         = 3
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  bytes signature = 4;
 }
 
 message Proposal {
-  SignedMsgType             type      = 1;
-  int64                     height    = 2;
-  int32                     round     = 3;
-  int32                     pol_round = 4;
-  BlockID                   block_id  = 5 [(gogoproto.customname) = "BlockID", (gogoproto.nullable) = false];
-  google.protobuf.Timestamp timestamp = 6 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
-  bytes                     signature = 7;
+  SignedMsgType type      = 1;
+  int64         height    = 2;
+  int32         round     = 3;
+  int32         pol_round = 4;
+  BlockID       block_id  = 5 [(gogoproto.customname) = "BlockID", (gogoproto.nullable) = false];
+  google.protobuf.Timestamp timestamp = 6
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  bytes signature = 7;
 }
 
 message SignedHeader {
@@ -145,7 +151,8 @@ message BlockMeta {
   int64   num_txs    = 4;
 }
 
-// TxProof represents a Merkle proof of the presence of a transaction in the Merkle tree.
+// TxProof represents a Merkle proof of the presence of a transaction in the
+// Merkle tree.
 message TxProof {
   bytes                   root_hash = 1;
   bytes                   data      = 2;

--- a/lib/cosmos-sdk/proto/tendermint/version/types.proto
+++ b/lib/cosmos-sdk/proto/tendermint/version/types.proto
@@ -13,9 +13,9 @@ message App {
   string software = 2;
 }
 
-// Consensus captures the consensus rules for processing a block in the blockchain,
-// including all blockchain data structures and the rules of the application's
-// state transition machine.
+// Consensus captures the consensus rules for processing a block in the
+// blockchain, including all blockchain data structures and the rules of the
+// application's state transition machine.
 message Consensus {
   option (gogoproto.equal) = true;
 

--- a/lib/cosmos-sdk/testutil/testdata/testpb/query.proto
+++ b/lib/cosmos-sdk/testutil/testdata/testpb/query.proto
@@ -14,26 +14,14 @@ service Query {
   rpc TestAny(TestAnyRequest) returns (TestAnyResponse);
 }
 
-message EchoRequest {
-  string message = 1;
-}
+message EchoRequest { string message = 1; }
 
-message EchoResponse {
-  string message = 1;
-}
+message EchoResponse { string message = 1; }
 
-message SayHelloRequest {
-  string name = 1;
-}
+message SayHelloRequest { string name = 1; }
 
-message SayHelloResponse {
-  string greeting = 1;
-}
+message SayHelloResponse { string greeting = 1; }
 
-message TestAnyRequest {
-  google.protobuf.Any any_animal = 1;
-}
+message TestAnyRequest { google.protobuf.Any any_animal = 1; }
 
-message TestAnyResponse {
-  testpb.HasAnimal has_animal = 1;
-}
+message TestAnyResponse { testpb.HasAnimal has_animal = 1; }

--- a/lib/cosmos-sdk/testutil/testdata/testpb/testdata.proto
+++ b/lib/cosmos-sdk/testutil/testdata/testpb/testdata.proto
@@ -26,13 +26,9 @@ message HasAnimal {
   int64 x = 2;
 }
 
-message HasHasAnimal {
-  google.protobuf.Any has_animal = 1;
-}
+message HasHasAnimal { google.protobuf.Any has_animal = 1; }
 
-message HasHasHasAnimal {
-  google.protobuf.Any has_has_animal = 1;
-}
+message HasHasHasAnimal { google.protobuf.Any has_has_animal = 1; }
 
 // bad MultiSignature with extra fields
 message BadMultiSignature {

--- a/lib/cosmos-sdk/testutil/testdata/testpb/tx.proto
+++ b/lib/cosmos-sdk/testutil/testdata/testpb/tx.proto
@@ -8,17 +8,11 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/testutil/te
 
 // Msg tests the Protobuf message service as defined in
 // https://github.com/cosmos/cosmos-sdk/issues/7500.
-service Msg {
-  rpc CreateDog(MsgCreateDog) returns (MsgCreateDogResponse);
-}
+service Msg { rpc CreateDog(MsgCreateDog) returns (MsgCreateDogResponse); }
 
-message MsgCreateDog {
-  testpb.Dog dog = 1;
-}
+message MsgCreateDog { testpb.Dog dog = 1; }
 
-message MsgCreateDogResponse {
-  string name = 1;
-}
+message MsgCreateDogResponse { string name = 1; }
 
 // TestMsg is msg type for testing protobuf message using any, as defined in
 // https://github.com/cosmos/cosmos-sdk/issues/6213.

--- a/lib/cosmos-sdk/testutil/testdata/testpb/unknonwnproto.proto
+++ b/lib/cosmos-sdk/testutil/testdata/testpb/unknonwnproto.proto
@@ -103,9 +103,10 @@ message Customer3 {
 message TestVersion1 {
   int64 x = 1;
   TestVersion1 a = 2;
-  TestVersion1 b = 3; // [(gogoproto.nullable) = false] generates invalid recursive structs;
+  TestVersion1 b =
+      3; // [(gogoproto.nullable) = false] generates invalid recursive structs;
   repeated TestVersion1 c = 4;
-  repeated TestVersion1 d = 5 [(gogoproto.nullable) = false];
+  repeated TestVersion1 d = 5 [ (gogoproto.nullable) = false ];
   oneof sum {
     int32 e = 6;
     TestVersion1 f = 7;
@@ -114,7 +115,7 @@ message TestVersion1 {
   repeated TestVersion1 h = 9; // [(gogoproto.castrepeated) = "TestVersion1"];
   // google.protobuf.Timestamp i = 10;
   // google.protobuf.Timestamp j = 11; // [(gogoproto.stdtime) = true];
-  Customer1 k = 12 [(gogoproto.embed) = true];
+  Customer1 k = 12 [ (gogoproto.embed) = true ];
 }
 message TestVersion2 {
   int64 x = 1;
@@ -130,7 +131,7 @@ message TestVersion2 {
   repeated TestVersion1 h = 9; // [(gogoproto.castrepeated) = "TestVersion1"];
   // google.protobuf.Timestamp i = 10;
   // google.protobuf.Timestamp j = 11; // [(gogoproto.stdtime) = true];
-  Customer1 k = 12 [(gogoproto.embed) = true];
+  Customer1 k = 12 [ (gogoproto.embed) = true ];
   uint64 new_field = 25;
 }
 message TestVersion3 {
@@ -147,7 +148,7 @@ message TestVersion3 {
   repeated TestVersion1 h = 9; //[(gogoproto.castrepeated) = "TestVersion1"];
   // google.protobuf.Timestamp i = 10;
   // google.protobuf.Timestamp j = 11; // [(gogoproto.stdtime) = true];
-  Customer1 k = 12 [(gogoproto.embed) = true];
+  Customer1 k = 12 [ (gogoproto.embed) = true ];
   string non_critical_field = 1031;
 }
 
@@ -157,14 +158,12 @@ message TestVersion3LoneOneOfValue {
   TestVersion3 b = 3; // [(gogoproto.nullable) = false];
   repeated TestVersion3 c = 4;
   repeated TestVersion3 d = 5; // [(gogoproto.nullable) = false];
-  oneof sum {
-    int32 e = 6;
-  }
+  oneof sum { int32 e = 6; }
   google.protobuf.Any g = 8;
   repeated TestVersion1 h = 9; //[(gogoproto.castrepeated) = "TestVersion1"];
   // google.protobuf.Timestamp i = 10;
   // google.protobuf.Timestamp j = 11; // [(gogoproto.stdtime) = true];
-  Customer1 k = 12 [(gogoproto.embed) = true];
+  Customer1 k = 12 [ (gogoproto.embed) = true ];
   string non_critical_field = 1031;
 }
 
@@ -174,14 +173,12 @@ message TestVersion3LoneNesting {
   TestVersion3 b = 3; // [(gogoproto.nullable) = false];
   repeated TestVersion3 c = 4;
   repeated TestVersion3 d = 5; // [(gogoproto.nullable) = false];
-  oneof sum {
-    TestVersion3LoneNesting f = 7;
-  }
+  oneof sum { TestVersion3LoneNesting f = 7; }
   google.protobuf.Any g = 8;
   repeated TestVersion1 h = 9; //[(gogoproto.castrepeated) = "TestVersion1"];
   // google.protobuf.Timestamp i = 10;
   // google.protobuf.Timestamp j = 11; // [(gogoproto.stdtime) = true];
-  Customer1 k = 12 [(gogoproto.embed) = true];
+  Customer1 k = 12 [ (gogoproto.embed) = true ];
   string non_critical_field = 1031;
 
   message Inner1 {
@@ -215,14 +212,12 @@ message TestVersion4LoneNesting {
   TestVersion3 b = 3; // [(gogoproto.nullable) = false];
   repeated TestVersion3 c = 4;
   repeated TestVersion3 d = 5; // [(gogoproto.nullable) = false];
-  oneof sum {
-    TestVersion3LoneNesting f = 7;
-  }
+  oneof sum { TestVersion3LoneNesting f = 7; }
   google.protobuf.Any g = 8;
   repeated TestVersion1 h = 9; //[(gogoproto.castrepeated) = "TestVersion1"];
   // google.protobuf.Timestamp i = 10;
   // google.protobuf.Timestamp j = 11; // [(gogoproto.stdtime) = true];
-  Customer1 k = 12 [(gogoproto.embed) = true];
+  Customer1 k = 12 [ (gogoproto.embed) = true ];
   string non_critical_field = 1031;
 
   message Inner1 {
@@ -273,7 +268,7 @@ message TestVersionFD1WithExtraAny {
 }
 
 message AnyWithExtra {
-  google.protobuf.Any a = 1 [(gogoproto.embed) = true];
+  google.protobuf.Any a = 1 [ (gogoproto.embed) = true ];
   int64 b = 3;
   int64 c = 4;
 }
@@ -303,6 +298,4 @@ message TestUpdatedAuthInfo {
   bytes new_field_1024 = 1024;
 }
 
-message TestRepeatedUints {
-  repeated uint64 nums = 1;
-}
+message TestRepeatedUints { repeated uint64 nums = 1; }

--- a/lib/ibc-go/proto/ibc/applications/interchain_accounts/controller/v1/query.proto
+++ b/lib/ibc-go/proto/ibc/applications/interchain_accounts/controller/v1/query.proto
@@ -10,7 +10,8 @@ import "google/api/annotations.proto";
 
 // Query provides defines the gRPC querier service.
 service Query {
-  // InterchainAccount returns the interchain account address for a given owner address on a given connection
+  // InterchainAccount returns the interchain account address for a given owner
+  // address on a given connection
   rpc InterchainAccount(QueryInterchainAccountRequest) returns (QueryInterchainAccountResponse) {
     option (google.api.http).get =
         "/ibc/apps/interchain_accounts/controller/v1/owners/{owner}/connections/{connection_id}";
@@ -22,13 +23,15 @@ service Query {
   }
 }
 
-// QueryInterchainAccountRequest is the request type for the Query/InterchainAccount RPC method.
+// QueryInterchainAccountRequest is the request type for the
+// Query/InterchainAccount RPC method.
 message QueryInterchainAccountRequest {
   string owner         = 1;
   string connection_id = 2 [(gogoproto.moretags) = "yaml:\"connection_id\""];
 }
 
-// QueryInterchainAccountResponse the response type for the Query/InterchainAccount RPC method.
+// QueryInterchainAccountResponse the response type for the
+// Query/InterchainAccount RPC method.
 message QueryInterchainAccountResponse {
   string address = 1;
 }

--- a/lib/ibc-go/proto/ibc/applications/interchain_accounts/controller/v1/tx.proto
+++ b/lib/ibc-go/proto/ibc/applications/interchain_accounts/controller/v1/tx.proto
@@ -10,8 +10,10 @@ import "ibc/core/channel/v1/channel.proto";
 
 // Msg defines the 27-interchain-accounts/controller Msg service.
 service Msg {
-  // RegisterInterchainAccount defines a rpc handler for MsgRegisterInterchainAccount.
-  rpc RegisterInterchainAccount(MsgRegisterInterchainAccount) returns (MsgRegisterInterchainAccountResponse);
+  // RegisterInterchainAccount defines a rpc handler for
+  // MsgRegisterInterchainAccount.
+  rpc RegisterInterchainAccount(MsgRegisterInterchainAccount)
+      returns (MsgRegisterInterchainAccountResponse);
   // SendTx defines a rpc handler for MsgSendTx.
   rpc SendTx(MsgSendTx) returns (MsgSendTxResponse);
 }
@@ -27,7 +29,8 @@ message MsgRegisterInterchainAccount {
   ibc.core.channel.v1.Order ordering      = 4;
 }
 
-// MsgRegisterInterchainAccountResponse defines the response for Msg/RegisterAccount
+// MsgRegisterInterchainAccountResponse defines the response for
+// Msg/RegisterAccount
 message MsgRegisterInterchainAccountResponse {
   string channel_id = 1 [(gogoproto.moretags) = "yaml:\"channel_id\""];
   string port_id    = 2 [(gogoproto.moretags) = "yaml:\"port_id\""];
@@ -42,8 +45,8 @@ message MsgSendTx {
   string connection_id = 2 [(gogoproto.moretags) = "yaml:\"connection_id\""];
   ibc.applications.interchain_accounts.v1.InterchainAccountPacketData packet_data = 3
       [(gogoproto.moretags) = "yaml:\"packet_data\"", (gogoproto.nullable) = false];
-  // Relative timeout timestamp provided will be added to the current block time during transaction execution.
-  // The timeout timestamp must be non-zero.
+  // Relative timeout timestamp provided will be added to the current block time
+  // during transaction execution. The timeout timestamp must be non-zero.
   uint64 relative_timeout = 4 [(gogoproto.moretags) = "yaml:\"relative_timeout\""];
 }
 

--- a/lib/ibc-go/proto/ibc/applications/interchain_accounts/genesis/v1/genesis.proto
+++ b/lib/ibc-go/proto/ibc/applications/interchain_accounts/genesis/v1/genesis.proto
@@ -16,14 +16,16 @@ message GenesisState {
       [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"host_genesis_state\""];
 }
 
-// ControllerGenesisState defines the interchain accounts controller genesis state
+// ControllerGenesisState defines the interchain accounts controller genesis
+// state
 message ControllerGenesisState {
   repeated ActiveChannel active_channels = 1
       [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"active_channels\""];
   repeated RegisteredInterchainAccount interchain_accounts = 2
       [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"interchain_accounts\""];
   repeated string                                           ports  = 3;
-  ibc.applications.interchain_accounts.controller.v1.Params params = 4 [(gogoproto.nullable) = false];
+  ibc.applications.interchain_accounts.controller.v1.Params params = 4
+      [(gogoproto.nullable) = false];
 }
 
 // HostGenesisState defines the interchain accounts host genesis state
@@ -36,8 +38,8 @@ message HostGenesisState {
   ibc.applications.interchain_accounts.host.v1.Params params = 4 [(gogoproto.nullable) = false];
 }
 
-// ActiveChannel contains a connection ID, port ID and associated active channel ID, as well as a boolean flag to
-// indicate if the channel is middleware enabled
+// ActiveChannel contains a connection ID, port ID and associated active channel
+// ID, as well as a boolean flag to indicate if the channel is middleware enabled
 message ActiveChannel {
   string connection_id         = 1 [(gogoproto.moretags) = "yaml:\"connection_id\""];
   string port_id               = 2 [(gogoproto.moretags) = "yaml:\"port_id\""];
@@ -45,7 +47,8 @@ message ActiveChannel {
   bool   is_middleware_enabled = 4 [(gogoproto.moretags) = "yaml:\"is_middleware_enabled\""];
 }
 
-// RegisteredInterchainAccount contains a connection ID, port ID and associated interchain account address
+// RegisteredInterchainAccount contains a connection ID, port ID and associated
+// interchain account address
 message RegisteredInterchainAccount {
   string connection_id   = 1 [(gogoproto.moretags) = "yaml:\"connection_id\""];
   string port_id         = 2 [(gogoproto.moretags) = "yaml:\"port_id\""];

--- a/lib/ibc-go/proto/ibc/applications/interchain_accounts/host/v1/host.proto
+++ b/lib/ibc-go/proto/ibc/applications/interchain_accounts/host/v1/host.proto
@@ -11,7 +11,8 @@ import "gogoproto/gogo.proto";
 message Params {
   // host_enabled enables or disables the host submodule.
   bool host_enabled = 1 [(gogoproto.moretags) = "yaml:\"host_enabled\""];
-  // allow_messages defines a list of sdk message typeURLs allowed to be executed on a host chain.
+  // allow_messages defines a list of sdk message typeURLs allowed to be executed
+  // on a host chain.
   repeated string allow_messages = 2 [(gogoproto.moretags) = "yaml:\"allow_messages\""];
 }
 

--- a/lib/ibc-go/proto/ibc/applications/interchain_accounts/v1/account.proto
+++ b/lib/ibc-go/proto/ibc/applications/interchain_accounts/v1/account.proto
@@ -8,11 +8,13 @@ import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 import "cosmos/auth/v1beta1/auth.proto";
 
-// An InterchainAccount is defined as a BaseAccount & the address of the account owner on the controller chain
+// An InterchainAccount is defined as a BaseAccount & the address of the account
+// owner on the controller chain
 message InterchainAccount {
-  option (gogoproto.goproto_getters)         = false;
-  option (gogoproto.goproto_stringer)        = false;
-  option (cosmos_proto.implements_interface) = "ibc.applications.interchain_accounts.v1.InterchainAccountI";
+  option (gogoproto.goproto_getters)  = false;
+  option (gogoproto.goproto_stringer) = false;
+  option (cosmos_proto.implements_interface) =
+      "ibc.applications.interchain_accounts.v1.InterchainAccountI";
 
   cosmos.auth.v1beta1.BaseAccount base_account = 1
       [(gogoproto.embed) = true, (gogoproto.moretags) = "yaml:\"base_account\""];

--- a/lib/ibc-go/proto/ibc/applications/interchain_accounts/v1/metadata.proto
+++ b/lib/ibc-go/proto/ibc/applications/interchain_accounts/v1/metadata.proto
@@ -6,17 +6,21 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/ibc-go/modules/apps/27
 
 import "gogoproto/gogo.proto";
 
-// Metadata defines a set of protocol specific data encoded into the ICS27 channel version bytestring
-// See ICS004: https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#Versioning
+// Metadata defines a set of protocol specific data encoded into the ICS27
+// channel version bytestring See ICS004:
+// https://github.com/cosmos/ibc/tree/master/spec/core/ics-004-channel-and-packet-semantics#Versioning
 message Metadata {
   // version defines the ICS27 protocol version
   string version = 1;
-  // controller_connection_id is the connection identifier associated with the controller chain
+  // controller_connection_id is the connection identifier associated with the
+  // controller chain
   string controller_connection_id = 2 [(gogoproto.moretags) = "yaml:\"controller_connection_id\""];
-  // host_connection_id is the connection identifier associated with the host chain
+  // host_connection_id is the connection identifier associated with the host
+  // chain
   string host_connection_id = 3 [(gogoproto.moretags) = "yaml:\"host_connection_id\""];
-  // address defines the interchain account address to be fulfilled upon the OnChanOpenTry handshake step
-  // NOTE: the address field is empty on the OnChanOpenInit handshake step
+  // address defines the interchain account address to be fulfilled upon the
+  // OnChanOpenTry handshake step NOTE: the address field is empty on the
+  // OnChanOpenInit handshake step
   string address = 4;
   // encoding defines the supported codec format
   string encoding = 5;

--- a/lib/ibc-go/proto/ibc/applications/interchain_accounts/v1/packet.proto
+++ b/lib/ibc-go/proto/ibc/applications/interchain_accounts/v1/packet.proto
@@ -7,8 +7,8 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/ibc-go/modules/apps/27
 import "google/protobuf/any.proto";
 import "gogoproto/gogo.proto";
 
-// Type defines a classification of message issued from a controller chain to its associated interchain accounts
-// host
+// Type defines a classification of message issued from a controller chain to its
+// associated interchain accounts host
 enum Type {
   option (gogoproto.goproto_enum_prefix) = false;
 
@@ -18,14 +18,16 @@ enum Type {
   TYPE_EXECUTE_TX = 1 [(gogoproto.enumvalue_customname) = "EXECUTE_TX"];
 }
 
-// InterchainAccountPacketData is comprised of a raw transaction, type of transaction and optional memo field.
+// InterchainAccountPacketData is comprised of a raw transaction, type of
+// transaction and optional memo field.
 message InterchainAccountPacketData {
   Type   type = 1;
   bytes  data = 2;
   string memo = 3;
 }
 
-// CosmosTx contains a list of sdk.Msg's. It should be used when sending transactions to an SDK host chain.
+// CosmosTx contains a list of sdk.Msg's. It should be used when sending
+// transactions to an SDK host chain.
 message CosmosTx {
   repeated google.protobuf.Any messages = 1;
 }

--- a/lib/ibc-go/proto/ibc/applications/transfer/v1/authz.proto
+++ b/lib/ibc-go/proto/ibc/applications/transfer/v1/authz.proto
@@ -16,7 +16,7 @@ message Allocation {
   string source_channel = 2 [(gogoproto.moretags) = "yaml:\"source_channel\""];
   // spend limitation on the channel
   repeated cosmos.base.v1beta1.Coin spend_limit = 3 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)     = false,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
   // allow list of receivers, an empty allow list permits any receiver address

--- a/lib/ibc-go/proto/ibc/applications/transfer/v1/genesis.proto
+++ b/lib/ibc-go/proto/ibc/applications/transfer/v1/genesis.proto
@@ -10,18 +10,18 @@ option go_package = "github.com/NibiruChain/nibiru/v2/lib/ibc-go/modules/apps/tr
 
 // GenesisState defines the ibc-transfer genesis state
 message GenesisState {
-  string port_id = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
+  string              port_id      = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
   repeated DenomTrace denom_traces = 2 [
     (gogoproto.castrepeated) = "Traces",
-    (gogoproto.nullable) = false,
-    (gogoproto.moretags) = "yaml:\"denom_traces\""
+    (gogoproto.nullable)     = false,
+    (gogoproto.moretags)     = "yaml:\"denom_traces\""
   ];
   Params params = 3 [(gogoproto.nullable) = false];
   // total_escrowed contains the total amount of tokens escrowed
   // by the transfer module
   repeated cosmos.base.v1beta1.Coin total_escrowed = 4 [
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins",
-    (gogoproto.nullable) = false,
-    (gogoproto.moretags) = "yaml:\"total_escrowed\""
+    (gogoproto.nullable)     = false,
+    (gogoproto.moretags)     = "yaml:\"total_escrowed\""
   ];
 }

--- a/lib/ibc-go/proto/ibc/applications/transfer/v1/query.proto
+++ b/lib/ibc-go/proto/ibc/applications/transfer/v1/query.proto
@@ -32,13 +32,17 @@ service Query {
     option (google.api.http).get = "/ibc/apps/transfer/v1/denom_hashes/{trace=**}";
   }
 
-  // EscrowAddress returns the escrow address for a particular port and channel id.
+  // EscrowAddress returns the escrow address for a particular port and channel
+  // id.
   rpc EscrowAddress(QueryEscrowAddressRequest) returns (QueryEscrowAddressResponse) {
-    option (google.api.http).get = "/ibc/apps/transfer/v1/channels/{channel_id}/ports/{port_id}/escrow_address";
+    option (google.api.http).get =
+        "/ibc/apps/transfer/v1/channels/{channel_id}/ports/{port_id}/escrow_address";
   }
 
-  // TotalEscrowForDenom returns the total amount of tokens in escrow based on the denom.
-  rpc TotalEscrowForDenom(QueryTotalEscrowForDenomRequest) returns (QueryTotalEscrowForDenomResponse) {
+  // TotalEscrowForDenom returns the total amount of tokens in escrow based on
+  // the denom.
+  rpc TotalEscrowForDenom(QueryTotalEscrowForDenomRequest)
+      returns (QueryTotalEscrowForDenomResponse) {
     option (google.api.http).get = "/ibc/apps/transfer/v1/denoms/{denom=**}/total_escrow";
   }
 }
@@ -46,7 +50,8 @@ service Query {
 // QueryDenomTraceRequest is the request type for the Query/DenomTrace RPC
 // method
 message QueryDenomTraceRequest {
-  // hash (in hex format) or denom (full denom with ibc prefix) of the denomination trace information.
+  // hash (in hex format) or denom (full denom with ibc prefix) of the
+  // denomination trace information.
   string hash = 1;
 }
 
@@ -68,7 +73,8 @@ message QueryDenomTracesRequest {
 // method.
 message QueryDenomTracesResponse {
   // denom_traces returns all denominations trace information.
-  repeated DenomTrace denom_traces = 1 [(gogoproto.castrepeated) = "Traces", (gogoproto.nullable) = false];
+  repeated DenomTrace denom_traces = 1
+      [(gogoproto.castrepeated) = "Traces", (gogoproto.nullable) = false];
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
@@ -96,7 +102,8 @@ message QueryDenomHashResponse {
   string hash = 1;
 }
 
-// QueryEscrowAddressRequest is the request type for the EscrowAddress RPC method.
+// QueryEscrowAddressRequest is the request type for the EscrowAddress RPC
+// method.
 message QueryEscrowAddressRequest {
   // unique port identifier
   string port_id = 1;
@@ -104,18 +111,21 @@ message QueryEscrowAddressRequest {
   string channel_id = 2;
 }
 
-// QueryEscrowAddressResponse is the response type of the EscrowAddress RPC method.
+// QueryEscrowAddressResponse is the response type of the EscrowAddress RPC
+// method.
 message QueryEscrowAddressResponse {
   // the escrow account address
   string escrow_address = 1;
 }
 
-// QueryTotalEscrowForDenomRequest is the request type for TotalEscrowForDenom RPC method.
+// QueryTotalEscrowForDenomRequest is the request type for TotalEscrowForDenom
+// RPC method.
 message QueryTotalEscrowForDenomRequest {
   string denom = 1;
 }
 
-// QueryTotalEscrowForDenomResponse is the response type for TotalEscrowForDenom RPC method.
+// QueryTotalEscrowForDenomResponse is the response type for TotalEscrowForDenom
+// RPC method.
 message QueryTotalEscrowForDenomResponse {
   cosmos.base.v1beta1.Coin amount = 1 [(gogoproto.nullable) = false];
 }

--- a/lib/ibc-go/proto/ibc/core/channel/v1/genesis.proto
+++ b/lib/ibc-go/proto/ibc/core/channel/v1/genesis.proto
@@ -9,11 +9,12 @@ import "ibc/core/channel/v1/channel.proto";
 
 // GenesisState defines the ibc channel submodule's genesis state.
 message GenesisState {
-  repeated IdentifiedChannel channels = 1 [(gogoproto.casttype) = "IdentifiedChannel", (gogoproto.nullable) = false];
-  repeated PacketState       acknowledgements = 2 [(gogoproto.nullable) = false];
-  repeated PacketState       commitments      = 3 [(gogoproto.nullable) = false];
-  repeated PacketState       receipts         = 4 [(gogoproto.nullable) = false];
-  repeated PacketSequence    send_sequences   = 5
+  repeated IdentifiedChannel channels = 1
+      [(gogoproto.casttype) = "IdentifiedChannel", (gogoproto.nullable) = false];
+  repeated PacketState    acknowledgements = 2 [(gogoproto.nullable) = false];
+  repeated PacketState    commitments      = 3 [(gogoproto.nullable) = false];
+  repeated PacketState    receipts         = 4 [(gogoproto.nullable) = false];
+  repeated PacketSequence send_sequences   = 5
       [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"send_sequences\""];
   repeated PacketSequence recv_sequences = 6
       [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"recv_sequences\""];

--- a/lib/ibc-go/proto/ibc/core/channel/v1/query.proto
+++ b/lib/ibc-go/proto/ibc/core/channel/v1/query.proto
@@ -38,7 +38,8 @@ service Query {
 
   // ChannelConsensusState queries for the consensus state for the channel
   // associated with the provided channel identifiers.
-  rpc ChannelConsensusState(QueryChannelConsensusStateRequest) returns (QueryChannelConsensusStateResponse) {
+  rpc ChannelConsensusState(QueryChannelConsensusStateRequest)
+      returns (QueryChannelConsensusStateResponse) {
     option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
                                    "ports/{port_id}/consensus_state/revision/"
                                    "{revision_number}/height/{revision_height}";
@@ -65,14 +66,16 @@ service Query {
   }
 
   // PacketAcknowledgement queries a stored packet acknowledgement hash.
-  rpc PacketAcknowledgement(QueryPacketAcknowledgementRequest) returns (QueryPacketAcknowledgementResponse) {
+  rpc PacketAcknowledgement(QueryPacketAcknowledgementRequest)
+      returns (QueryPacketAcknowledgementResponse) {
     option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
                                    "ports/{port_id}/packet_acks/{sequence}";
   }
 
   // PacketAcknowledgements returns all the packet acknowledgements associated
   // with a channel.
-  rpc PacketAcknowledgements(QueryPacketAcknowledgementsRequest) returns (QueryPacketAcknowledgementsResponse) {
+  rpc PacketAcknowledgements(QueryPacketAcknowledgementsRequest)
+      returns (QueryPacketAcknowledgementsResponse) {
     option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
                                    "ports/{port_id}/packet_acknowledgements";
   }
@@ -94,7 +97,8 @@ service Query {
   }
 
   // NextSequenceReceive returns the next receive sequence for a given channel.
-  rpc NextSequenceReceive(QueryNextSequenceReceiveRequest) returns (QueryNextSequenceReceiveResponse) {
+  rpc NextSequenceReceive(QueryNextSequenceReceiveRequest)
+      returns (QueryNextSequenceReceiveResponse) {
     option (google.api.http).get = "/ibc/core/channel/v1/channels/{channel_id}/"
                                    "ports/{port_id}/next_sequence";
   }

--- a/lib/ibc-go/proto/ibc/core/channel/v1/tx.proto
+++ b/lib/ibc-go/proto/ibc/core/channel/v1/tx.proto
@@ -48,7 +48,8 @@ enum ResponseResultType {
 
   // Default zero value enumeration
   RESPONSE_RESULT_TYPE_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "UNSPECIFIED"];
-  // The message did not call the IBC application callbacks (because, for example, the packet had already been relayed)
+  // The message did not call the IBC application callbacks (because, for
+  // example, the packet had already been relayed)
   RESPONSE_RESULT_TYPE_NOOP = 1 [(gogoproto.enumvalue_customname) = "NOOP"];
   // The message was executed successfully
   RESPONSE_RESULT_TYPE_SUCCESS = 2 [(gogoproto.enumvalue_customname) = "SUCCESS"];
@@ -72,20 +73,23 @@ message MsgChannelOpenInitResponse {
 }
 
 // MsgChannelOpenInit defines a msg sent by a Relayer to try to open a channel
-// on Chain B. The version field within the Channel field has been deprecated. Its
-// value will be ignored by core IBC.
+// on Chain B. The version field within the Channel field has been deprecated.
+// Its value will be ignored by core IBC.
 message MsgChannelOpenTry {
   option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   string port_id = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
-  // Deprecated: this field is unused. Crossing hello's are no longer supported in core IBC.
-  string previous_channel_id = 2 [deprecated = true, (gogoproto.moretags) = "yaml:\"previous_channel_id\""];
-  // NOTE: the version field within the channel has been deprecated. Its value will be ignored by core IBC.
-  Channel                   channel              = 3 [(gogoproto.nullable) = false];
-  string                    counterparty_version = 4 [(gogoproto.moretags) = "yaml:\"counterparty_version\""];
-  bytes                     proof_init           = 5 [(gogoproto.moretags) = "yaml:\"proof_init\""];
-  ibc.core.client.v1.Height proof_height         = 6
+  // Deprecated: this field is unused. Crossing hello's are no longer supported
+  // in core IBC.
+  string previous_channel_id = 2
+      [deprecated = true, (gogoproto.moretags) = "yaml:\"previous_channel_id\""];
+  // NOTE: the version field within the channel has been deprecated. Its value
+  // will be ignored by core IBC.
+  Channel channel              = 3 [(gogoproto.nullable) = false];
+  string  counterparty_version = 4 [(gogoproto.moretags) = "yaml:\"counterparty_version\""];
+  bytes   proof_init           = 5 [(gogoproto.moretags) = "yaml:\"proof_init\""];
+  ibc.core.client.v1.Height proof_height = 6
       [(gogoproto.moretags) = "yaml:\"proof_height\"", (gogoproto.nullable) = false];
   string signer = 7;
 }
@@ -102,12 +106,12 @@ message MsgChannelOpenAck {
   option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string                    port_id                 = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
-  string                    channel_id              = 2 [(gogoproto.moretags) = "yaml:\"channel_id\""];
-  string                    counterparty_channel_id = 3 [(gogoproto.moretags) = "yaml:\"counterparty_channel_id\""];
-  string                    counterparty_version    = 4 [(gogoproto.moretags) = "yaml:\"counterparty_version\""];
-  bytes                     proof_try               = 5 [(gogoproto.moretags) = "yaml:\"proof_try\""];
-  ibc.core.client.v1.Height proof_height            = 6
+  string port_id                 = 1 [(gogoproto.moretags) = "yaml:\"port_id\""];
+  string channel_id              = 2 [(gogoproto.moretags) = "yaml:\"channel_id\""];
+  string counterparty_channel_id = 3 [(gogoproto.moretags) = "yaml:\"counterparty_channel_id\""];
+  string counterparty_version    = 4 [(gogoproto.moretags) = "yaml:\"counterparty_version\""];
+  bytes  proof_try               = 5 [(gogoproto.moretags) = "yaml:\"proof_try\""];
+  ibc.core.client.v1.Height proof_height = 6
       [(gogoproto.moretags) = "yaml:\"proof_height\"", (gogoproto.nullable) = false];
   string signer = 7;
 }
@@ -170,9 +174,9 @@ message MsgRecvPacket {
   option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  Packet                    packet           = 1 [(gogoproto.nullable) = false];
-  bytes                     proof_commitment = 2 [(gogoproto.moretags) = "yaml:\"proof_commitment\""];
-  ibc.core.client.v1.Height proof_height     = 3
+  Packet packet                          = 1 [(gogoproto.nullable) = false];
+  bytes  proof_commitment                = 2 [(gogoproto.moretags) = "yaml:\"proof_commitment\""];
+  ibc.core.client.v1.Height proof_height = 3
       [(gogoproto.moretags) = "yaml:\"proof_height\"", (gogoproto.nullable) = false];
   string signer = 4;
 }
@@ -189,9 +193,9 @@ message MsgTimeout {
   option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  Packet                    packet           = 1 [(gogoproto.nullable) = false];
-  bytes                     proof_unreceived = 2 [(gogoproto.moretags) = "yaml:\"proof_unreceived\""];
-  ibc.core.client.v1.Height proof_height     = 3
+  Packet packet                          = 1 [(gogoproto.nullable) = false];
+  bytes  proof_unreceived                = 2 [(gogoproto.moretags) = "yaml:\"proof_unreceived\""];
+  ibc.core.client.v1.Height proof_height = 3
       [(gogoproto.moretags) = "yaml:\"proof_height\"", (gogoproto.nullable) = false];
   uint64 next_sequence_recv = 4 [(gogoproto.moretags) = "yaml:\"next_sequence_recv\""];
   string signer             = 5;
@@ -209,10 +213,10 @@ message MsgTimeoutOnClose {
   option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  Packet                    packet           = 1 [(gogoproto.nullable) = false];
-  bytes                     proof_unreceived = 2 [(gogoproto.moretags) = "yaml:\"proof_unreceived\""];
-  bytes                     proof_close      = 3 [(gogoproto.moretags) = "yaml:\"proof_close\""];
-  ibc.core.client.v1.Height proof_height     = 4
+  Packet packet                          = 1 [(gogoproto.nullable) = false];
+  bytes  proof_unreceived                = 2 [(gogoproto.moretags) = "yaml:\"proof_unreceived\""];
+  bytes  proof_close                     = 3 [(gogoproto.moretags) = "yaml:\"proof_close\""];
+  ibc.core.client.v1.Height proof_height = 4
       [(gogoproto.moretags) = "yaml:\"proof_height\"", (gogoproto.nullable) = false];
   uint64 next_sequence_recv = 5 [(gogoproto.moretags) = "yaml:\"next_sequence_recv\""];
   string signer             = 6;

--- a/lib/ibc-go/proto/ibc/core/client/v1/client.proto
+++ b/lib/ibc-go/proto/ibc/core/client/v1/client.proto
@@ -38,9 +38,10 @@ message ClientConsensusStates {
 }
 
 // ClientUpdateProposal is a governance proposal. If it passes, the substitute
-// client's latest consensus state is copied over to the subject client. The proposal
-// handler may fail if the subject and the substitute do not match in client and
-// chain parameters (with exception to latest height, frozen height, and chain-id).
+// client's latest consensus state is copied over to the subject client. The
+// proposal handler may fail if the subject and the substitute do not match in
+// client and chain parameters (with exception to latest height, frozen height,
+// and chain-id).
 message ClientUpdateProposal {
   option (gogoproto.goproto_getters)         = false;
   option (cosmos_proto.implements_interface) = "cosmos.gov.v1beta1.Content";
@@ -73,7 +74,8 @@ message UpgradeProposal {
   // new upgraded client is valid by verifying a proof on the previous version
   // of the chain. This will allow IBC connections to persist smoothly across
   // planned chain upgrades
-  google.protobuf.Any upgraded_client_state = 4 [(gogoproto.moretags) = "yaml:\"upgraded_client_state\""];
+  google.protobuf.Any upgraded_client_state = 4
+      [(gogoproto.moretags) = "yaml:\"upgraded_client_state\""];
 }
 
 // Height is a monotonically increasing data type
@@ -98,8 +100,9 @@ message Height {
 
 // Params defines the set of IBC light client parameters.
 message Params {
-  // allowed_clients defines the list of allowed client state types which can be created
-  // and interacted with. If a client type is removed from the allowed clients list, usage
-  // of this client will be disabled until it is added again to the list.
+  // allowed_clients defines the list of allowed client state types which can be
+  // created and interacted with. If a client type is removed from the allowed
+  // clients list, usage of this client will be disabled until it is added again
+  // to the list.
   repeated string allowed_clients = 1 [(gogoproto.moretags) = "yaml:\"allowed_clients\""];
 }

--- a/lib/ibc-go/proto/ibc/core/client/v1/query.proto
+++ b/lib/ibc-go/proto/ibc/core/client/v1/query.proto
@@ -36,8 +36,10 @@ service Query {
     option (google.api.http).get = "/ibc/core/client/v1/consensus_states/{client_id}";
   }
 
-  // ConsensusStateHeights queries the height of every consensus states associated with a given client.
-  rpc ConsensusStateHeights(QueryConsensusStateHeightsRequest) returns (QueryConsensusStateHeightsResponse) {
+  // ConsensusStateHeights queries the height of every consensus states
+  // associated with a given client.
+  rpc ConsensusStateHeights(QueryConsensusStateHeightsRequest)
+      returns (QueryConsensusStateHeightsResponse) {
     option (google.api.http).get = "/ibc/core/client/v1/consensus_states/{client_id}/heights";
   }
 
@@ -52,12 +54,14 @@ service Query {
   }
 
   // UpgradedClientState queries an Upgraded IBC light client.
-  rpc UpgradedClientState(QueryUpgradedClientStateRequest) returns (QueryUpgradedClientStateResponse) {
+  rpc UpgradedClientState(QueryUpgradedClientStateRequest)
+      returns (QueryUpgradedClientStateResponse) {
     option (google.api.http).get = "/ibc/core/client/v1/upgraded_client_states";
   }
 
   // UpgradedConsensusState queries an Upgraded IBC consensus state.
-  rpc UpgradedConsensusState(QueryUpgradedConsensusStateRequest) returns (QueryUpgradedConsensusStateResponse) {
+  rpc UpgradedConsensusState(QueryUpgradedConsensusStateRequest)
+      returns (QueryUpgradedConsensusStateResponse) {
     option (google.api.http).get = "/ibc/core/client/v1/upgraded_consensus_states";
   }
 }
@@ -142,8 +146,8 @@ message QueryConsensusStatesResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// QueryConsensusStateHeightsRequest is the request type for Query/ConsensusStateHeights
-// RPC method.
+// QueryConsensusStateHeightsRequest is the request type for
+// Query/ConsensusStateHeights RPC method.
 message QueryConsensusStateHeightsRequest {
   // client identifier
   string client_id = 1;

--- a/lib/ibc-go/proto/ibc/core/client/v1/tx.proto
+++ b/lib/ibc-go/proto/ibc/core/client/v1/tx.proto
@@ -72,7 +72,8 @@ message MsgUpgradeClient {
   // proof that old chain committed to new client
   bytes proof_upgrade_client = 4 [(gogoproto.moretags) = "yaml:\"proof_upgrade_client\""];
   // proof that old chain committed to new consensus state
-  bytes proof_upgrade_consensus_state = 5 [(gogoproto.moretags) = "yaml:\"proof_upgrade_consensus_state\""];
+  bytes proof_upgrade_consensus_state = 5
+      [(gogoproto.moretags) = "yaml:\"proof_upgrade_consensus_state\""];
   // signer address
   string signer = 6;
 }

--- a/lib/ibc-go/proto/ibc/core/connection/v1/connection.proto
+++ b/lib/ibc-go/proto/ibc/core/connection/v1/connection.proto
@@ -107,8 +107,10 @@ message Version {
 
 // Params defines the set of Connection parameters.
 message Params {
-  // maximum expected time per block (in nanoseconds), used to enforce block delay. This parameter should reflect the
-  // largest amount of time that the chain might reasonably take to produce the next block under normal operating
+  // maximum expected time per block (in nanoseconds), used to enforce block
+  // delay. This parameter should reflect the largest amount of time that the
+  // chain might reasonably take to produce the next block under normal operating
   // conditions. A safe choice is 3-5x the expected time per block.
-  uint64 max_expected_time_per_block = 1 [(gogoproto.moretags) = "yaml:\"max_expected_time_per_block\""];
+  uint64 max_expected_time_per_block = 1
+      [(gogoproto.moretags) = "yaml:\"max_expected_time_per_block\""];
 }

--- a/lib/ibc-go/proto/ibc/core/connection/v1/query.proto
+++ b/lib/ibc-go/proto/ibc/core/connection/v1/query.proto
@@ -31,15 +31,19 @@ service Query {
 
   // ConnectionClientState queries the client state associated with the
   // connection.
-  rpc ConnectionClientState(QueryConnectionClientStateRequest) returns (QueryConnectionClientStateResponse) {
-    option (google.api.http).get = "/ibc/core/connection/v1/connections/{connection_id}/client_state";
+  rpc ConnectionClientState(QueryConnectionClientStateRequest)
+      returns (QueryConnectionClientStateResponse) {
+    option (google.api.http).get =
+        "/ibc/core/connection/v1/connections/{connection_id}/client_state";
   }
 
   // ConnectionConsensusState queries the consensus state associated with the
   // connection.
-  rpc ConnectionConsensusState(QueryConnectionConsensusStateRequest) returns (QueryConnectionConsensusStateResponse) {
-    option (google.api.http).get = "/ibc/core/connection/v1/connections/{connection_id}/consensus_state/"
-                                   "revision/{revision_number}/height/{revision_height}";
+  rpc ConnectionConsensusState(QueryConnectionConsensusStateRequest)
+      returns (QueryConnectionConsensusStateResponse) {
+    option (google.api.http).get =
+        "/ibc/core/connection/v1/connections/{connection_id}/consensus_state/"
+        "revision/{revision_number}/height/{revision_height}";
   }
 
   // ConnectionParams queries all parameters of the ibc connection submodule.
@@ -142,10 +146,12 @@ message QueryConnectionConsensusStateResponse {
   ibc.core.client.v1.Height proof_height = 4 [(gogoproto.nullable) = false];
 }
 
-// QueryConnectionParamsRequest is the request type for the Query/ConnectionParams RPC method.
+// QueryConnectionParamsRequest is the request type for the
+// Query/ConnectionParams RPC method.
 message QueryConnectionParamsRequest {}
 
-// QueryConnectionParamsResponse is the response type for the Query/ConnectionParams RPC method.
+// QueryConnectionParamsResponse is the response type for the
+// Query/ConnectionParams RPC method.
 message QueryConnectionParamsResponse {
   // params defines the parameters of the module.
   Params params = 1;

--- a/lib/ibc-go/proto/ibc/core/connection/v1/tx.proto
+++ b/lib/ibc-go/proto/ibc/core/connection/v1/tx.proto
@@ -49,13 +49,17 @@ message MsgConnectionOpenTry {
   option (gogoproto.goproto_getters) = false;
 
   string client_id = 1 [(gogoproto.moretags) = "yaml:\"client_id\""];
-  // Deprecated: this field is unused. Crossing hellos are no longer supported in core IBC.
-  string previous_connection_id = 2 [deprecated = true, (gogoproto.moretags) = "yaml:\"previous_connection_id\""];
-  google.protobuf.Any       client_state = 3 [deprecated = true, (gogoproto.moretags) = "yaml:\"client_state\""];
-  Counterparty              counterparty = 4 [(gogoproto.nullable) = false];
-  uint64                    delay_period = 5 [(gogoproto.moretags) = "yaml:\"delay_period\""];
-  repeated Version          counterparty_versions = 6 [(gogoproto.moretags) = "yaml:\"counterparty_versions\""];
-  ibc.core.client.v1.Height proof_height          = 7
+  // Deprecated: this field is unused. Crossing hellos are no longer supported in
+  // core IBC.
+  string previous_connection_id = 2
+      [deprecated = true, (gogoproto.moretags) = "yaml:\"previous_connection_id\""];
+  google.protobuf.Any client_state = 3
+      [deprecated = true, (gogoproto.moretags) = "yaml:\"client_state\""];
+  Counterparty     counterparty          = 4 [(gogoproto.nullable) = false];
+  uint64           delay_period          = 5 [(gogoproto.moretags) = "yaml:\"delay_period\""];
+  repeated Version counterparty_versions = 6
+      [(gogoproto.moretags) = "yaml:\"counterparty_versions\""];
+  ibc.core.client.v1.Height proof_height = 7
       [(gogoproto.moretags) = "yaml:\"proof_height\"", (gogoproto.nullable) = false];
   // proof of the initialization the connection on Chain A: `UNITIALIZED ->
   // INIT`
@@ -63,11 +67,15 @@ message MsgConnectionOpenTry {
   // proof of client state included in message
   bytes proof_client = 9 [deprecated = true, (gogoproto.moretags) = "yaml:\"proof_client\""];
   // proof of client consensus state
-  bytes                     proof_consensus = 10 [deprecated = true, (gogoproto.moretags) = "yaml:\"proof_consensus\""];
-  ibc.core.client.v1.Height consensus_height = 11
-      [deprecated = true, (gogoproto.moretags) = "yaml:\"consensus_height\"", (gogoproto.nullable) = false];
+  bytes proof_consensus = 10 [deprecated = true, (gogoproto.moretags) = "yaml:\"proof_consensus\""];
+  ibc.core.client.v1.Height consensus_height = 11 [
+    deprecated           = true,
+    (gogoproto.moretags) = "yaml:\"consensus_height\"",
+    (gogoproto.nullable) = false
+  ];
   string signer = 12;
-  // optional proof data for host state machines that are unable to introspect their own consensus state
+  // optional proof data for host state machines that are unable to introspect
+  // their own consensus state
   bytes host_consensus_state_proof = 13 [deprecated = true];
 }
 
@@ -80,11 +88,12 @@ message MsgConnectionOpenAck {
   option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string              connection_id              = 1 [(gogoproto.moretags) = "yaml:\"connection_id\""];
-  string              counterparty_connection_id = 2 [(gogoproto.moretags) = "yaml:\"counterparty_connection_id\""];
-  Version             version                    = 3;
-  google.protobuf.Any client_state               = 4 [(gogoproto.moretags) = "yaml:\"client_state\""];
-  ibc.core.client.v1.Height proof_height         = 5
+  string connection_id              = 1 [(gogoproto.moretags) = "yaml:\"connection_id\""];
+  string counterparty_connection_id = 2
+      [(gogoproto.moretags) = "yaml:\"counterparty_connection_id\""];
+  Version                   version      = 3;
+  google.protobuf.Any       client_state = 4 [(gogoproto.moretags) = "yaml:\"client_state\""];
+  ibc.core.client.v1.Height proof_height = 5
       [(gogoproto.moretags) = "yaml:\"proof_height\"", (gogoproto.nullable) = false];
   // proof of the initialization the connection on Chain B: `UNITIALIZED ->
   // TRYOPEN`
@@ -92,11 +101,12 @@ message MsgConnectionOpenAck {
   // proof of client state included in message
   bytes proof_client = 7 [(gogoproto.moretags) = "yaml:\"proof_client\""];
   // proof of client consensus state
-  bytes                     proof_consensus  = 8 [(gogoproto.moretags) = "yaml:\"proof_consensus\""];
+  bytes                     proof_consensus = 8 [(gogoproto.moretags) = "yaml:\"proof_consensus\""];
   ibc.core.client.v1.Height consensus_height = 9
       [(gogoproto.moretags) = "yaml:\"consensus_height\"", (gogoproto.nullable) = false];
   string signer = 10;
-  // optional proof data for host state machines that are unable to introspect their own consensus state
+  // optional proof data for host state machines that are unable to introspect
+  // their own consensus state
   bytes host_consensus_state_proof = 11;
 }
 

--- a/lib/ibc-go/proto/ibc/lightclients/solomachine/v2/solomachine.proto
+++ b/lib/ibc-go/proto/ibc/lightclients/solomachine/v2/solomachine.proto
@@ -20,7 +20,8 @@ message ClientState {
   ConsensusState consensus_state = 3 [(gogoproto.moretags) = "yaml:\"consensus_state\""];
   // when set to true, will allow governance to update a solo machine client.
   // The client will be unfrozen if it is frozen.
-  bool allow_update_after_proposal = 4 [(gogoproto.moretags) = "yaml:\"allow_update_after_proposal\""];
+  bool allow_update_after_proposal = 4
+      [(gogoproto.moretags) = "yaml:\"allow_update_after_proposal\""];
 }
 
 // ConsensusState defines a solo machine consensus state. The sequence of a

--- a/lib/ibc-go/proto/ibc/lightclients/tendermint/v1/tendermint.proto
+++ b/lib/ibc-go/proto/ibc/lightclients/tendermint/v1/tendermint.proto
@@ -19,11 +19,15 @@ message ClientState {
   option (gogoproto.goproto_getters) = false;
 
   string   chain_id    = 1;
-  Fraction trust_level = 2 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"trust_level\""];
+  Fraction trust_level = 2
+      [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"trust_level\""];
   // duration of the period since the LastestTimestamp during which the
   // submitted headers are valid for upgrade
-  google.protobuf.Duration trusting_period = 3
-      [(gogoproto.nullable) = false, (gogoproto.stdduration) = true, (gogoproto.moretags) = "yaml:\"trusting_period\""];
+  google.protobuf.Duration trusting_period = 3 [
+    (gogoproto.nullable)    = false,
+    (gogoproto.stdduration) = true,
+    (gogoproto.moretags)    = "yaml:\"trusting_period\""
+  ];
   // duration of the staking unbonding period
   google.protobuf.Duration unbonding_period = 4 [
     (gogoproto.nullable)    = false,
@@ -31,8 +35,11 @@ message ClientState {
     (gogoproto.moretags)    = "yaml:\"unbonding_period\""
   ];
   // defines how much new (untrusted) header's Time can drift into the future.
-  google.protobuf.Duration max_clock_drift = 5
-      [(gogoproto.nullable) = false, (gogoproto.stdduration) = true, (gogoproto.moretags) = "yaml:\"max_clock_drift\""];
+  google.protobuf.Duration max_clock_drift = 5 [
+    (gogoproto.nullable)    = false,
+    (gogoproto.stdduration) = true,
+    (gogoproto.moretags)    = "yaml:\"max_clock_drift\""
+  ];
   // Block height when the client was frozen due to a misbehaviour
   ibc.core.client.v1.Height frozen_height = 6
       [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"frozen_height\""];
@@ -41,7 +48,8 @@ message ClientState {
       [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"latest_height\""];
 
   // Proof specifications used in verifying counterparty state
-  repeated cosmos.ics23.v1.ProofSpec proof_specs = 8 [(gogoproto.moretags) = "yaml:\"proof_specs\""];
+  repeated cosmos.ics23.v1.ProofSpec proof_specs = 8
+      [(gogoproto.moretags) = "yaml:\"proof_specs\""];
 
   // Path at which next upgraded client will be committed.
   // Each element corresponds to the key for a single CommitmentProof in the
@@ -53,7 +61,8 @@ message ClientState {
   repeated string upgrade_path = 9 [(gogoproto.moretags) = "yaml:\"upgrade_path\""];
 
   // allow_update_after_expiry is deprecated
-  bool allow_update_after_expiry = 10 [deprecated = true, (gogoproto.moretags) = "yaml:\"allow_update_after_expiry\""];
+  bool allow_update_after_expiry = 10
+      [deprecated = true, (gogoproto.moretags) = "yaml:\"allow_update_after_expiry\""];
   // allow_update_after_misbehaviour is deprecated
   bool allow_update_after_misbehaviour = 11
       [deprecated = true, (gogoproto.moretags) = "yaml:\"allow_update_after_misbehaviour\""];
@@ -65,7 +74,8 @@ message ConsensusState {
 
   // timestamp that corresponds to the block height in which the ConsensusState
   // was stored.
-  google.protobuf.Timestamp timestamp = 1 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
+  google.protobuf.Timestamp timestamp = 1
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
   // commitment root (i.e app hash)
   ibc.core.commitment.v1.MerkleRoot root                 = 2 [(gogoproto.nullable) = false];
   bytes                             next_validators_hash = 3 [
@@ -81,8 +91,10 @@ message Misbehaviour {
 
   // ClientID is deprecated
   string client_id = 1 [deprecated = true, (gogoproto.moretags) = "yaml:\"client_id\""];
-  Header header_1  = 2 [(gogoproto.customname) = "Header1", (gogoproto.moretags) = "yaml:\"header_1\""];
-  Header header_2  = 3 [(gogoproto.customname) = "Header2", (gogoproto.moretags) = "yaml:\"header_2\""];
+  Header header_1  = 2
+      [(gogoproto.customname) = "Header1", (gogoproto.moretags) = "yaml:\"header_1\""];
+  Header header_2 = 3
+      [(gogoproto.customname) = "Header2", (gogoproto.moretags) = "yaml:\"header_2\""];
 }
 
 // Header defines the Tendermint client consensus Header.
@@ -101,10 +113,12 @@ message Header {
   .tendermint.types.SignedHeader signed_header = 1
       [(gogoproto.embed) = true, (gogoproto.moretags) = "yaml:\"signed_header\""];
 
-  .tendermint.types.ValidatorSet validator_set  = 2 [(gogoproto.moretags) = "yaml:\"validator_set\""];
-  ibc.core.client.v1.Height      trusted_height = 3
+  .tendermint.types.ValidatorSet validator_set = 2
+      [(gogoproto.moretags) = "yaml:\"validator_set\""];
+  ibc.core.client.v1.Height trusted_height = 3
       [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"trusted_height\""];
-  .tendermint.types.ValidatorSet trusted_validators = 4 [(gogoproto.moretags) = "yaml:\"trusted_validators\""];
+  .tendermint.types.ValidatorSet trusted_validators = 4
+      [(gogoproto.moretags) = "yaml:\"trusted_validators\""];
 }
 
 // Fraction defines the protobuf message type for tmmath.Fraction that only

--- a/proto/cosmwasm/wasm/v1/authz.proto
+++ b/proto/cosmwasm/wasm/v1/authz.proto
@@ -8,18 +8,18 @@ import "cosmwasm/wasm/v1/types.proto";
 import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
+option go_package                      = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
 option (gogoproto.goproto_getters_all) = false;
 
 // StoreCodeAuthorization defines authorization for wasm code upload.
 // Since: wasmd 0.42
 message StoreCodeAuthorization {
-  option (amino.name) = "wasm/StoreCodeAuthorization";
+  option (amino.name)                        = "wasm/StoreCodeAuthorization";
   option (cosmos_proto.implements_interface) = "cosmos.authz.v1beta1.Authorization";
 
   // Grants for code upload
   repeated CodeGrant grants = 1 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
 }
@@ -27,12 +27,12 @@ message StoreCodeAuthorization {
 // ContractExecutionAuthorization defines authorization for wasm execute.
 // Since: wasmd 0.30
 message ContractExecutionAuthorization {
-  option (amino.name) = "wasm/ContractExecutionAuthorization";
+  option (amino.name)                        = "wasm/ContractExecutionAuthorization";
   option (cosmos_proto.implements_interface) = "cosmos.authz.v1beta1.Authorization";
 
   // Grants for contract executions
   repeated ContractGrant grants = 1 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
 }
@@ -40,12 +40,12 @@ message ContractExecutionAuthorization {
 // ContractMigrationAuthorization defines authorization for wasm contract
 // migration. Since: wasmd 0.30
 message ContractMigrationAuthorization {
-  option (amino.name) = "wasm/ContractMigrationAuthorization";
+  option (amino.name)                        = "wasm/ContractMigrationAuthorization";
   option (cosmos_proto.implements_interface) = "cosmos.authz.v1beta1.Authorization";
 
   // Grants for contract migrations
   repeated ContractGrant grants = 1 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
 }
@@ -81,7 +81,7 @@ message ContractGrant {
 // MaxCallsLimit limited number of calls to the contract. No funds transferable.
 // Since: wasmd 0.30
 message MaxCallsLimit {
-  option (amino.name) = "wasm/MaxCallsLimit";
+  option (amino.name)                        = "wasm/MaxCallsLimit";
   option (cosmos_proto.implements_interface) = "cosmwasm.wasm.v1.ContractAuthzLimitX";
 
   // Remaining number that is decremented on each execution
@@ -91,13 +91,13 @@ message MaxCallsLimit {
 // MaxFundsLimit defines the maximal amounts that can be sent to the contract.
 // Since: wasmd 0.30
 message MaxFundsLimit {
-  option (amino.name) = "wasm/MaxFundsLimit";
+  option (amino.name)                        = "wasm/MaxFundsLimit";
   option (cosmos_proto.implements_interface) = "cosmwasm.wasm.v1.ContractAuthzLimitX";
 
   // Amounts is the maximal amount of tokens transferable to the contract.
   repeated cosmos.base.v1beta1.Coin amounts = 1 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -106,15 +106,15 @@ message MaxFundsLimit {
 // the maximal number of calls executable. Both need to remain >0 to be valid.
 // Since: wasmd 0.30
 message CombinedLimit {
-  option (amino.name) = "wasm/CombinedLimit";
+  option (amino.name)                        = "wasm/CombinedLimit";
   option (cosmos_proto.implements_interface) = "cosmwasm.wasm.v1.ContractAuthzLimitX";
 
   // Remaining number that is decremented on each execution
   uint64 calls_remaining = 1;
   // Amounts is the maximal amount of tokens transferable to the contract.
   repeated cosmos.base.v1beta1.Coin amounts = 2 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -123,7 +123,7 @@ message CombinedLimit {
 // message.
 // Since: wasmd 0.30
 message AllowAllMessagesFilter {
-  option (amino.name) = "wasm/AllowAllMessagesFilter";
+  option (amino.name)                        = "wasm/AllowAllMessagesFilter";
   option (cosmos_proto.implements_interface) = "cosmwasm.wasm.v1.ContractAuthzFilterX";
 }
 
@@ -131,7 +131,7 @@ message AllowAllMessagesFilter {
 // the json object to be executed.
 // Since: wasmd 0.30
 message AcceptedMessageKeysFilter {
-  option (amino.name) = "wasm/AcceptedMessageKeysFilter";
+  option (amino.name)                        = "wasm/AcceptedMessageKeysFilter";
   option (cosmos_proto.implements_interface) = "cosmwasm.wasm.v1.ContractAuthzFilterX";
 
   // Messages is the list of unique keys
@@ -142,7 +142,7 @@ message AcceptedMessageKeysFilter {
 // executed.
 // Since: wasmd 0.30
 message AcceptedMessagesFilter {
-  option (amino.name) = "wasm/AcceptedMessagesFilter";
+  option (amino.name)                        = "wasm/AcceptedMessagesFilter";
   option (cosmos_proto.implements_interface) = "cosmwasm.wasm.v1.ContractAuthzFilterX";
 
   // Messages is the list of raw contract messages

--- a/proto/cosmwasm/wasm/v1/authz.proto
+++ b/proto/cosmwasm/wasm/v1/authz.proto
@@ -18,10 +18,7 @@ message StoreCodeAuthorization {
   option (cosmos_proto.implements_interface) = "cosmos.authz.v1beta1.Authorization";
 
   // Grants for code upload
-  repeated CodeGrant grants = 1 [
-    (gogoproto.nullable)   = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated CodeGrant grants = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // ContractExecutionAuthorization defines authorization for wasm execute.
@@ -31,10 +28,7 @@ message ContractExecutionAuthorization {
   option (cosmos_proto.implements_interface) = "cosmos.authz.v1beta1.Authorization";
 
   // Grants for contract executions
-  repeated ContractGrant grants = 1 [
-    (gogoproto.nullable)   = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated ContractGrant grants = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // ContractMigrationAuthorization defines authorization for wasm contract
@@ -44,10 +38,7 @@ message ContractMigrationAuthorization {
   option (cosmos_proto.implements_interface) = "cosmos.authz.v1beta1.Authorization";
 
   // Grants for contract migrations
-  repeated ContractGrant grants = 1 [
-    (gogoproto.nullable)   = false,
-    (amino.dont_omitempty) = true
-  ];
+  repeated ContractGrant grants = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // CodeGrant a granted permission for a single code
@@ -70,12 +61,14 @@ message ContractGrant {
 
   // Limit defines execution limits that are enforced and updated when the grant
   // is applied. When the limit lapsed the grant is removed.
-  google.protobuf.Any limit = 2 [(cosmos_proto.accepts_interface) = "cosmwasm.wasm.v1.ContractAuthzLimitX"];
+  google.protobuf.Any limit = 2
+      [(cosmos_proto.accepts_interface) = "cosmwasm.wasm.v1.ContractAuthzLimitX"];
 
   // Filter define more fine-grained control on the message payload passed
   // to the contract in the operation. When no filter applies on execution, the
   // operation is prohibited.
-  google.protobuf.Any filter = 3 [(cosmos_proto.accepts_interface) = "cosmwasm.wasm.v1.ContractAuthzFilterX"];
+  google.protobuf.Any filter = 3
+      [(cosmos_proto.accepts_interface) = "cosmwasm.wasm.v1.ContractAuthzFilterX"];
 }
 
 // MaxCallsLimit limited number of calls to the contract. No funds transferable.

--- a/proto/cosmwasm/wasm/v1/genesis.proto
+++ b/proto/cosmwasm/wasm/v1/genesis.proto
@@ -10,29 +10,29 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
 // GenesisState - genesis state of x/wasm
 message GenesisState {
   Params params = 1
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   repeated Code codes = 2 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true,
-    (gogoproto.jsontag) = "codes,omitempty"
+    (gogoproto.jsontag)    = "codes,omitempty"
   ];
   repeated Contract contracts = 3 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true,
-    (gogoproto.jsontag) = "contracts,omitempty"
+    (gogoproto.jsontag)    = "contracts,omitempty"
   ];
   repeated Sequence sequences = 4 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true,
-    (gogoproto.jsontag) = "sequences,omitempty"
+    (gogoproto.jsontag)    = "sequences,omitempty"
   ];
 }
 
 // Code struct encompasses CodeInfo and CodeBytes
 message Code {
-  uint64 code_id = 1 [ (gogoproto.customname) = "CodeID" ];
+  uint64   code_id   = 1 [(gogoproto.customname) = "CodeID"];
   CodeInfo code_info = 2
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   bytes code_bytes = 3;
   // Pinned to wasmvm cache
   bool pinned = 4;
@@ -40,17 +40,17 @@ message Code {
 
 // Contract struct encompasses ContractAddress, ContractInfo, and ContractState
 message Contract {
-  string contract_address = 1;
-  ContractInfo contract_info = 2
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+  string       contract_address = 1;
+  ContractInfo contract_info    = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   repeated Model contract_state = 3
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   repeated ContractCodeHistoryEntry contract_code_history = 4
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // Sequence key and value of an id generation counter
 message Sequence {
-  bytes id_key = 1 [ (gogoproto.customname) = "IDKey" ];
-  uint64 value = 2;
+  bytes  id_key = 1 [(gogoproto.customname) = "IDKey"];
+  uint64 value  = 2;
 }

--- a/proto/cosmwasm/wasm/v1/genesis.proto
+++ b/proto/cosmwasm/wasm/v1/genesis.proto
@@ -9,9 +9,8 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
 
 // GenesisState - genesis state of x/wasm
 message GenesisState {
-  Params params = 1
-      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
-  repeated Code codes = 2 [
+  Params        params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  repeated Code codes  = 2 [
     (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true,
     (gogoproto.jsontag)    = "codes,omitempty"
@@ -30,21 +29,18 @@ message GenesisState {
 
 // Code struct encompasses CodeInfo and CodeBytes
 message Code {
-  uint64   code_id   = 1 [(gogoproto.customname) = "CodeID"];
-  CodeInfo code_info = 2
-      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
-  bytes code_bytes = 3;
+  uint64   code_id    = 1 [(gogoproto.customname) = "CodeID"];
+  CodeInfo code_info  = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  bytes    code_bytes = 3;
   // Pinned to wasmvm cache
   bool pinned = 4;
 }
 
 // Contract struct encompasses ContractAddress, ContractInfo, and ContractState
 message Contract {
-  string       contract_address = 1;
-  ContractInfo contract_info    = 2
-      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
-  repeated Model contract_state = 3
-      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  string         contract_address = 1;
+  ContractInfo   contract_info    = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  repeated Model contract_state   = 3 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   repeated ContractCodeHistoryEntry contract_code_history = 4
       [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }

--- a/proto/cosmwasm/wasm/v1/ibc.proto
+++ b/proto/cosmwasm/wasm/v1/ibc.proto
@@ -3,22 +3,22 @@ package cosmwasm.wasm.v1;
 
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
+option go_package                      = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
 option (gogoproto.goproto_getters_all) = false;
 
 // MsgIBCSend
 message MsgIBCSend {
   // the channel by which the packet will be sent
-  string channel = 2 [ (gogoproto.moretags) = "yaml:\"source_channel\"" ];
+  string channel = 2 [(gogoproto.moretags) = "yaml:\"source_channel\""];
 
   // Timeout height relative to the current block height.
   // The timeout is disabled when set to 0.
   uint64 timeout_height = 4
-      [ (gogoproto.moretags) = "yaml:\"timeout_height\"" ];
+      [(gogoproto.moretags) = "yaml:\"timeout_height\""];
   // Timeout timestamp (in nanoseconds) relative to the current block timestamp.
   // The timeout is disabled when set to 0.
   uint64 timeout_timestamp = 5
-      [ (gogoproto.moretags) = "yaml:\"timeout_timestamp\"" ];
+      [(gogoproto.moretags) = "yaml:\"timeout_timestamp\""];
 
   // Data is the payload to transfer. We must not make assumption what format or
   // content is in here.
@@ -33,5 +33,5 @@ message MsgIBCSendResponse {
 
 // MsgIBCCloseChannel port and channel need to be owned by the contract
 message MsgIBCCloseChannel {
-  string channel = 2 [ (gogoproto.moretags) = "yaml:\"source_channel\"" ];
+  string channel = 2 [(gogoproto.moretags) = "yaml:\"source_channel\""];
 }

--- a/proto/cosmwasm/wasm/v1/ibc.proto
+++ b/proto/cosmwasm/wasm/v1/ibc.proto
@@ -13,12 +13,10 @@ message MsgIBCSend {
 
   // Timeout height relative to the current block height.
   // The timeout is disabled when set to 0.
-  uint64 timeout_height = 4
-      [(gogoproto.moretags) = "yaml:\"timeout_height\""];
+  uint64 timeout_height = 4 [(gogoproto.moretags) = "yaml:\"timeout_height\""];
   // Timeout timestamp (in nanoseconds) relative to the current block timestamp.
   // The timeout is disabled when set to 0.
-  uint64 timeout_timestamp = 5
-      [(gogoproto.moretags) = "yaml:\"timeout_timestamp\""];
+  uint64 timeout_timestamp = 5 [(gogoproto.moretags) = "yaml:\"timeout_timestamp\""];
 
   // Data is the payload to transfer. We must not make assumption what format or
   // content is in here.

--- a/proto/cosmwasm/wasm/v1/query.proto
+++ b/proto/cosmwasm/wasm/v1/query.proto
@@ -14,37 +14,28 @@ option (gogoproto.equal_all)           = false;
 // Query provides defines the gRPC querier service
 service Query {
   // ContractInfo gets the contract meta data
-  rpc ContractInfo(QueryContractInfoRequest)
-      returns (QueryContractInfoResponse) {
+  rpc ContractInfo(QueryContractInfoRequest) returns (QueryContractInfoResponse) {
     option (google.api.http).get = "/cosmwasm/wasm/v1/contract/{address}";
   }
   // ContractHistory gets the contract code history
-  rpc ContractHistory(QueryContractHistoryRequest)
-      returns (QueryContractHistoryResponse) {
-    option (google.api.http).get =
-        "/cosmwasm/wasm/v1/contract/{address}/history";
+  rpc ContractHistory(QueryContractHistoryRequest) returns (QueryContractHistoryResponse) {
+    option (google.api.http).get = "/cosmwasm/wasm/v1/contract/{address}/history";
   }
   // ContractsByCode lists all smart contracts for a code id
-  rpc ContractsByCode(QueryContractsByCodeRequest)
-      returns (QueryContractsByCodeResponse) {
+  rpc ContractsByCode(QueryContractsByCodeRequest) returns (QueryContractsByCodeResponse) {
     option (google.api.http).get = "/cosmwasm/wasm/v1/code/{code_id}/contracts";
   }
   // AllContractState gets all raw store data for a single contract
-  rpc AllContractState(QueryAllContractStateRequest)
-      returns (QueryAllContractStateResponse) {
+  rpc AllContractState(QueryAllContractStateRequest) returns (QueryAllContractStateResponse) {
     option (google.api.http).get = "/cosmwasm/wasm/v1/contract/{address}/state";
   }
   // RawContractState gets single key from the raw store data of a contract
-  rpc RawContractState(QueryRawContractStateRequest)
-      returns (QueryRawContractStateResponse) {
-    option (google.api.http).get =
-        "/cosmwasm/wasm/v1/contract/{address}/raw/{query_data}";
+  rpc RawContractState(QueryRawContractStateRequest) returns (QueryRawContractStateResponse) {
+    option (google.api.http).get = "/cosmwasm/wasm/v1/contract/{address}/raw/{query_data}";
   }
   // SmartContractState get smart query result from the contract
-  rpc SmartContractState(QuerySmartContractStateRequest)
-      returns (QuerySmartContractStateResponse) {
-    option (google.api.http).get =
-        "/cosmwasm/wasm/v1/contract/{address}/smart/{query_data}";
+  rpc SmartContractState(QuerySmartContractStateRequest) returns (QuerySmartContractStateResponse) {
+    option (google.api.http).get = "/cosmwasm/wasm/v1/contract/{address}/smart/{query_data}";
   }
   // Code gets the binary code and metadata for a singe wasm code
   rpc Code(QueryCodeRequest) returns (QueryCodeResponse) {
@@ -66,10 +57,8 @@ service Query {
   }
 
   // ContractsByCreator gets the contracts by creator
-  rpc ContractsByCreator(QueryContractsByCreatorRequest)
-      returns (QueryContractsByCreatorResponse) {
-    option (google.api.http).get =
-        "/cosmwasm/wasm/v1/contracts/creator/{creator_address}";
+  rpc ContractsByCreator(QueryContractsByCreatorRequest) returns (QueryContractsByCreatorResponse) {
+    option (google.api.http).get = "/cosmwasm/wasm/v1/contracts/creator/{creator_address}";
   }
 }
 
@@ -142,8 +131,7 @@ message QueryAllContractStateRequest {
 // QueryAllContractStateResponse is the response type for the
 // Query/AllContractState RPC method
 message QueryAllContractStateResponse {
-  repeated Model models = 1
-      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  repeated Model models = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
@@ -188,14 +176,11 @@ message QueryCodeRequest {
 message CodeInfoResponse {
   option (gogoproto.equal) = true;
 
-  uint64 code_id = 1 [
-    (gogoproto.customname) = "CodeID",
-    (gogoproto.jsontag)    = "id"
-  ];  // id for legacy support
+  uint64 code_id = 1
+      [(gogoproto.customname) = "CodeID",
+       (gogoproto.jsontag)    = "id"];  // id for legacy support
   string creator   = 2;
-  bytes  data_hash = 3
-      [(gogoproto.casttype) =
-           "github.com/cometbft/cometbft/libs/bytes.HexBytes"];
+  bytes  data_hash = 3 [(gogoproto.casttype) = "github.com/cometbft/cometbft/libs/bytes.HexBytes"];
   // Used in v1beta1
   reserved 4, 5;
   AccessConfig instantiate_permission = 6
@@ -205,9 +190,8 @@ message CodeInfoResponse {
 // QueryCodeResponse is the response type for the Query/Code RPC method
 message QueryCodeResponse {
   option (gogoproto.equal)   = true;
-  CodeInfoResponse code_info = 1
-      [(gogoproto.embed) = true, (gogoproto.jsontag) = ""];
-  bytes data = 2 [(gogoproto.jsontag) = "data"];
+  CodeInfoResponse code_info = 1 [(gogoproto.embed) = true, (gogoproto.jsontag) = ""];
+  bytes            data      = 2 [(gogoproto.jsontag) = "data"];
 }
 
 // QueryCodesRequest is the request type for the Query/Codes RPC method
@@ -245,8 +229,7 @@ message QueryParamsRequest {}
 // QueryParamsResponse is the response type for the Query/Params RPC method.
 message QueryParamsResponse {
   // params defines the parameters of the module.
-  Params params = 1
-      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryContractsByCreatorRequest is the request type for the

--- a/proto/cosmwasm/wasm/v1/query.proto
+++ b/proto/cosmwasm/wasm/v1/query.proto
@@ -7,9 +7,9 @@ import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "amino/amino.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
+option go_package                      = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
 option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.equal_all) = false;
+option (gogoproto.equal_all)           = false;
 
 // Query provides defines the gRPC querier service
 service Query {
@@ -85,12 +85,12 @@ message QueryContractInfoResponse {
   option (gogoproto.equal) = true;
 
   // address is the address of the contract
-  string address = 1;
+  string       address       = 1;
   ContractInfo contract_info = 2 [
-    (gogoproto.embed) = true,
-    (gogoproto.nullable) = false,
+    (gogoproto.embed)      = true,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true,
-    (gogoproto.jsontag) = ""
+    (gogoproto.jsontag)    = ""
   ];
 }
 
@@ -107,7 +107,7 @@ message QueryContractHistoryRequest {
 // Query/ContractHistory RPC method
 message QueryContractHistoryResponse {
   repeated ContractCodeHistoryEntry entries = 1
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
@@ -115,7 +115,7 @@ message QueryContractHistoryResponse {
 // QueryContractsByCodeRequest is the request type for the Query/ContractsByCode
 // RPC method
 message QueryContractsByCodeRequest {
-  uint64 code_id = 1; // grpc-gateway_out does not support Go style CodID
+  uint64 code_id = 1;  // grpc-gateway_out does not support Go style CodID
   // pagination defines an optional pagination for the request.
   cosmos.base.query.v1beta1.PageRequest pagination = 2;
 }
@@ -143,7 +143,7 @@ message QueryAllContractStateRequest {
 // Query/AllContractState RPC method
 message QueryAllContractStateResponse {
   repeated Model models = 1
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
@@ -152,8 +152,8 @@ message QueryAllContractStateResponse {
 // Query/RawContractState RPC method
 message QueryRawContractStateRequest {
   // address is the address of the contract
-  string address = 1;
-  bytes query_data = 2;
+  string address    = 1;
+  bytes  query_data = 2;
 }
 
 // QueryRawContractStateResponse is the response type for the
@@ -169,19 +169,19 @@ message QuerySmartContractStateRequest {
   // address is the address of the contract
   string address = 1;
   // QueryData contains the query data passed to the contract
-  bytes query_data = 2 [ (gogoproto.casttype) = "RawContractMessage" ];
+  bytes query_data = 2 [(gogoproto.casttype) = "RawContractMessage"];
 }
 
 // QuerySmartContractStateResponse is the response type for the
 // Query/SmartContractState RPC method
 message QuerySmartContractStateResponse {
   // Data contains the json data returned from the smart contract
-  bytes data = 1 [ (gogoproto.casttype) = "RawContractMessage" ];
+  bytes data = 1 [(gogoproto.casttype) = "RawContractMessage"];
 }
 
 // QueryCodeRequest is the request type for the Query/Code RPC method
 message QueryCodeRequest {
-  uint64 code_id = 1; // grpc-gateway_out does not support Go style CodID
+  uint64 code_id = 1;  // grpc-gateway_out does not support Go style CodID
 }
 
 // CodeInfoResponse contains code meta data from CodeInfo
@@ -190,24 +190,24 @@ message CodeInfoResponse {
 
   uint64 code_id = 1 [
     (gogoproto.customname) = "CodeID",
-    (gogoproto.jsontag) = "id"
-  ]; // id for legacy support
-  string creator = 2;
-  bytes data_hash = 3
-      [ (gogoproto.casttype) =
-            "github.com/cometbft/cometbft/libs/bytes.HexBytes" ];
+    (gogoproto.jsontag)    = "id"
+  ];  // id for legacy support
+  string creator   = 2;
+  bytes  data_hash = 3
+      [(gogoproto.casttype) =
+           "github.com/cometbft/cometbft/libs/bytes.HexBytes"];
   // Used in v1beta1
   reserved 4, 5;
   AccessConfig instantiate_permission = 6
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryCodeResponse is the response type for the Query/Code RPC method
 message QueryCodeResponse {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)   = true;
   CodeInfoResponse code_info = 1
-      [ (gogoproto.embed) = true, (gogoproto.jsontag) = "" ];
-  bytes data = 2 [ (gogoproto.jsontag) = "data" ];
+      [(gogoproto.embed) = true, (gogoproto.jsontag) = ""];
+  bytes data = 2 [(gogoproto.jsontag) = "data"];
 }
 
 // QueryCodesRequest is the request type for the Query/Codes RPC method
@@ -219,7 +219,7 @@ message QueryCodesRequest {
 // QueryCodesResponse is the response type for the Query/Codes RPC method
 message QueryCodesResponse {
   repeated CodeInfoResponse code_infos = 1
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
@@ -234,7 +234,7 @@ message QueryPinnedCodesRequest {
 // QueryPinnedCodesResponse is the response type for the
 // Query/PinnedCodes RPC method
 message QueryPinnedCodesResponse {
-  repeated uint64 code_ids = 1 [ (gogoproto.customname) = "CodeIDs" ];
+  repeated uint64 code_ids = 1 [(gogoproto.customname) = "CodeIDs"];
   // pagination defines the pagination in the response.
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
@@ -246,7 +246,7 @@ message QueryParamsRequest {}
 message QueryParamsResponse {
   // params defines the parameters of the module.
   Params params = 1
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // QueryContractsByCreatorRequest is the request type for the

--- a/proto/cosmwasm/wasm/v1/tx.proto
+++ b/proto/cosmwasm/wasm/v1/tx.proto
@@ -8,7 +8,7 @@ import "cosmos_proto/cosmos.proto";
 import "cosmwasm/wasm/v1/types.proto";
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
+option go_package                      = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
 option (gogoproto.goproto_getters_all) = false;
 
 // Msg defines the wasm Msg service.
@@ -77,7 +77,7 @@ service Msg {
 
 // MsgStoreCode submit Wasm code to the system
 message MsgStoreCode {
-  option (amino.name) = "wasm/MsgStoreCode";
+  option (amino.name)           = "wasm/MsgStoreCode";
   option (cosmos.msg.v1.signer) = "sender";
 
   // Sender is the actor that signed the messages
@@ -101,7 +101,7 @@ message MsgStoreCodeResponse {
 // MsgInstantiateContract create a new smart contract instance for the given
 // code id.
 message MsgInstantiateContract {
-  option (amino.name) = "wasm/MsgInstantiateContract";
+  option (amino.name)           = "wasm/MsgInstantiateContract";
   option (cosmos.msg.v1.signer) = "sender";
 
   // Sender is the that actor that signed the messages
@@ -116,8 +116,8 @@ message MsgInstantiateContract {
   bytes msg = 5 [(gogoproto.casttype) = "RawContractMessage"];
   // Funds coins that are transferred to the contract on instantiation
   repeated cosmos.base.v1beta1.Coin funds = 6 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -133,7 +133,7 @@ message MsgInstantiateContractResponse {
 // MsgInstantiateContract2 create a new smart contract instance for the given
 // code id with a predicable address.
 message MsgInstantiateContract2 {
-  option (amino.name) = "wasm/MsgInstantiateContract2";
+  option (amino.name)           = "wasm/MsgInstantiateContract2";
   option (cosmos.msg.v1.signer) = "sender";
 
   // Sender is the that actor that signed the messages
@@ -148,8 +148,8 @@ message MsgInstantiateContract2 {
   bytes msg = 5 [(gogoproto.casttype) = "RawContractMessage"];
   // Funds coins that are transferred to the contract on instantiation
   repeated cosmos.base.v1beta1.Coin funds = 6 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
   // Salt is an arbitrary value provided by the sender. Size can be 1 to 64.
@@ -169,7 +169,7 @@ message MsgInstantiateContract2Response {
 
 // MsgExecuteContract submits the given message data to a smart contract
 message MsgExecuteContract {
-  option (amino.name) = "wasm/MsgExecuteContract";
+  option (amino.name)           = "wasm/MsgExecuteContract";
   option (cosmos.msg.v1.signer) = "sender";
 
   // Sender is the that actor that signed the messages
@@ -180,8 +180,8 @@ message MsgExecuteContract {
   bytes msg = 3 [(gogoproto.casttype) = "RawContractMessage"];
   // Funds coins that are transferred to the contract on execution
   repeated cosmos.base.v1beta1.Coin funds = 5 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
 }
@@ -194,7 +194,7 @@ message MsgExecuteContractResponse {
 
 // MsgMigrateContract runs a code upgrade/ downgrade for a smart contract
 message MsgMigrateContract {
-  option (amino.name) = "wasm/MsgMigrateContract";
+  option (amino.name)           = "wasm/MsgMigrateContract";
   option (cosmos.msg.v1.signer) = "sender";
 
   // Sender is the that actor that signed the messages
@@ -216,7 +216,7 @@ message MsgMigrateContractResponse {
 
 // MsgUpdateAdmin sets a new admin for a smart contract
 message MsgUpdateAdmin {
-  option (amino.name) = "wasm/MsgUpdateAdmin";
+  option (amino.name)           = "wasm/MsgUpdateAdmin";
   option (cosmos.msg.v1.signer) = "sender";
 
   // Sender is the that actor that signed the messages
@@ -232,7 +232,7 @@ message MsgUpdateAdminResponse {}
 
 // MsgClearAdmin removes any admin stored for a smart contract
 message MsgClearAdmin {
-  option (amino.name) = "wasm/MsgClearAdmin";
+  option (amino.name)           = "wasm/MsgClearAdmin";
   option (cosmos.msg.v1.signer) = "sender";
 
   // Sender is the actor that signed the messages
@@ -251,14 +251,14 @@ message AccessConfigUpdate {
   uint64 code_id = 1 [(gogoproto.customname) = "CodeID"];
   // InstantiatePermission to apply to the set of code ids
   AccessConfig instantiate_permission = 2 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
 }
 
 // MsgUpdateInstantiateConfig updates instantiate config for a smart contract
 message MsgUpdateInstantiateConfig {
-  option (amino.name) = "wasm/MsgUpdateInstantiateConfig";
+  option (amino.name)           = "wasm/MsgUpdateInstantiateConfig";
   option (cosmos.msg.v1.signer) = "sender";
 
   // Sender is the that actor that signed the messages
@@ -276,7 +276,7 @@ message MsgUpdateInstantiateConfigResponse {}
 //
 // Since: 0.40
 message MsgUpdateParams {
-  option (amino.name) = "wasm/MsgUpdateParams";
+  option (amino.name)           = "wasm/MsgUpdateParams";
   option (cosmos.msg.v1.signer) = "authority";
 
   // Authority is the address of the governance account.
@@ -286,7 +286,7 @@ message MsgUpdateParams {
   //
   // NOTE: All parameters must be supplied.
   Params params = 2 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true
   ];
 }
@@ -301,7 +301,7 @@ message MsgUpdateParamsResponse {}
 //
 // Since: 0.40
 message MsgSudoContract {
-  option (amino.name) = "wasm/MsgSudoContract";
+  option (amino.name)           = "wasm/MsgSudoContract";
   option (cosmos.msg.v1.signer) = "authority";
 
   // Authority is the address of the governance account.
@@ -326,7 +326,7 @@ message MsgSudoContractResponse {
 //
 // Since: 0.40
 message MsgPinCodes {
-  option (amino.name) = "wasm/MsgPinCodes";
+  option (amino.name)           = "wasm/MsgPinCodes";
   option (cosmos.msg.v1.signer) = "authority";
 
   // Authority is the address of the governance account.
@@ -334,7 +334,7 @@ message MsgPinCodes {
   // CodeIDs references the new WASM codes
   repeated uint64 code_ids = 2 [
     (gogoproto.customname) = "CodeIDs",
-    (gogoproto.moretags) = "yaml:\"code_ids\""
+    (gogoproto.moretags)   = "yaml:\"code_ids\""
   ];
 }
 
@@ -348,7 +348,7 @@ message MsgPinCodesResponse {}
 //
 // Since: 0.40
 message MsgUnpinCodes {
-  option (amino.name) = "wasm/MsgUnpinCodes";
+  option (amino.name)           = "wasm/MsgUnpinCodes";
   option (cosmos.msg.v1.signer) = "authority";
 
   // Authority is the address of the governance account.
@@ -356,7 +356,7 @@ message MsgUnpinCodes {
   // CodeIDs references the WASM codes
   repeated uint64 code_ids = 2 [
     (gogoproto.customname) = "CodeIDs",
-    (gogoproto.moretags) = "yaml:\"code_ids\""
+    (gogoproto.moretags)   = "yaml:\"code_ids\""
   ];
 }
 
@@ -371,7 +371,7 @@ message MsgUnpinCodesResponse {}
 //
 // Since: 0.40
 message MsgStoreAndInstantiateContract {
-  option (amino.name) = "wasm/MsgStoreAndInstantiateContract";
+  option (amino.name)           = "wasm/MsgStoreAndInstantiateContract";
   option (cosmos.msg.v1.signer) = "authority";
 
   // Authority is the address of the governance account.
@@ -392,8 +392,8 @@ message MsgStoreAndInstantiateContract {
   // Funds coins that are transferred from the authority account to the contract
   // on instantiation
   repeated cosmos.base.v1beta1.Coin funds = 9 [
-    (gogoproto.nullable) = false,
-    (amino.dont_omitempty) = true,
+    (gogoproto.nullable)     = false,
+    (amino.dont_omitempty)   = true,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.Coins"
   ];
   // Source is the URL where the code is hosted
@@ -420,7 +420,7 @@ message MsgStoreAndInstantiateContractResponse {
 // MsgAddCodeUploadParamsAddresses is the
 // MsgAddCodeUploadParamsAddresses request type.
 message MsgAddCodeUploadParamsAddresses {
-  option (amino.name) = "wasm/MsgAddCodeUploadParamsAddresses";
+  option (amino.name)           = "wasm/MsgAddCodeUploadParamsAddresses";
   option (cosmos.msg.v1.signer) = "authority";
 
   // Authority is the address of the governance account.
@@ -436,7 +436,7 @@ message MsgAddCodeUploadParamsAddressesResponse {}
 // MsgRemoveCodeUploadParamsAddresses is the
 // MsgRemoveCodeUploadParamsAddresses request type.
 message MsgRemoveCodeUploadParamsAddresses {
-  option (amino.name) = "wasm/MsgRemoveCodeUploadParamsAddresses";
+  option (amino.name)           = "wasm/MsgRemoveCodeUploadParamsAddresses";
   option (cosmos.msg.v1.signer) = "authority";
 
   // Authority is the address of the governance account.
@@ -454,7 +454,7 @@ message MsgRemoveCodeUploadParamsAddressesResponse {}
 //
 // Since: 0.42
 message MsgStoreAndMigrateContract {
-  option (amino.name) = "wasm/MsgStoreAndMigrateContract";
+  option (amino.name)           = "wasm/MsgStoreAndMigrateContract";
   option (cosmos.msg.v1.signer) = "authority";
 
   // Authority is the address of the governance account.
@@ -484,7 +484,7 @@ message MsgStoreAndMigrateContractResponse {
 
 // MsgUpdateContractLabel sets a new label for a smart contract
 message MsgUpdateContractLabel {
-  option (amino.name) = "wasm/MsgUpdateContractLabel";
+  option (amino.name)           = "wasm/MsgUpdateContractLabel";
   option (cosmos.msg.v1.signer) = "sender";
 
   // Sender is the that actor that signed the messages
@@ -497,4 +497,3 @@ message MsgUpdateContractLabel {
 
 // MsgUpdateContractLabelResponse returns empty data
 message MsgUpdateContractLabelResponse {}
-

--- a/proto/cosmwasm/wasm/v1/tx.proto
+++ b/proto/cosmwasm/wasm/v1/tx.proto
@@ -30,7 +30,8 @@ service Msg {
   // ClearAdmin removes any admin stored for a smart contract
   rpc ClearAdmin(MsgClearAdmin) returns (MsgClearAdminResponse);
   // UpdateInstantiateConfig updates instantiate config for a smart contract
-  rpc UpdateInstantiateConfig(MsgUpdateInstantiateConfig) returns (MsgUpdateInstantiateConfigResponse);
+  rpc UpdateInstantiateConfig(MsgUpdateInstantiateConfig)
+      returns (MsgUpdateInstantiateConfigResponse);
   // UpdateParams defines a governance operation for updating the x/wasm
   // module parameters. The authority is defined in the keeper.
   //
@@ -55,20 +56,24 @@ service Msg {
   // and instantiating the contract. The authority is defined in the keeper.
   //
   // Since: 0.40
-  rpc StoreAndInstantiateContract(MsgStoreAndInstantiateContract) returns (MsgStoreAndInstantiateContractResponse);
+  rpc StoreAndInstantiateContract(MsgStoreAndInstantiateContract)
+      returns (MsgStoreAndInstantiateContractResponse);
   // RemoveCodeUploadParamsAddresses defines a governance operation for
   // removing addresses from code upload params.
   // The authority is defined in the keeper.
-  rpc RemoveCodeUploadParamsAddresses(MsgRemoveCodeUploadParamsAddresses) returns (MsgRemoveCodeUploadParamsAddressesResponse);
+  rpc RemoveCodeUploadParamsAddresses(MsgRemoveCodeUploadParamsAddresses)
+      returns (MsgRemoveCodeUploadParamsAddressesResponse);
   // AddCodeUploadParamsAddresses defines a governance operation for
   // adding addresses to code upload params.
   // The authority is defined in the keeper.
-  rpc AddCodeUploadParamsAddresses(MsgAddCodeUploadParamsAddresses) returns (MsgAddCodeUploadParamsAddressesResponse);
+  rpc AddCodeUploadParamsAddresses(MsgAddCodeUploadParamsAddresses)
+      returns (MsgAddCodeUploadParamsAddressesResponse);
   // StoreAndMigrateContract defines a governance operation for storing
   // and migrating the contract. The authority is defined in the keeper.
   //
   // Since: 0.42
-  rpc StoreAndMigrateContract(MsgStoreAndMigrateContract) returns (MsgStoreAndMigrateContractResponse);
+  rpc StoreAndMigrateContract(MsgStoreAndMigrateContract)
+      returns (MsgStoreAndMigrateContractResponse);
   // UpdateContractLabel sets a new label for a smart contract
   //
   // Since: 0.43
@@ -250,10 +255,8 @@ message AccessConfigUpdate {
   // CodeID is the reference to the stored WASM code to be updated
   uint64 code_id = 1 [(gogoproto.customname) = "CodeID"];
   // InstantiatePermission to apply to the set of code ids
-  AccessConfig instantiate_permission = 2 [
-    (gogoproto.nullable)   = false,
-    (amino.dont_omitempty) = true
-  ];
+  AccessConfig instantiate_permission = 2
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgUpdateInstantiateConfig updates instantiate config for a smart contract
@@ -285,10 +288,7 @@ message MsgUpdateParams {
   // params defines the x/wasm parameters to update.
   //
   // NOTE: All parameters must be supplied.
-  Params params = 2 [
-    (gogoproto.nullable)   = false,
-    (amino.dont_omitempty) = true
-  ];
+  Params params = 2 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a
@@ -332,10 +332,8 @@ message MsgPinCodes {
   // Authority is the address of the governance account.
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // CodeIDs references the new WASM codes
-  repeated uint64 code_ids = 2 [
-    (gogoproto.customname) = "CodeIDs",
-    (gogoproto.moretags)   = "yaml:\"code_ids\""
-  ];
+  repeated uint64 code_ids = 2
+      [(gogoproto.customname) = "CodeIDs", (gogoproto.moretags) = "yaml:\"code_ids\""];
 }
 
 // MsgPinCodesResponse defines the response structure for executing a
@@ -354,10 +352,8 @@ message MsgUnpinCodes {
   // Authority is the address of the governance account.
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // CodeIDs references the WASM codes
-  repeated uint64 code_ids = 2 [
-    (gogoproto.customname) = "CodeIDs",
-    (gogoproto.moretags)   = "yaml:\"code_ids\""
-  ];
+  repeated uint64 code_ids = 2
+      [(gogoproto.customname) = "CodeIDs", (gogoproto.moretags) = "yaml:\"code_ids\""];
 }
 
 // MsgUnpinCodesResponse defines the response structure for executing a

--- a/proto/cosmwasm/wasm/v1/types.proto
+++ b/proto/cosmwasm/wasm/v1/types.proto
@@ -6,57 +6,57 @@ import "gogoproto/gogo.proto";
 import "google/protobuf/any.proto";
 import "amino/amino.proto";
 
-option go_package = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
+option go_package                      = "github.com/NibiruChain/nibiru/v2/x/wasm/types";
 option (gogoproto.goproto_getters_all) = false;
-option (gogoproto.equal_all) = true;
+option (gogoproto.equal_all)           = true;
 
 // AccessType permission types
 enum AccessType {
-  option (gogoproto.goproto_enum_prefix) = false;
+  option (gogoproto.goproto_enum_prefix)   = false;
   option (gogoproto.goproto_enum_stringer) = false;
   // AccessTypeUnspecified placeholder for empty value
   ACCESS_TYPE_UNSPECIFIED = 0
-      [ (gogoproto.enumvalue_customname) = "AccessTypeUnspecified" ];
+      [(gogoproto.enumvalue_customname) = "AccessTypeUnspecified"];
   // AccessTypeNobody forbidden
   ACCESS_TYPE_NOBODY = 1
-      [ (gogoproto.enumvalue_customname) = "AccessTypeNobody" ];
+      [(gogoproto.enumvalue_customname) = "AccessTypeNobody"];
 
-  reserved 2; // was AccessTypeOnlyAddress
+  reserved 2;  // was AccessTypeOnlyAddress
 
   // AccessTypeEverybody unrestricted
   ACCESS_TYPE_EVERYBODY = 3
-      [ (gogoproto.enumvalue_customname) = "AccessTypeEverybody" ];
+      [(gogoproto.enumvalue_customname) = "AccessTypeEverybody"];
   // AccessTypeAnyOfAddresses allow any of the addresses
   ACCESS_TYPE_ANY_OF_ADDRESSES = 4
-      [ (gogoproto.enumvalue_customname) = "AccessTypeAnyOfAddresses" ];
+      [(gogoproto.enumvalue_customname) = "AccessTypeAnyOfAddresses"];
 }
 
 // AccessTypeParam
 message AccessTypeParam {
   option (gogoproto.goproto_stringer) = true;
-  AccessType value = 1 [ (gogoproto.moretags) = "yaml:\"value\"" ];
+  AccessType value                    = 1 [(gogoproto.moretags) = "yaml:\"value\""];
 }
 
 // AccessConfig access control type.
 message AccessConfig {
   option (gogoproto.goproto_stringer) = true;
-  AccessType permission = 1 [ (gogoproto.moretags) = "yaml:\"permission\"" ];
+  AccessType permission               = 1 [(gogoproto.moretags) = "yaml:\"permission\""];
 
-  reserved 2; // was address
+  reserved 2;  // was address
 
-  repeated string addresses = 3 [ (gogoproto.moretags) = "yaml:\"addresses\"" ];
+  repeated string addresses = 3 [(gogoproto.moretags) = "yaml:\"addresses\""];
 }
 
 // Params defines the set of wasm parameters.
 message Params {
   option (gogoproto.goproto_stringer) = false;
-  AccessConfig code_upload_access = 1 [
-    (gogoproto.nullable) = false,
+  AccessConfig code_upload_access     = 1 [
+    (gogoproto.nullable)   = false,
     (amino.dont_omitempty) = true,
-    (gogoproto.moretags) = "yaml:\"code_upload_access\""
+    (gogoproto.moretags)   = "yaml:\"code_upload_access\""
   ];
   AccessType instantiate_default_permission = 2
-      [ (gogoproto.moretags) = "yaml:\"instantiate_default_permission\"" ];
+      [(gogoproto.moretags) = "yaml:\"instantiate_default_permission\""];
 }
 
 // CodeInfo is data for the uploaded contract WASM code
@@ -69,7 +69,7 @@ message CodeInfo {
   reserved 3, 4;
   // InstantiateConfig access control to apply on contract creation, optional
   AccessConfig instantiate_config = 5
-      [ (gogoproto.nullable) = false, (amino.dont_omitempty) = true ];
+      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // ContractInfo stores a WASM contract instance
@@ -77,7 +77,7 @@ message ContractInfo {
   option (gogoproto.equal) = true;
 
   // CodeID is the reference to the stored Wasm code
-  uint64 code_id = 1 [ (gogoproto.customname) = "CodeID" ];
+  uint64 code_id = 1 [(gogoproto.customname) = "CodeID"];
   // Creator address who initially instantiated the contract
   string creator = 2;
   // Admin is an optional address that can execute migrations
@@ -85,14 +85,14 @@ message ContractInfo {
   // Label is optional metadata to be stored with a contract instance.
   string label = 4;
   // Created Tx position when the contract was instantiated.
-  AbsoluteTxPosition created = 5;
-  string ibc_port_id = 6 [ (gogoproto.customname) = "IBCPortID" ];
+  AbsoluteTxPosition created     = 5;
+  string             ibc_port_id = 6 [(gogoproto.customname) = "IBCPortID"];
 
   // Extension is an extension point to store custom metadata within the
   // persistence model.
   google.protobuf.Any extension = 7
-      [ (cosmos_proto.accepts_interface) =
-            "cosmwasm.wasm.v1.ContractInfoExtension" ];
+      [(cosmos_proto.accepts_interface) =
+           "cosmwasm.wasm.v1.ContractInfoExtension"];
 }
 
 // ContractCodeHistoryOperationType actions that caused a code change
@@ -100,30 +100,30 @@ enum ContractCodeHistoryOperationType {
   option (gogoproto.goproto_enum_prefix) = false;
   // ContractCodeHistoryOperationTypeUnspecified placeholder for empty value
   CONTRACT_CODE_HISTORY_OPERATION_TYPE_UNSPECIFIED = 0
-      [ (gogoproto.enumvalue_customname) =
-            "ContractCodeHistoryOperationTypeUnspecified" ];
+      [(gogoproto.enumvalue_customname) =
+           "ContractCodeHistoryOperationTypeUnspecified"];
   // ContractCodeHistoryOperationTypeInit on chain contract instantiation
   CONTRACT_CODE_HISTORY_OPERATION_TYPE_INIT = 1
-      [ (gogoproto.enumvalue_customname) =
-            "ContractCodeHistoryOperationTypeInit" ];
+      [(gogoproto.enumvalue_customname) =
+           "ContractCodeHistoryOperationTypeInit"];
   // ContractCodeHistoryOperationTypeMigrate code migration
   CONTRACT_CODE_HISTORY_OPERATION_TYPE_MIGRATE = 2
-      [ (gogoproto.enumvalue_customname) =
-            "ContractCodeHistoryOperationTypeMigrate" ];
+      [(gogoproto.enumvalue_customname) =
+           "ContractCodeHistoryOperationTypeMigrate"];
   // ContractCodeHistoryOperationTypeGenesis based on genesis data
   CONTRACT_CODE_HISTORY_OPERATION_TYPE_GENESIS = 3
-      [ (gogoproto.enumvalue_customname) =
-            "ContractCodeHistoryOperationTypeGenesis" ];
+      [(gogoproto.enumvalue_customname) =
+           "ContractCodeHistoryOperationTypeGenesis"];
 }
 
 // ContractCodeHistoryEntry metadata to a contract.
 message ContractCodeHistoryEntry {
   ContractCodeHistoryOperationType operation = 1;
   // CodeID is the reference to the stored WASM code
-  uint64 code_id = 2 [ (gogoproto.customname) = "CodeID" ];
+  uint64 code_id = 2 [(gogoproto.customname) = "CodeID"];
   // Updated Tx position when the operation was executed.
   AbsoluteTxPosition updated = 3;
-  bytes msg = 4 [ (gogoproto.casttype) = "RawContractMessage" ];
+  bytes              msg     = 4 [(gogoproto.casttype) = "RawContractMessage"];
 }
 
 // AbsoluteTxPosition is a unique transaction position that allows for global
@@ -139,8 +139,8 @@ message AbsoluteTxPosition {
 // Model is a struct that holds a KV pair
 message Model {
   // hex-encode key to read it better (this is often ascii)
-  bytes key = 1 [ (gogoproto.casttype) =
-                      "github.com/cometbft/cometbft/libs/bytes.HexBytes" ];
+  bytes key = 1 [(gogoproto.casttype) =
+                     "github.com/cometbft/cometbft/libs/bytes.HexBytes"];
   // base64-encode raw value
   bytes value = 2;
 }

--- a/proto/cosmwasm/wasm/v1/types.proto
+++ b/proto/cosmwasm/wasm/v1/types.proto
@@ -15,20 +15,16 @@ enum AccessType {
   option (gogoproto.goproto_enum_prefix)   = false;
   option (gogoproto.goproto_enum_stringer) = false;
   // AccessTypeUnspecified placeholder for empty value
-  ACCESS_TYPE_UNSPECIFIED = 0
-      [(gogoproto.enumvalue_customname) = "AccessTypeUnspecified"];
+  ACCESS_TYPE_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "AccessTypeUnspecified"];
   // AccessTypeNobody forbidden
-  ACCESS_TYPE_NOBODY = 1
-      [(gogoproto.enumvalue_customname) = "AccessTypeNobody"];
+  ACCESS_TYPE_NOBODY = 1 [(gogoproto.enumvalue_customname) = "AccessTypeNobody"];
 
   reserved 2;  // was AccessTypeOnlyAddress
 
   // AccessTypeEverybody unrestricted
-  ACCESS_TYPE_EVERYBODY = 3
-      [(gogoproto.enumvalue_customname) = "AccessTypeEverybody"];
+  ACCESS_TYPE_EVERYBODY = 3 [(gogoproto.enumvalue_customname) = "AccessTypeEverybody"];
   // AccessTypeAnyOfAddresses allow any of the addresses
-  ACCESS_TYPE_ANY_OF_ADDRESSES = 4
-      [(gogoproto.enumvalue_customname) = "AccessTypeAnyOfAddresses"];
+  ACCESS_TYPE_ANY_OF_ADDRESSES = 4 [(gogoproto.enumvalue_customname) = "AccessTypeAnyOfAddresses"];
 }
 
 // AccessTypeParam
@@ -68,8 +64,7 @@ message CodeInfo {
   // Used in v1beta1
   reserved 3, 4;
   // InstantiateConfig access control to apply on contract creation, optional
-  AccessConfig instantiate_config = 5
-      [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  AccessConfig instantiate_config = 5 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
 }
 
 // ContractInfo stores a WASM contract instance
@@ -91,8 +86,7 @@ message ContractInfo {
   // Extension is an extension point to store custom metadata within the
   // persistence model.
   google.protobuf.Any extension = 7
-      [(cosmos_proto.accepts_interface) =
-           "cosmwasm.wasm.v1.ContractInfoExtension"];
+      [(cosmos_proto.accepts_interface) = "cosmwasm.wasm.v1.ContractInfoExtension"];
 }
 
 // ContractCodeHistoryOperationType actions that caused a code change
@@ -100,20 +94,16 @@ enum ContractCodeHistoryOperationType {
   option (gogoproto.goproto_enum_prefix) = false;
   // ContractCodeHistoryOperationTypeUnspecified placeholder for empty value
   CONTRACT_CODE_HISTORY_OPERATION_TYPE_UNSPECIFIED = 0
-      [(gogoproto.enumvalue_customname) =
-           "ContractCodeHistoryOperationTypeUnspecified"];
+      [(gogoproto.enumvalue_customname) = "ContractCodeHistoryOperationTypeUnspecified"];
   // ContractCodeHistoryOperationTypeInit on chain contract instantiation
   CONTRACT_CODE_HISTORY_OPERATION_TYPE_INIT = 1
-      [(gogoproto.enumvalue_customname) =
-           "ContractCodeHistoryOperationTypeInit"];
+      [(gogoproto.enumvalue_customname) = "ContractCodeHistoryOperationTypeInit"];
   // ContractCodeHistoryOperationTypeMigrate code migration
   CONTRACT_CODE_HISTORY_OPERATION_TYPE_MIGRATE = 2
-      [(gogoproto.enumvalue_customname) =
-           "ContractCodeHistoryOperationTypeMigrate"];
+      [(gogoproto.enumvalue_customname) = "ContractCodeHistoryOperationTypeMigrate"];
   // ContractCodeHistoryOperationTypeGenesis based on genesis data
   CONTRACT_CODE_HISTORY_OPERATION_TYPE_GENESIS = 3
-      [(gogoproto.enumvalue_customname) =
-           "ContractCodeHistoryOperationTypeGenesis"];
+      [(gogoproto.enumvalue_customname) = "ContractCodeHistoryOperationTypeGenesis"];
 }
 
 // ContractCodeHistoryEntry metadata to a contract.
@@ -139,8 +129,7 @@ message AbsoluteTxPosition {
 // Model is a struct that holds a KV pair
 message Model {
   // hex-encode key to read it better (this is often ascii)
-  bytes key = 1 [(gogoproto.casttype) =
-                     "github.com/cometbft/cometbft/libs/bytes.HexBytes"];
+  bytes key = 1 [(gogoproto.casttype) = "github.com/cometbft/cometbft/libs/bytes.HexBytes"];
   // base64-encode raw value
   bytes value = 2;
 }

--- a/proto/eth/evm/v1/events.proto
+++ b/proto/eth/evm/v1/events.proto
@@ -41,19 +41,19 @@ message EventBlockBloom {
 
 // EventFunTokenCreated defines a fun token creation event.
 message EventFunTokenCreated {
-  string bank_denom = 1;
+  string bank_denom             = 1;
   string erc20_contract_address = 2;
-  string creator = 3;
-  bool is_made_from_coin = 4;
+  string creator                = 3;
+  bool   is_made_from_coin      = 4;
 }
 
 // EventConvertCoinToEvm is an event emitted when converting Bank Coins into
 // ERC20 tokens with the "eth.evm.v1.MsgConvertCoinToEvm" transaction message.
 message EventConvertCoinToEvm {
-  string sender = 1;
-  string erc20_contract_address = 2;
-  string to_eth_addr = 3;
-  cosmos.base.v1beta1.Coin bank_coin = 4 [
+  string                   sender                 = 1;
+  string                   erc20_contract_address = 2;
+  string                   to_eth_addr            = 3;
+  cosmos.base.v1beta1.Coin bank_coin              = 4 [
     (gogoproto.moretags) = "yaml:\"bank_coin\"",
     (gogoproto.nullable) = false
   ];
@@ -62,34 +62,34 @@ message EventConvertCoinToEvm {
 
 // EventTransfer defines event for EVM transfer
 message EventTransfer {
-  string sender = 1;
+  string sender    = 1;
   string recipient = 2;
-  string amount = 3;
+  string amount    = 3;
 }
 
 // EventContractDeployed defines event for EVM contract deployment
 message EventContractDeployed {
-  string sender = 1;
+  string sender        = 1;
   string contract_addr = 2;
 }
 
 // EventContractExecuted defines event for EVM contract execution
 message EventContractExecuted {
-  string sender = 1;
+  string sender        = 1;
   string contract_addr = 2;
 }
 
 // EventConvertEvmToCoin is an event emitted when converting ERC20 tokens to
 // Bank Coins with the "eth.evm.v1.MsgConvertEvmToCoin" transaction message.
 message EventConvertEvmToCoin {
-  string sender = 1;
-  string erc20_contract_address = 2;
-  string to_address = 3;
-  cosmos.base.v1beta1.Coin bank_coin = 4 [
+  string                   sender                 = 1;
+  string                   erc20_contract_address = 2;
+  string                   to_address             = 3;
+  cosmos.base.v1beta1.Coin bank_coin              = 4 [
     (gogoproto.moretags) = "yaml:\"bank_coin\"",
     (gogoproto.nullable) = false
   ];
-  string sender_eth_addr = 6;
+  string   sender_eth_addr             = 6;
   repeated eth.evm.v1.LogLite evm_logs = 7 [(gogoproto.nullable) = false];
 }
 
@@ -100,7 +100,7 @@ message EventWeiBlockDelta {
   // this point. It is the value for "NetWeiBlockDelta" in the EVM state.
   string net_wei_block_delta = 1 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // WeiBlockDelta is the net sum of all calls of "AddWei" and "SubWei" in the
@@ -110,7 +110,7 @@ message EventWeiBlockDelta {
   // supply. "WeiBlockDelta" is a mechanism for recording that if it happens.
   string wei_block_delta = 2 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // block_number for which this event is emitted during EVM EndBlock

--- a/proto/eth/evm/v1/events.proto
+++ b/proto/eth/evm/v1/events.proto
@@ -53,10 +53,8 @@ message EventConvertCoinToEvm {
   string                   sender                 = 1;
   string                   erc20_contract_address = 2;
   string                   to_eth_addr            = 3;
-  cosmos.base.v1beta1.Coin bank_coin              = 4 [
-    (gogoproto.moretags) = "yaml:\"bank_coin\"",
-    (gogoproto.nullable) = false
-  ];
+  cosmos.base.v1beta1.Coin bank_coin              = 4
+      [(gogoproto.moretags) = "yaml:\"bank_coin\"", (gogoproto.nullable) = false];
   repeated eth.evm.v1.LogLite evm_logs = 5 [(gogoproto.nullable) = false];
 }
 
@@ -85,10 +83,8 @@ message EventConvertEvmToCoin {
   string                   sender                 = 1;
   string                   erc20_contract_address = 2;
   string                   to_address             = 3;
-  cosmos.base.v1beta1.Coin bank_coin              = 4 [
-    (gogoproto.moretags) = "yaml:\"bank_coin\"",
-    (gogoproto.nullable) = false
-  ];
+  cosmos.base.v1beta1.Coin bank_coin              = 4
+      [(gogoproto.moretags) = "yaml:\"bank_coin\"", (gogoproto.nullable) = false];
   string   sender_eth_addr             = 6;
   repeated eth.evm.v1.LogLite evm_logs = 7 [(gogoproto.nullable) = false];
 }
@@ -98,20 +94,16 @@ message EventConvertEvmToCoin {
 message EventWeiBlockDelta {
   // net_wei_block_delta is the new sum of all "wei_block_delta" changes up to
   // this point. It is the value for "NetWeiBlockDelta" in the EVM state.
-  string net_wei_block_delta = 1 [
-    (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable)   = false
-  ];
+  string net_wei_block_delta = 1
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.nullable) = false];
 
   // WeiBlockDelta is the net sum of all calls of "AddWei" and "SubWei" in the
   // current block. There is no guarantee in the functional sense that the EVM
   // State DB will add the same amount it subtracts. It is possible for the
   // total amount of wei (NIBI) across all accounts to diverge from the initial
   // supply. "WeiBlockDelta" is a mechanism for recording that if it happens.
-  string wei_block_delta = 2 [
-    (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable)   = false
-  ];
+  string wei_block_delta = 2
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.nullable) = false];
 
   // block_number for which this event is emitted during EVM EndBlock
   uint64 block_number = 3;

--- a/proto/eth/evm/v1/evm.proto
+++ b/proto/eth/evm/v1/evm.proto
@@ -14,7 +14,7 @@ message FunToken {
   // Hexadecimal address of the ERC20 token to which the `FunToken` maps
   string erc20_addr = 1 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/eth.EIP55Addr",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // bank_denom: Coin denomination in the Bank Module.
@@ -39,7 +39,7 @@ message Params {
   // extra_eips defines the additional EIPs for the vm.Config
   repeated int64 extra_eips = 4 [
     (gogoproto.customname) = "ExtraEIPs",
-    (gogoproto.moretags) = "yaml:\"extra_eips\""
+    (gogoproto.moretags)   = "yaml:\"extra_eips\""
   ];
   // DEPRECATED: chain_config
   reserved 5;
@@ -56,13 +56,13 @@ message Params {
   // "evm_denom".
   string create_funtoken_fee = 9 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // Hexadecimal address of the canonical WNIBI contract on Nibiru mainnet
   string canonical_wnibi = 10 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/eth.EIP55Addr",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   repeated eth.evm.v1.WasmPlugin wasm_plugins = 11 [(gogoproto.nullable) = false];

--- a/proto/eth/evm/v1/evm.proto
+++ b/proto/eth/evm/v1/evm.proto
@@ -37,10 +37,8 @@ message Params {
   reserved 3;
 
   // extra_eips defines the additional EIPs for the vm.Config
-  repeated int64 extra_eips = 4 [
-    (gogoproto.customname) = "ExtraEIPs",
-    (gogoproto.moretags)   = "yaml:\"extra_eips\""
-  ];
+  repeated int64 extra_eips = 4
+      [(gogoproto.customname) = "ExtraEIPs", (gogoproto.moretags) = "yaml:\"extra_eips\""];
   // DEPRECATED: chain_config
   reserved 5;
   // DEPRECATED: allow_unprotected_txs
@@ -54,10 +52,8 @@ message Params {
 
   // Fee deducted and burned when calling "CreateFunToken" in units of
   // "evm_denom".
-  string create_funtoken_fee = 9 [
-    (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable)   = false
-  ];
+  string create_funtoken_fee = 9
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.nullable) = false];
 
   // Hexadecimal address of the canonical WNIBI contract on Nibiru mainnet
   string canonical_wnibi = 10 [

--- a/proto/eth/evm/v1/genesis.proto
+++ b/proto/eth/evm/v1/genesis.proto
@@ -28,8 +28,5 @@ message GenesisAccount {
   // code defines the hex bytes of the account code.
   string code = 2;
   // storage defines the set of state key values for the account.
-  repeated State storage = 3 [
-    (gogoproto.nullable)     = false,
-    (gogoproto.castrepeated) = "Storage"
-  ];
+  repeated State storage = 3 [(gogoproto.nullable) = false, (gogoproto.castrepeated) = "Storage"];
 }

--- a/proto/eth/evm/v1/genesis.proto
+++ b/proto/eth/evm/v1/genesis.proto
@@ -29,7 +29,7 @@ message GenesisAccount {
   string code = 2;
   // storage defines the set of state key values for the account.
   repeated State storage = 3 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)     = false,
     (gogoproto.castrepeated) = "Storage"
   ];
 }

--- a/proto/eth/evm/v1/query.proto
+++ b/proto/eth/evm/v1/query.proto
@@ -85,7 +85,7 @@ service Query {
 
 // QueryEthAccountRequest: Request type for "/eth.evm.v1.Query/EthAccount"
 message QueryEthAccountRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the Ethereum hex address or nibi Bech32 address to query the
@@ -120,7 +120,7 @@ message QueryEthAccountResponse {
 // QueryValidatorAccountRequest is the request type for the
 // Query/ValidatorAccount RPC method.
 message QueryValidatorAccountRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // cons_address is the validator cons address to query the account for.
@@ -140,7 +140,7 @@ message QueryValidatorAccountResponse {
 
 // QueryBalanceRequest: Response type for "/eth.evm.v1.Query/Balance"
 message QueryBalanceRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the ethereum hex address to query the balance for.
@@ -167,26 +167,26 @@ message QueryBalanceResponse {
 
 // BalanceBank is the Bank module balance view for a token.
 message BalanceBank {
-  string symbol = 1;
+  string symbol        = 1;
   string balance_human = 2;
-  uint32 decimals = 3;
-  string coin_denom = 4;
-  string balance_base = 5;
+  uint32 decimals      = 3;
+  string coin_denom    = 4;
+  string balance_base  = 5;
 }
 
 // BalanceERC20 is the ERC20 balance view for a token.
 message BalanceERC20 {
-  string address = 1;
-  string symbol = 2;
+  string address       = 1;
+  string symbol        = 2;
   string balance_human = 3;
-  uint32 decimals = 4;
-  string name = 5;
-  string balance_base = 6;
+  uint32 decimals      = 4;
+  string name          = 5;
+  string balance_base  = 6;
 }
 
 // QueryStorageRequest is the request type for the Query/Storage RPC method.
 message QueryStorageRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the ethereum hex address to query the storage state for.
@@ -205,7 +205,7 @@ message QueryStorageResponse {
 
 // QueryCodeRequest is the request type for the Query/Code RPC method.
 message QueryCodeRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // address is the ethereum hex address to query the code for.
@@ -221,7 +221,7 @@ message QueryCodeResponse {
 
 // QueryTxLogsRequest is the request type for the Query/TxLogs RPC method.
 message QueryTxLogsRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // hash is the ethereum transaction hex hash to query the logs for.
@@ -284,7 +284,7 @@ message QueryTraceTxRequest {
   // block_time of requested transaction
   google.protobuf.Timestamp block_time = 7 [
     (gogoproto.nullable) = false,
-    (gogoproto.stdtime) = true
+    (gogoproto.stdtime)  = true
   ];
   // proposer_address is the proposer of the requested block
   bytes proposer_address = 8 [(gogoproto.casttype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.ConsAddress"];
@@ -313,7 +313,7 @@ message QueryTraceBlockRequest {
   // block_time of the traced block
   google.protobuf.Timestamp block_time = 7 [
     (gogoproto.nullable) = false,
-    (gogoproto.stdtime) = true
+    (gogoproto.stdtime)  = true
   ];
   // proposer_address is the address of the requested block
   bytes proposer_address = 8 [(gogoproto.casttype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.ConsAddress"];
@@ -344,7 +344,7 @@ message QueryBaseFeeResponse {
 }
 
 message QueryFunTokenMappingRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // Either the hexadecimal-encoded ERC20 contract address or denomination of
@@ -353,7 +353,7 @@ message QueryFunTokenMappingRequest {
 }
 
 message QueryFunTokenMappingResponse {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // fun_token is a mapping between the Bank Coin and the ERC20 contract address

--- a/proto/eth/evm/v1/query.proto
+++ b/proto/eth/evm/v1/query.proto
@@ -254,7 +254,8 @@ message EthCallRequest {
   // gas_cap defines the default gas cap to be used
   uint64 gas_cap = 2;
   // proposer_address of the requested block in hex format
-  bytes proposer_address = 3 [(gogoproto.casttype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.ConsAddress"];
+  bytes proposer_address = 3
+      [(gogoproto.casttype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.ConsAddress"];
   // chain_id is the eip155 chain id parsed from the requested block header
   int64 chain_id = 4;
 }
@@ -282,12 +283,11 @@ message QueryTraceTxRequest {
   // block_hash of requested transaction
   string block_hash = 6;
   // block_time of requested transaction
-  google.protobuf.Timestamp block_time = 7 [
-    (gogoproto.nullable) = false,
-    (gogoproto.stdtime)  = true
-  ];
+  google.protobuf.Timestamp block_time = 7
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
   // proposer_address is the proposer of the requested block
-  bytes proposer_address = 8 [(gogoproto.casttype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.ConsAddress"];
+  bytes proposer_address = 8
+      [(gogoproto.casttype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.ConsAddress"];
   // chain_id is the the eip155 chain id parsed from the requested block header
   int64 chain_id = 9;
   // block_max_gas of the block of the requested transaction
@@ -311,12 +311,11 @@ message QueryTraceBlockRequest {
   // block_hash (hex) of the traced block
   string block_hash = 6;
   // block_time of the traced block
-  google.protobuf.Timestamp block_time = 7 [
-    (gogoproto.nullable) = false,
-    (gogoproto.stdtime)  = true
-  ];
+  google.protobuf.Timestamp block_time = 7
+      [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
   // proposer_address is the address of the requested block
-  bytes proposer_address = 8 [(gogoproto.casttype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.ConsAddress"];
+  bytes proposer_address = 8
+      [(gogoproto.casttype) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.ConsAddress"];
   // chain_id is the eip155 chain id parsed from the requested block header
   int64 chain_id = 9;
   // block_max_gas of the traced block

--- a/proto/eth/evm/v1/tx.proto
+++ b/proto/eth/evm/v1/tx.proto
@@ -75,10 +75,8 @@ message LegacyTx {
   // to is the hex formatted address of the recipient
   string to = 4;
   // value defines the unsigned integer value of the transaction amount.
-  string value = 5 [
-    (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.customname) = "Amount"
-  ];
+  string value = 5
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.customname) = "Amount"];
   // data is the data payload bytes of the transaction.
   bytes data = 6;
 
@@ -122,10 +120,8 @@ message AccessListTx {
   // to is the recipient address in hex format
   string to = 5;
   // value defines the unsigned integer value of the transaction amount.
-  string value = 6 [
-    (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.customname) = "Amount"
-  ];
+  string value = 6
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.customname) = "Amount"];
   // data is the data payload bytes of the transaction.
   bytes data = 7;
   // accesses is an array of access tuples
@@ -177,10 +173,8 @@ message DynamicFeeTx {
   // to is the hex formatted address of the recipient
   string to = 6;
   // value defines the the transaction amount.
-  string value = 7 [
-    (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.customname) = "Amount"
-  ];
+  string value = 7
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.customname) = "Amount"];
   // data is the data payload bytes of the transaction.
   bytes data = 8;
   // accesses is an array of access tuples
@@ -290,10 +284,8 @@ message MsgConvertCoinToEvm {
   string sender = 2;
 
   // Bank Coin to get converted to ERC20
-  cosmos.base.v1beta1.Coin bank_coin = 3 [
-    (gogoproto.moretags) = "yaml:\"bank_coin\"",
-    (gogoproto.nullable) = false
-  ];
+  cosmos.base.v1beta1.Coin bank_coin = 3
+      [(gogoproto.moretags) = "yaml:\"bank_coin\"", (gogoproto.nullable) = false];
 }
 message MsgConvertCoinToEvmResponse {}
 
@@ -311,10 +303,8 @@ message MsgConvertEvmToCoin {
   ];
 
   // Amount of ERC20 tokens to convert
-  string amount = 3 [
-    (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable)   = false
-  ];
+  string amount = 3
+      [(gogoproto.customtype) = "cosmossdk.io/math.Int", (gogoproto.nullable) = false];
 
   // Recipient address for the bank coins in Ethereum hexadecimal or
   // nibi-prefixed Bech32 format.

--- a/proto/eth/evm/v1/tx.proto
+++ b/proto/eth/evm/v1/tx.proto
@@ -63,7 +63,7 @@ message MsgEthereumTx {
 // LegacyTx is a custom implementation of "LegacyTx" from
 // "github.com/ethereum/go-ethereum/core/types".
 message LegacyTx {
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)         = false;
   option (cosmos_proto.implements_interface) = "TxData";
 
   // nonce corresponds to the account nonce (transaction sequence).
@@ -104,14 +104,14 @@ message LegacyTx {
 // It is a custom implementation of "AccessListTx" from
 // "github.com/ethereum/go-ethereum/core/types".
 message AccessListTx {
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)         = false;
   option (cosmos_proto.implements_interface) = "TxData";
 
   // chain_id of the destination EVM chain
   string chain_id = 1 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
     (gogoproto.customname) = "ChainID",
-    (gogoproto.jsontag) = "chainID"
+    (gogoproto.jsontag)    = "chainID"
   ];
   // nonce corresponds to the account nonce (transaction sequence).
   uint64 nonce = 2;
@@ -131,8 +131,8 @@ message AccessListTx {
   // accesses is an array of access tuples
   repeated AccessTuple accesses = 8 [
     (gogoproto.castrepeated) = "AccessList",
-    (gogoproto.jsontag) = "accessList",
-    (gogoproto.nullable) = false
+    (gogoproto.jsontag)      = "accessList",
+    (gogoproto.nullable)     = false
   ];
 
   // v defines the recovery id and "v" signature value from the elliptic curve
@@ -157,14 +157,14 @@ message AccessListTx {
 // implementation of "DynamicFeeTx" from
 // "github.com/ethereum/go-ethereum/core/types".
 message DynamicFeeTx {
-  option (gogoproto.goproto_getters) = false;
+  option (gogoproto.goproto_getters)         = false;
   option (cosmos_proto.implements_interface) = "TxData";
 
   // chain_id of the destination EVM chain
   string chain_id = 1 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
     (gogoproto.customname) = "ChainID",
-    (gogoproto.jsontag) = "chainID"
+    (gogoproto.jsontag)    = "chainID"
   ];
   // nonce corresponds to the account nonce (transaction sequence).
   uint64 nonce = 2;
@@ -186,8 +186,8 @@ message DynamicFeeTx {
   // accesses is an array of access tuples
   repeated AccessTuple accesses = 9 [
     (gogoproto.castrepeated) = "AccessList",
-    (gogoproto.jsontag) = "accessList",
-    (gogoproto.nullable) = false
+    (gogoproto.jsontag)      = "accessList",
+    (gogoproto.nullable)     = false
   ];
   // v defines the recovery id and "v" signature value from the elliptic curve
   // digital signatute algorithm (ECDSA). It indicates which of two possible
@@ -255,7 +255,7 @@ message MsgCreateFunToken {
   // Hexadecimal address of the ERC20 token to which the `FunToken` maps
   string from_erc20 = 1 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/eth.EIP55Addr",
-    (gogoproto.nullable) = true
+    (gogoproto.nullable)   = true
   ];
 
   // Coin denomination in the Bank Module.
@@ -283,7 +283,7 @@ message MsgConvertCoinToEvm {
   // Hexadecimal address of the ERC20 token to which the `FunToken` maps
   string to_eth_addr = 1 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/eth.EIP55Addr",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // Sender: Address for the signer of the transaction.
@@ -307,13 +307,13 @@ message MsgConvertEvmToCoin {
   // Hexadecimal address of the ERC20 token to be converted and sent
   string erc20_addr = 2 [
     (gogoproto.customtype) = "github.com/NibiruChain/nibiru/v2/eth.EIP55Addr",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // Amount of ERC20 tokens to convert
   string amount = 3 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // Recipient address for the bank coins in Ethereum hexadecimal or

--- a/proto/eth/types/v1/account.proto
+++ b/proto/eth/types/v1/account.proto
@@ -12,13 +12,13 @@ option go_package = "github.com/NibiruChain/nibiru/v2/eth";
 // authtypes.BaseAccount type. It is compatible with the auth AccountKeeper.
 message EthAccount {
   option (gogoproto.goproto_getters) = false;
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
 
   option (cosmos_proto.implements_interface) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/auth/types.cosmos.auth.v1beta1.AccountI";
 
   // base_account is an authtypes.BaseAccount
   cosmos.auth.v1beta1.BaseAccount base_account = 1 [
-    (gogoproto.embed) = true,
+    (gogoproto.embed)    = true,
     (gogoproto.moretags) = "yaml:\"base_account\""
   ];
 

--- a/proto/eth/types/v1/account.proto
+++ b/proto/eth/types/v1/account.proto
@@ -14,13 +14,12 @@ message EthAccount {
   option (gogoproto.goproto_getters) = false;
   option (gogoproto.equal)           = false;
 
-  option (cosmos_proto.implements_interface) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/auth/types.cosmos.auth.v1beta1.AccountI";
+  option (cosmos_proto.implements_interface) =
+      "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/auth/types.cosmos.auth.v1beta1.AccountI";
 
   // base_account is an authtypes.BaseAccount
-  cosmos.auth.v1beta1.BaseAccount base_account = 1 [
-    (gogoproto.embed)    = true,
-    (gogoproto.moretags) = "yaml:\"base_account\""
-  ];
+  cosmos.auth.v1beta1.BaseAccount base_account = 1
+      [(gogoproto.embed) = true, (gogoproto.moretags) = "yaml:\"base_account\""];
 
   // code_hash is the hash calculated from the code contents
   string code_hash = 2 [(gogoproto.moretags) = "yaml:\"code_hash\""];

--- a/proto/nibiru/devgas/v1/event.proto
+++ b/proto/nibiru/devgas/v1/event.proto
@@ -51,4 +51,6 @@ message EventUpdateDevGas {
 
 // ABCI event emitted when fee sharing payouts are made, containing details on
 // the payouts in JSON format.
-message EventPayoutDevGas { string payouts = 1; }
+message EventPayoutDevGas {
+  string payouts = 1;
+}

--- a/proto/nibiru/devgas/v1/genesis.proto
+++ b/proto/nibiru/devgas/v1/genesis.proto
@@ -9,10 +9,10 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/devgas/v1/types";
 // GenesisState defines the module's genesis state.
 message GenesisState {
   // params are the feeshare module parameters
-  nibiru.devgas.v1.ModuleParams params = 1 [ (gogoproto.nullable) = false ];
+  nibiru.devgas.v1.ModuleParams params = 1 [(gogoproto.nullable) = false];
   // FeeShare is a slice of active registered contracts for fee distribution
   repeated nibiru.devgas.v1.FeeShare fee_share = 2
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }
 
 // ModuleParams defines the params for the devgas module
@@ -22,9 +22,9 @@ message ModuleParams {
   // developer_shares defines the proportion of the transaction fees to be
   // distributed to the registered contract owner
   string developer_shares = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // allowed_denoms defines the list of denoms that are allowed to be paid to
   // the contract withdraw addresses. If said denom is not in the list, the fees

--- a/proto/nibiru/devgas/v1/genesis.proto
+++ b/proto/nibiru/devgas/v1/genesis.proto
@@ -11,8 +11,7 @@ message GenesisState {
   // params are the feeshare module parameters
   nibiru.devgas.v1.ModuleParams params = 1 [(gogoproto.nullable) = false];
   // FeeShare is a slice of active registered contracts for fee distribution
-  repeated nibiru.devgas.v1.FeeShare fee_share = 2
-      [(gogoproto.nullable) = false];
+  repeated nibiru.devgas.v1.FeeShare fee_share = 2 [(gogoproto.nullable) = false];
 }
 
 // ModuleParams defines the params for the devgas module

--- a/proto/nibiru/devgas/v1/query.proto
+++ b/proto/nibiru/devgas/v1/query.proto
@@ -59,7 +59,7 @@ message QueryFeeSharesRequest {
 message QueryFeeSharesResponse {
   // FeeShare is the slice of all stored Reveneue for the deployer
   repeated nibiru.devgas.v1.FeeShare feeshare = 1
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }
 
 // QueryFeeShareRequest is the request type for the Query/FeeShare RPC method.
@@ -71,7 +71,7 @@ message QueryFeeShareRequest {
 // QueryFeeShareResponse is the response type for the Query/FeeShare RPC method.
 message QueryFeeShareResponse {
   // FeeShare is a stored Reveneue for the queried contract
-  nibiru.devgas.v1.FeeShare feeshare = 1 [ (gogoproto.nullable) = false ];
+  nibiru.devgas.v1.FeeShare feeshare = 1 [(gogoproto.nullable) = false];
 }
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.
@@ -80,7 +80,7 @@ message QueryParamsRequest {}
 // QueryParamsResponse is the response type for the Query/Params RPC method.
 message QueryParamsResponse {
   // params is the returned FeeShare parameter
-  nibiru.devgas.v1.ModuleParams params = 1 [ (gogoproto.nullable) = false ];
+  nibiru.devgas.v1.ModuleParams params = 1 [(gogoproto.nullable) = false];
 }
 
 // QueryFeeSharesByWithdrawerRequest is the request type for the
@@ -94,5 +94,5 @@ message QueryFeeSharesByWithdrawerRequest {
 // Query/FeeSharesByWithdrawer RPC method.
 message QueryFeeSharesByWithdrawerResponse {
   repeated nibiru.devgas.v1.FeeShare feeshare = 1
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }

--- a/proto/nibiru/devgas/v1/query.proto
+++ b/proto/nibiru/devgas/v1/query.proto
@@ -19,8 +19,7 @@ service Query {
 
   // FeeShare retrieves a registered FeeShare for a given contract address
   rpc FeeShare(QueryFeeShareRequest) returns (QueryFeeShareResponse) {
-    option (google.api.http).get =
-        "/nibiru/devgas/v1/fee_shares/{contract_address}";
+    option (google.api.http).get = "/nibiru/devgas/v1/fee_shares/{contract_address}";
   }
 
   // Params retrieves the module params
@@ -32,8 +31,7 @@ service Query {
   // address
   rpc FeeSharesByWithdrawer(QueryFeeSharesByWithdrawerRequest)
       returns (QueryFeeSharesByWithdrawerResponse) {
-    option (google.api.http).get =
-        "/nibiru/devgas/v1/fee_shares/{withdrawer_address}";
+    option (google.api.http).get = "/nibiru/devgas/v1/fee_shares/{withdrawer_address}";
   }
 }
 
@@ -58,8 +56,7 @@ message QueryFeeSharesRequest {
 // method.
 message QueryFeeSharesResponse {
   // FeeShare is the slice of all stored Reveneue for the deployer
-  repeated nibiru.devgas.v1.FeeShare feeshare = 1
-      [(gogoproto.nullable) = false];
+  repeated nibiru.devgas.v1.FeeShare feeshare = 1 [(gogoproto.nullable) = false];
 }
 
 // QueryFeeShareRequest is the request type for the Query/FeeShare RPC method.
@@ -93,6 +90,5 @@ message QueryFeeSharesByWithdrawerRequest {
 // QueryFeeSharesByWithdrawerResponse is the response type for the
 // Query/FeeSharesByWithdrawer RPC method.
 message QueryFeeSharesByWithdrawerResponse {
-  repeated nibiru.devgas.v1.FeeShare feeshare = 1
-      [(gogoproto.nullable) = false];
+  repeated nibiru.devgas.v1.FeeShare feeshare = 1 [(gogoproto.nullable) = false];
 }

--- a/proto/nibiru/devgas/v1/tx.proto
+++ b/proto/nibiru/devgas/v1/tx.proto
@@ -84,12 +84,12 @@ message MsgUpdateParams {
 
   // authority is the address that controls the module (defaults to x/gov unless
   // overwritten).
-  string authority = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   // params defines the x/feeshare parameters to update.
   //
   // NOTE: All parameters must be supplied.
-  ModuleParams params = 2 [ (gogoproto.nullable) = false ];
+  ModuleParams params = 2 [(gogoproto.nullable) = false];
 }
 
 // MsgUpdateParamsResponse defines the response structure for executing a

--- a/proto/nibiru/devgas/v1/tx.proto
+++ b/proto/nibiru/devgas/v1/tx.proto
@@ -13,8 +13,7 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/devgas/v1/types";
 // Msg defines the fees Msg service.
 service Msg {
   // RegisterFeeShare registers a new contract for receiving transaction fees
-  rpc RegisterFeeShare(MsgRegisterFeeShare)
-      returns (MsgRegisterFeeShareResponse) {
+  rpc RegisterFeeShare(MsgRegisterFeeShare) returns (MsgRegisterFeeShareResponse) {
     option (google.api.http).post = "/nibiru/devgas/v1/tx/register_FeeShare";
   };
   // UpdateFeeShare updates the withdrawer address of a FeeShare

--- a/proto/nibiru/epochs/v1/event.proto
+++ b/proto/nibiru/epochs/v1/event.proto
@@ -12,7 +12,7 @@ message EventEpochStart {
 
   // The start timestamp of the epoch.
   google.protobuf.Timestamp epoch_start_time = 2
-      [ (gogoproto.stdtime) = true, (gogoproto.nullable) = false ];
+      [(gogoproto.stdtime) = true, (gogoproto.nullable) = false];
 }
 
 message EventEpochEnd {

--- a/proto/nibiru/epochs/v1/genesis.proto
+++ b/proto/nibiru/epochs/v1/genesis.proto
@@ -11,5 +11,5 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/epochs";
 // GenesisState defines the epochs module's genesis state.
 message GenesisState {
   repeated nibiru.epochs.v1.EpochInfo epochs = 1
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }

--- a/proto/nibiru/epochs/v1/genesis.proto
+++ b/proto/nibiru/epochs/v1/genesis.proto
@@ -10,6 +10,5 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/epochs";
 
 // GenesisState defines the epochs module's genesis state.
 message GenesisState {
-  repeated nibiru.epochs.v1.EpochInfo epochs = 1
-      [(gogoproto.nullable) = false];
+  repeated nibiru.epochs.v1.EpochInfo epochs = 1 [(gogoproto.nullable) = false];
 }

--- a/proto/nibiru/epochs/v1/query.proto
+++ b/proto/nibiru/epochs/v1/query.proto
@@ -15,16 +15,14 @@ service Query {
     option (google.api.http).get = "/nibiru/epochs/v1beta1/epochs";
   }
   // CurrentEpoch provide current epoch of specified identifier
-  rpc CurrentEpoch(QueryCurrentEpochRequest)
-      returns (QueryCurrentEpochResponse) {
+  rpc CurrentEpoch(QueryCurrentEpochRequest) returns (QueryCurrentEpochResponse) {
     option (google.api.http).get = "/nibiru/epochs/v1beta1/current_epoch";
   }
 }
 
 message QueryEpochInfosRequest {}
 message QueryEpochInfosResponse {
-  repeated nibiru.epochs.v1.EpochInfo epochs = 1
-      [(gogoproto.nullable) = false];
+  repeated nibiru.epochs.v1.EpochInfo epochs = 1 [(gogoproto.nullable) = false];
 }
 
 message QueryCurrentEpochRequest {

--- a/proto/nibiru/epochs/v1/query.proto
+++ b/proto/nibiru/epochs/v1/query.proto
@@ -24,8 +24,12 @@ service Query {
 message QueryEpochInfosRequest {}
 message QueryEpochInfosResponse {
   repeated nibiru.epochs.v1.EpochInfo epochs = 1
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }
 
-message QueryCurrentEpochRequest { string identifier = 1; }
-message QueryCurrentEpochResponse { uint64 current_epoch = 1; }
+message QueryCurrentEpochRequest {
+  string identifier = 1;
+}
+message QueryCurrentEpochResponse {
+  uint64 current_epoch = 1;
+}

--- a/proto/nibiru/epochs/v1/state.proto
+++ b/proto/nibiru/epochs/v1/state.proto
@@ -13,17 +13,17 @@ message EpochInfo {
 
   // When the epoch repetitino should start.
   google.protobuf.Timestamp start_time = 2 [
-    (gogoproto.stdtime) = true,
+    (gogoproto.stdtime)  = true,
     (gogoproto.nullable) = false,
     (gogoproto.moretags) = "yaml:\"start_time\""
   ];
 
   // How long each epoch lasts for.
   google.protobuf.Duration duration = 3 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)    = false,
     (gogoproto.stdduration) = true,
-    (gogoproto.jsontag) = "duration,omitempty",
-    (gogoproto.moretags) = "yaml:\"duration\""
+    (gogoproto.jsontag)     = "duration,omitempty",
+    (gogoproto.moretags)    = "yaml:\"duration\""
   ];
 
   // The current epoch number, starting from 1.
@@ -31,7 +31,7 @@ message EpochInfo {
 
   // The start timestamp of the current epoch.
   google.protobuf.Timestamp current_epoch_start_time = 5 [
-    (gogoproto.stdtime) = true,
+    (gogoproto.stdtime)  = true,
     (gogoproto.nullable) = false,
     (gogoproto.moretags) = "yaml:\"current_epoch_start_time\""
   ];

--- a/proto/nibiru/genmsg/v1/genmsg.proto
+++ b/proto/nibiru/genmsg/v1/genmsg.proto
@@ -7,4 +7,6 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/genmsg/v1";
 
 // GenesisState represents the messages to be processed during genesis by the
 // genmsg module.
-message GenesisState { repeated google.protobuf.Any messages = 1; }
+message GenesisState {
+  repeated google.protobuf.Any messages = 1;
+}

--- a/proto/nibiru/inflation/v1/event.proto
+++ b/proto/nibiru/inflation/v1/event.proto
@@ -9,18 +9,12 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/mint";
 // EventInflationDistribution: Emitted when NIBI tokens are minted on the
 // network based on Nibiru's inflation schedule.
 message EventInflationDistribution {
-  cosmos.base.v1beta1.Coin staking_rewards = 1 [
-    (gogoproto.moretags) = "yaml:\"staking_rewards\"",
-    (gogoproto.nullable) = false
-  ];
+  cosmos.base.v1beta1.Coin staking_rewards = 1
+      [(gogoproto.moretags) = "yaml:\"staking_rewards\"", (gogoproto.nullable) = false];
 
-  cosmos.base.v1beta1.Coin strategic_reserve = 2 [
-    (gogoproto.moretags) = "yaml:\"strategic_reserve\"",
-    (gogoproto.nullable) = false
-  ];
+  cosmos.base.v1beta1.Coin strategic_reserve = 2
+      [(gogoproto.moretags) = "yaml:\"strategic_reserve\"", (gogoproto.nullable) = false];
 
-  cosmos.base.v1beta1.Coin community_pool = 3 [
-    (gogoproto.moretags) = "yaml:\"community_pool\"",
-    (gogoproto.nullable) = false
-  ];
+  cosmos.base.v1beta1.Coin community_pool = 3
+      [(gogoproto.moretags) = "yaml:\"community_pool\"", (gogoproto.nullable) = false];
 }

--- a/proto/nibiru/inflation/v1/genesis.proto
+++ b/proto/nibiru/inflation/v1/genesis.proto
@@ -27,9 +27,9 @@ message Params {
   // polynomial_factors takes in the variables to calculate polynomial
   // inflation
   repeated string polynomial_factors = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // inflation_distribution of the minted denom
   InflationDistribution inflation_distribution = 3 [(gogoproto.nullable) = false];

--- a/proto/nibiru/inflation/v1/inflation.proto
+++ b/proto/nibiru/inflation/v1/inflation.proto
@@ -13,22 +13,22 @@ message InflationDistribution {
   // staking_rewards defines the proportion of the minted_denom that is
   // to be allocated as staking rewards
   string staking_rewards = 1 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // community_pool defines the proportion of the minted_denom that is to
   // be allocated to the community pool
   string community_pool = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // strategic_reserves defines the proportion of the minted_denom that
   // is to be allocated to the strategic reserves module address
   string strategic_reserves = 3 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }

--- a/proto/nibiru/inflation/v1/query.proto
+++ b/proto/nibiru/inflation/v1/query.proto
@@ -61,7 +61,7 @@ message QueryEpochMintProvisionRequest {}
 message QueryEpochMintProvisionResponse {
   // epoch_mint_provision is the current minting per epoch provision value.
   cosmos.base.v1beta1.DecCoin epoch_mint_provision = 1 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)     = false,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins"
   ];
 }
@@ -87,7 +87,7 @@ message QueryCirculatingSupplyRequest {}
 message QueryCirculatingSupplyResponse {
   // circulating_supply is the total amount of coins in circulation
   cosmos.base.v1beta1.DecCoin circulating_supply = 1 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)     = false,
     (gogoproto.castrepeated) = "github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/types.DecCoins"
   ];
 }
@@ -101,9 +101,9 @@ message QueryInflationRateRequest {}
 message QueryInflationRateResponse {
   // inflation_rate by which the total supply increases within one period
   string inflation_rate = 1 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 

--- a/proto/nibiru/inflation/v1/tx.proto
+++ b/proto/nibiru/inflation/v1/tx.proto
@@ -67,10 +67,8 @@ message MsgEditInflationParamsResponse {}
 // MsgBurn: allows burning of any token
 message MsgBurn {
   string                   sender = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
-  cosmos.base.v1beta1.Coin coin   = 2 [
-    (gogoproto.moretags) = "yaml:\"coin\"",
-    (gogoproto.nullable) = false
-  ];
+  cosmos.base.v1beta1.Coin coin   = 2
+      [(gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false];
 }
 
 message MsgBurnResponse {}

--- a/proto/nibiru/inflation/v1/tx.proto
+++ b/proto/nibiru/inflation/v1/tx.proto
@@ -23,40 +23,40 @@ service Msg {
 
 // MsgToggleInflation defines a message to enable or disable inflation.
 message MsgToggleInflation {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   string sender = 1;
-  bool enable = 2 [(gogoproto.moretags) = "yaml:\"enable\""];
+  bool   enable = 2 [(gogoproto.moretags) = "yaml:\"enable\""];
 }
 
 message MsgEditInflationParams {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string sender = 1;
-  bool inflation_enabled = 2;
+  string          sender             = 1;
+  bool            inflation_enabled  = 2;
   repeated string polynomial_factors = 3 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = true
+    (gogoproto.nullable)   = true
   ];
   InflationDistribution inflation_distribution = 4 [(gogoproto.nullable) = true];
 
   string epochs_per_period = 5 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable) = true
+    (gogoproto.nullable)   = true
   ];
   string periods_per_year = 6 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable) = true
+    (gogoproto.nullable)   = true
   ];
   string max_period = 7 [
-    (cosmos_proto.scalar) = "cosmos.Int",
+    (cosmos_proto.scalar)  = "cosmos.Int",
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
-    (gogoproto.nullable) = true
+    (gogoproto.nullable)   = true
   ];
 }
 
@@ -66,8 +66,8 @@ message MsgEditInflationParamsResponse {}
 
 // MsgBurn: allows burning of any token
 message MsgBurn {
-  string sender = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
-  cosmos.base.v1beta1.Coin coin = 2 [
+  string                   sender = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
+  cosmos.base.v1beta1.Coin coin   = 2 [
     (gogoproto.moretags) = "yaml:\"coin\"",
     (gogoproto.nullable) = false
   ];

--- a/proto/nibiru/oracle/v1/event.proto
+++ b/proto/nibiru/oracle/v1/event.proto
@@ -39,10 +39,8 @@ message EventAggregateVote {
   // transaction messages on behalf of the voting validator.
   string feeder = 2;
 
-  repeated nibiru.oracle.v1.ExchangeRateTuple prices = 3 [
-    (gogoproto.castrepeated) = "ExchangeRateTuples",
-    (gogoproto.nullable)     = false
-  ];
+  repeated nibiru.oracle.v1.ExchangeRateTuple prices = 3
+      [(gogoproto.castrepeated) = "ExchangeRateTuples", (gogoproto.nullable) = false];
 }
 
 // Emitted by MsgAggregateExchangePrevote when an aggregate prevote is added

--- a/proto/nibiru/oracle/v1/event.proto
+++ b/proto/nibiru/oracle/v1/event.proto
@@ -11,11 +11,11 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/oracle/types";
 
 // Emitted when a price is posted
 message EventPriceUpdate {
-  string pair = 1;
+  string pair  = 1;
   string price = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   int64 timestamp_ms = 3;
 }
@@ -41,7 +41,7 @@ message EventAggregateVote {
 
   repeated nibiru.oracle.v1.ExchangeRateTuple prices = 3 [
     (gogoproto.castrepeated) = "ExchangeRateTuples",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)     = false
   ];
 }
 

--- a/proto/nibiru/oracle/v1/genesis.proto
+++ b/proto/nibiru/oracle/v1/genesis.proto
@@ -10,25 +10,16 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/oracle/types";
 // GenesisState defines the oracle module's genesis state.
 message GenesisState {
   nibiru.oracle.v1.Params params                                = 1 [(gogoproto.nullable) = false];
-  repeated nibiru.oracle.v1.FeederDelegation feeder_delegations = 2
+  repeated nibiru.oracle.v1.FeederDelegation feeder_delegations = 2 [(gogoproto.nullable) = false];
+  repeated nibiru.oracle.v1.ExchangeRateTuple exchange_rates    = 3
+      [(gogoproto.castrepeated) = "ExchangeRateTuples", (gogoproto.nullable) = false];
+  repeated nibiru.oracle.v1.MissCounter miss_counters = 4 [(gogoproto.nullable) = false];
+  repeated nibiru.oracle.v1.AggregateExchangeRatePrevote aggregate_exchange_rate_prevotes = 5
       [(gogoproto.nullable) = false];
-  repeated nibiru.oracle.v1.ExchangeRateTuple exchange_rates = 3 [
-    (gogoproto.castrepeated) = "ExchangeRateTuples",
-    (gogoproto.nullable)     = false
-  ];
-  repeated nibiru.oracle.v1.MissCounter miss_counters = 4
+  repeated nibiru.oracle.v1.AggregateExchangeRateVote aggregate_exchange_rate_votes = 6
       [(gogoproto.nullable) = false];
-  repeated        nibiru.oracle.v1.AggregateExchangeRatePrevote
-                  aggregate_exchange_rate_prevotes = 5 [(gogoproto.nullable) = false];
-  repeated        nibiru.oracle.v1.AggregateExchangeRateVote
-                  aggregate_exchange_rate_votes = 6 [(gogoproto.nullable) = false];
-  repeated string pairs                         = 7 [
-    (gogoproto.customtype) =
-        "Pair",
-    (gogoproto.nullable) = false
-  ];
-  repeated nibiru.oracle.v1.Rewards rewards = 8
-      [(gogoproto.nullable) = false];
+  repeated string pairs = 7 [(gogoproto.customtype) = "Pair", (gogoproto.nullable) = false];
+  repeated nibiru.oracle.v1.Rewards rewards = 8 [(gogoproto.nullable) = false];
 }
 
 // FeederDelegation is the address for where oracle feeder authority are

--- a/proto/nibiru/oracle/v1/genesis.proto
+++ b/proto/nibiru/oracle/v1/genesis.proto
@@ -9,33 +9,33 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/oracle/types";
 
 // GenesisState defines the oracle module's genesis state.
 message GenesisState {
-  nibiru.oracle.v1.Params params = 1 [ (gogoproto.nullable) = false ];
+  nibiru.oracle.v1.Params params                                = 1 [(gogoproto.nullable) = false];
   repeated nibiru.oracle.v1.FeederDelegation feeder_delegations = 2
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
   repeated nibiru.oracle.v1.ExchangeRateTuple exchange_rates = 3 [
     (gogoproto.castrepeated) = "ExchangeRateTuples",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)     = false
   ];
   repeated nibiru.oracle.v1.MissCounter miss_counters = 4
-      [ (gogoproto.nullable) = false ];
-  repeated nibiru.oracle.v1.AggregateExchangeRatePrevote
-      aggregate_exchange_rate_prevotes = 5 [ (gogoproto.nullable) = false ];
-  repeated nibiru.oracle.v1.AggregateExchangeRateVote
-      aggregate_exchange_rate_votes = 6 [ (gogoproto.nullable) = false ];
-  repeated string pairs = 7 [
+      [(gogoproto.nullable) = false];
+  repeated        nibiru.oracle.v1.AggregateExchangeRatePrevote
+                  aggregate_exchange_rate_prevotes = 5 [(gogoproto.nullable) = false];
+  repeated        nibiru.oracle.v1.AggregateExchangeRateVote
+                  aggregate_exchange_rate_votes = 6 [(gogoproto.nullable) = false];
+  repeated string pairs                         = 7 [
     (gogoproto.customtype) =
         "Pair",
     (gogoproto.nullable) = false
   ];
   repeated nibiru.oracle.v1.Rewards rewards = 8
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }
 
 // FeederDelegation is the address for where oracle feeder authority are
 // delegated to. By default this struct is only used at genesis to feed in
 // default feeder addresses.
 message FeederDelegation {
-  string feeder_address = 1;
+  string feeder_address    = 1;
   string validator_address = 2;
 }
 
@@ -43,5 +43,5 @@ message FeederDelegation {
 // oracle module's genesis state
 message MissCounter {
   string validator_address = 1;
-  uint64 miss_counter = 2;
+  uint64 miss_counter      = 2;
 }

--- a/proto/nibiru/oracle/v1/oracle.proto
+++ b/proto/nibiru/oracle/v1/oracle.proto
@@ -39,11 +39,8 @@ message Params {
   ];
   // The set of whitelisted markets, or asset pairs, for the module.
   // Ex. '["unibi:uusd","ubtc:uusd"]'
-  repeated string whitelist = 4 [
-    (gogoproto.moretags) = "yaml:\"whitelist\"",
-    (gogoproto.customtype) =
-        "Pair"
-  ];
+  repeated string whitelist = 4
+      [(gogoproto.moretags) = "yaml:\"whitelist\"", (gogoproto.customtype) = "Pair"];
   // SlashFraction returns the proportion of an oracle's stake that gets
   // slashed in the event of slashing. `SlashFraction` specifies the exact
   // penalty for failing a voting period.
@@ -86,8 +83,7 @@ message Params {
     (gogoproto.nullable)   = false
   ];
 
-  uint64 expiration_blocks = 11
-      [(gogoproto.moretags) = "yaml:\"expiration_blocks\""];
+  uint64 expiration_blocks = 11 [(gogoproto.moretags) = "yaml:\"expiration_blocks\""];
 }
 
 // Struct for aggregate prevoting on the ExchangeRateVote.
@@ -124,10 +120,9 @@ message ExchangeRateTuple {
   option (gogoproto.goproto_getters) = false;
 
   string pair = 1 [
-    (gogoproto.moretags) = "yaml:\"pair\"",
-    (gogoproto.customtype) =
-        "Pair",
-    (gogoproto.nullable) = false
+    (gogoproto.moretags)   = "yaml:\"pair\"",
+    (gogoproto.customtype) = "Pair",
+    (gogoproto.nullable)   = false
   ];
 
   string exchange_rate = 2 [
@@ -151,8 +146,7 @@ message ExchangeRateAtBlock {
   // Block timestamp for the block where the oracle came to consensus for this
   // price. This timestamp is a conventional Unix millisecond time, i.e. the
   // number of milliseconds elapsed since January 1, 1970 UTC.
-  int64 block_timestamp_ms = 3
-      [(gogoproto.moretags) = "yaml:\"block_timestamp_ms\""];
+  int64 block_timestamp_ms = 3 [(gogoproto.moretags) = "yaml:\"block_timestamp_ms\""];
 }
 
 // Rewards defines a credit object towards validators

--- a/proto/nibiru/oracle/v1/oracle.proto
+++ b/proto/nibiru/oracle/v1/oracle.proto
@@ -13,15 +13,15 @@ message Params {
   option (gogoproto.equal) = true;
 
   // VotePeriod defines the number of blocks during which voting takes place.
-  uint64 vote_period = 1 [ (gogoproto.moretags) = "yaml:\"vote_period\"" ];
+  uint64 vote_period = 1 [(gogoproto.moretags) = "yaml:\"vote_period\""];
 
   // VoteThreshold specifies the minimum proportion of votes that must be
   // received for a ballot to pass.
   string vote_threshold = 2 [
-    (gogoproto.moretags) = "yaml:\"vote_threshold\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"vote_threshold\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // RewardBand defines a maximum divergence that a price vote can have from the
   // weighted median in the ballot. If a vote lies within the valid range
@@ -32,10 +32,10 @@ message Params {
   // Note that if the reward band is smaller than 1 standard
   // deviation, the band is taken to be 1 standard deviation.a price
   string reward_band = 3 [
-    (gogoproto.moretags) = "yaml:\"reward_band\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"reward_band\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // The set of whitelisted markets, or asset pairs, for the module.
   // Ex. '["unibi:uusd","ubtc:uusd"]'
@@ -48,46 +48,46 @@ message Params {
   // slashed in the event of slashing. `SlashFraction` specifies the exact
   // penalty for failing a voting period.
   string slash_fraction = 5 [
-    (gogoproto.moretags) = "yaml:\"slash_fraction\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"slash_fraction\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
   // SlashWindow returns the number of voting periods that specify a
   // "slash window". After each slash window, all oracles that have missed more
   // than the penalty threshold are slashed. Missing the penalty threshold is
   // synonymous with submitting fewer valid votes than `MinValidPerWindow`.
-  uint64 slash_window = 6 [ (gogoproto.moretags) = "yaml:\"slash_window\"" ];
+  uint64 slash_window         = 6 [(gogoproto.moretags) = "yaml:\"slash_window\""];
   string min_valid_per_window = 7 [
-    (gogoproto.moretags) = "yaml:\"min_valid_per_window\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"min_valid_per_window\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // Amount of time to look back for TWAP calculations.
   // Ex: "900.000000069s" corresponds to 900 seconds and 69 nanoseconds in JSON.
   google.protobuf.Duration twap_lookback_window = 8 [
-    (gogoproto.nullable) = false,
+    (gogoproto.nullable)    = false,
     (gogoproto.stdduration) = true,
-    (gogoproto.jsontag) = "twap_lookback_window,omitempty",
-    (gogoproto.moretags) = "yaml:\"twap_lookback_window\""
+    (gogoproto.jsontag)     = "twap_lookback_window,omitempty",
+    (gogoproto.moretags)    = "yaml:\"twap_lookback_window\""
   ];
 
   // The minimum number of voters (i.e. oracle validators) per pair for it to be
   // considered a passing ballot. Recommended at least 4.
-  uint64 min_voters = 9 [ (gogoproto.moretags) = "yaml:\"min_voters\"" ];
+  uint64 min_voters = 9 [(gogoproto.moretags) = "yaml:\"min_voters\""];
 
   // The validator fee ratio that is given to validators every epoch.
   string validator_fee_ratio = 10 [
-    (gogoproto.moretags) = "yaml:\"validator_fee_ratio\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"validator_fee_ratio\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   uint64 expiration_blocks = 11
-      [ (gogoproto.moretags) = "yaml:\"expiration_blocks\"" ];
+      [(gogoproto.moretags) = "yaml:\"expiration_blocks\""];
 }
 
 // Struct for aggregate prevoting on the ExchangeRateVote.
@@ -95,32 +95,32 @@ message Params {
 // which is formatted as hex string in
 // SHA256("{salt}:({pair},{exchange_rate})|...|({pair},{exchange_rate}):{voter}")
 message AggregateExchangeRatePrevote {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string hash = 1 [ (gogoproto.moretags) = "yaml:\"hash\"" ];
-  string voter = 2 [ (gogoproto.moretags) = "yaml:\"voter\"" ];
-  uint64 submit_block = 3 [ (gogoproto.moretags) = "yaml:\"submit_block\"" ];
+  string hash         = 1 [(gogoproto.moretags) = "yaml:\"hash\""];
+  string voter        = 2 [(gogoproto.moretags) = "yaml:\"voter\""];
+  uint64 submit_block = 3 [(gogoproto.moretags) = "yaml:\"submit_block\""];
 }
 
 // MsgAggregateExchangeRateVote - struct for voting on
 // the exchange rates different assets.
 message AggregateExchangeRateVote {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   repeated ExchangeRateTuple exchange_rate_tuples = 1 [
-    (gogoproto.moretags) = "yaml:\"exchange_rate_tuples\"",
+    (gogoproto.moretags)     = "yaml:\"exchange_rate_tuples\"",
     (gogoproto.castrepeated) = "ExchangeRateTuples",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)     = false
   ];
 
-  string voter = 2 [ (gogoproto.moretags) = "yaml:\"voter\"" ];
+  string voter = 2 [(gogoproto.moretags) = "yaml:\"voter\""];
 }
 
 // ExchangeRateTuple - struct to store interpreted exchange rates data to store
 message ExchangeRateTuple {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   string pair = 1 [
@@ -131,28 +131,28 @@ message ExchangeRateTuple {
   ];
 
   string exchange_rate = 2 [
-    (gogoproto.moretags) = "yaml:\"exchange_rate\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"exchange_rate\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 }
 
 message ExchangeRateAtBlock {
   string exchange_rate = 1 [
-    (gogoproto.moretags) = "yaml:\"exchange_rate\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"exchange_rate\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
-  uint64 created_block = 2 [ (gogoproto.moretags) = "yaml:\"created_block\"" ];
+  uint64 created_block = 2 [(gogoproto.moretags) = "yaml:\"created_block\""];
 
   // Block timestamp for the block where the oracle came to consensus for this
   // price. This timestamp is a conventional Unix millisecond time, i.e. the
   // number of milliseconds elapsed since January 1, 1970 UTC.
   int64 block_timestamp_ms = 3
-      [ (gogoproto.moretags) = "yaml:\"block_timestamp_ms\"" ];
+      [(gogoproto.moretags) = "yaml:\"block_timestamp_ms\""];
 }
 
 // Rewards defines a credit object towards validators
@@ -164,5 +164,5 @@ message Rewards {
   // distributed.
   uint64 vote_periods = 2;
   // Coins defines the amount of coins to distribute in a single vote period.
-  repeated cosmos.base.v1beta1.Coin coins = 3 [ (gogoproto.nullable) = false ];
+  repeated cosmos.base.v1beta1.Coin coins = 3 [(gogoproto.nullable) = false];
 }

--- a/proto/nibiru/oracle/v1/query.proto
+++ b/proto/nibiru/oracle/v1/query.proto
@@ -91,7 +91,7 @@ service Query {
 // QueryExchangeRateRequest is the request type for the Query/ExchangeRate RPC
 // method.
 message QueryExchangeRateRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // pair defines the pair to query for.
@@ -107,9 +107,9 @@ message QueryExchangeRateRequest {
 message QueryExchangeRateResponse {
   // exchange_rate defines the exchange rate of assets voted by validators
   string exchange_rate = 1 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // Block timestamp for the block where the oracle came to consensus for this
@@ -135,7 +135,7 @@ message QueryExchangeRatesResponse {
   // pairs.
   repeated nibiru.oracle.v1.ExchangeRateTuple exchange_rates = 1 [
     (gogoproto.castrepeated) = "ExchangeRateTuples",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)     = false
   ];
 }
 
@@ -172,7 +172,7 @@ message QueryVoteTargetsResponse {
 // QueryFeederDelegationRequest is the request type for the
 // Query/FeederDelegation RPC method.
 message QueryFeederDelegationRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // validator defines the validator address to query for.
@@ -189,7 +189,7 @@ message QueryFeederDelegationResponse {
 // QueryMissCounterRequest is the request type for the Query/MissCounter RPC
 // method.
 message QueryMissCounterRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // validator defines the validator address to query for.
@@ -206,7 +206,7 @@ message QueryMissCounterResponse {
 // QueryAggregatePrevoteRequest is the request type for the
 // Query/AggregatePrevote RPC method.
 message QueryAggregatePrevoteRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // validator defines the validator address to query for.
@@ -219,7 +219,7 @@ message QueryAggregatePrevoteResponse {
   // aggregate_prevote defines oracle aggregate prevote submitted by a validator
   // in the current vote period
   nibiru.oracle.v1.AggregateExchangeRatePrevote aggregate_prevote = 1
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }
 
 // QueryAggregatePrevotesRequest is the request type for the
@@ -232,13 +232,13 @@ message QueryAggregatePrevotesResponse {
   // aggregate_prevotes defines all oracle aggregate prevotes submitted in the
   // current vote period
   repeated nibiru.oracle.v1.AggregateExchangeRatePrevote aggregate_prevotes = 1
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }
 
 // QueryAggregateVoteRequest is the request type for the Query/AggregateVote RPC
 // method.
 message QueryAggregateVoteRequest {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
   // validator defines the validator address to query for.
@@ -251,7 +251,7 @@ message QueryAggregateVoteResponse {
   // aggregate_vote defines oracle aggregate vote submitted by a validator in
   // the current vote period
   nibiru.oracle.v1.AggregateExchangeRateVote aggregate_vote = 1
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }
 
 // QueryAggregateVotesRequest is the request type for the Query/AggregateVotes
@@ -264,7 +264,7 @@ message QueryAggregateVotesResponse {
   // aggregate_votes defines all oracle aggregate votes submitted in the current
   // vote period
   repeated nibiru.oracle.v1.AggregateExchangeRateVote aggregate_votes = 1
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.
@@ -273,5 +273,5 @@ message QueryParamsRequest {}
 // QueryParamsResponse is the response type for the Query/Params RPC method.
 message QueryParamsResponse {
   // params defines the parameters of the module.
-  nibiru.oracle.v1.Params params = 1 [ (gogoproto.nullable) = false ];
+  nibiru.oracle.v1.Params params = 1 [(gogoproto.nullable) = false];
 }

--- a/proto/nibiru/oracle/v1/query.proto
+++ b/proto/nibiru/oracle/v1/query.proto
@@ -13,22 +13,18 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/oracle/types";
 service Query {
   // ExchangeRate returns exchange rate of a pair along with the block height
   // and block time that the exchange rate was set by the oracle module.
-  rpc ExchangeRate(QueryExchangeRateRequest)
-      returns (QueryExchangeRateResponse) {
+  rpc ExchangeRate(QueryExchangeRateRequest) returns (QueryExchangeRateResponse) {
     option (google.api.http).get = "/nibiru/oracle/v1beta1/exchange_rate";
   }
 
   // ExchangeRateTwap returns twap exchange rate of a pair
-  rpc ExchangeRateTwap(QueryExchangeRateRequest)
-      returns (QueryExchangeRateResponse) {
+  rpc ExchangeRateTwap(QueryExchangeRateRequest) returns (QueryExchangeRateResponse) {
     option (google.api.http).get = "/nibiru/oracle/v1beta1/exchange_rate_twap";
   }
 
   // ExchangeRates returns exchange rates of all pairs
-  rpc ExchangeRates(QueryExchangeRatesRequest)
-      returns (QueryExchangeRatesResponse) {
-    option (google.api.http).get =
-        "/nibiru/oracle/v1beta1/pairs/exchange_rates";
+  rpc ExchangeRates(QueryExchangeRatesRequest) returns (QueryExchangeRatesResponse) {
+    option (google.api.http).get = "/nibiru/oracle/v1beta1/pairs/exchange_rates";
   }
 
   // Actives returns all active pairs
@@ -42,44 +38,35 @@ service Query {
   }
 
   // FeederDelegation returns feeder delegation of a validator
-  rpc FeederDelegation(QueryFeederDelegationRequest)
-      returns (QueryFeederDelegationResponse) {
-    option (google.api.http).get =
-        "/nibiru/oracle/v1beta1/validators/{validator_addr}/feeder";
+  rpc FeederDelegation(QueryFeederDelegationRequest) returns (QueryFeederDelegationResponse) {
+    option (google.api.http).get = "/nibiru/oracle/v1beta1/validators/{validator_addr}/feeder";
   }
 
   // MissCounter returns oracle miss counter of a validator
   rpc MissCounter(QueryMissCounterRequest) returns (QueryMissCounterResponse) {
-    option (google.api.http).get =
-        "/nibiru/oracle/v1beta1/validators/{validator_addr}/miss";
+    option (google.api.http).get = "/nibiru/oracle/v1beta1/validators/{validator_addr}/miss";
   }
 
   // AggregatePrevote returns an aggregate prevote of a validator
-  rpc AggregatePrevote(QueryAggregatePrevoteRequest)
-      returns (QueryAggregatePrevoteResponse) {
+  rpc AggregatePrevote(QueryAggregatePrevoteRequest) returns (QueryAggregatePrevoteResponse) {
     option (google.api.http).get =
         "/nibiru/oracle/v1beta1/validators/{validator_addr}/aggregate_prevote";
   }
 
   // AggregatePrevotes returns aggregate prevotes of all validators
-  rpc AggregatePrevotes(QueryAggregatePrevotesRequest)
-      returns (QueryAggregatePrevotesResponse) {
-    option (google.api.http).get =
-        "/nibiru/oracle/v1beta1/validators/aggregate_prevotes";
+  rpc AggregatePrevotes(QueryAggregatePrevotesRequest) returns (QueryAggregatePrevotesResponse) {
+    option (google.api.http).get = "/nibiru/oracle/v1beta1/validators/aggregate_prevotes";
   }
 
   // AggregateVote returns an aggregate vote of a validator
-  rpc AggregateVote(QueryAggregateVoteRequest)
-      returns (QueryAggregateVoteResponse) {
+  rpc AggregateVote(QueryAggregateVoteRequest) returns (QueryAggregateVoteResponse) {
     option (google.api.http).get =
         "/nibiru/oracle/v1beta1/valdiators/{validator_addr}/aggregate_vote";
   }
 
   // AggregateVotes returns aggregate votes of all validators
-  rpc AggregateVotes(QueryAggregateVotesRequest)
-      returns (QueryAggregateVotesResponse) {
-    option (google.api.http).get =
-        "/nibiru/oracle/v1beta1/validators/aggregate_votes";
+  rpc AggregateVotes(QueryAggregateVotesRequest) returns (QueryAggregateVotesResponse) {
+    option (google.api.http).get = "/nibiru/oracle/v1beta1/validators/aggregate_votes";
   }
 
   // Params queries all parameters.
@@ -95,11 +82,7 @@ message QueryExchangeRateRequest {
   option (gogoproto.goproto_getters) = false;
 
   // pair defines the pair to query for.
-  string pair = 1 [
-    (gogoproto.customtype) =
-        "Pair",
-    (gogoproto.nullable) = false
-  ];
+  string pair = 1 [(gogoproto.customtype) = "Pair", (gogoproto.nullable) = false];
 }
 
 // QueryExchangeRateResponse is response type for the
@@ -133,10 +116,8 @@ message QueryExchangeRatesRequest {}
 message QueryExchangeRatesResponse {
   // exchange_rates defines a list of the exchange rate for all whitelisted
   // pairs.
-  repeated nibiru.oracle.v1.ExchangeRateTuple exchange_rates = 1 [
-    (gogoproto.castrepeated) = "ExchangeRateTuples",
-    (gogoproto.nullable)     = false
-  ];
+  repeated nibiru.oracle.v1.ExchangeRateTuple exchange_rates = 1
+      [(gogoproto.castrepeated) = "ExchangeRateTuples", (gogoproto.nullable) = false];
 }
 
 // QueryActivesRequest is the request type for the Query/Actives RPC method.
@@ -146,11 +127,7 @@ message QueryActivesRequest {}
 // Query/Actives RPC method.
 message QueryActivesResponse {
   // actives defines a list of the pair which oracle prices agreed upon.
-  repeated string actives = 1 [
-    (gogoproto.customtype) =
-        "Pair",
-    (gogoproto.nullable) = false
-  ];
+  repeated string actives = 1 [(gogoproto.customtype) = "Pair", (gogoproto.nullable) = false];
 }
 
 // QueryVoteTargetsRequest is the request type for the Query/VoteTargets RPC
@@ -162,11 +139,7 @@ message QueryVoteTargetsRequest {}
 message QueryVoteTargetsResponse {
   // vote_targets defines a list of the pairs in which everyone
   // should vote in the current vote period.
-  repeated string vote_targets = 1 [
-    (gogoproto.customtype) =
-        "Pair",
-    (gogoproto.nullable) = false
-  ];
+  repeated string vote_targets = 1 [(gogoproto.customtype) = "Pair", (gogoproto.nullable) = false];
 }
 
 // QueryFeederDelegationRequest is the request type for the
@@ -250,8 +223,7 @@ message QueryAggregateVoteRequest {
 message QueryAggregateVoteResponse {
   // aggregate_vote defines oracle aggregate vote submitted by a validator in
   // the current vote period
-  nibiru.oracle.v1.AggregateExchangeRateVote aggregate_vote = 1
-      [(gogoproto.nullable) = false];
+  nibiru.oracle.v1.AggregateExchangeRateVote aggregate_vote = 1 [(gogoproto.nullable) = false];
 }
 
 // QueryAggregateVotesRequest is the request type for the Query/AggregateVotes

--- a/proto/nibiru/oracle/v1/state.proto
+++ b/proto/nibiru/oracle/v1/state.proto
@@ -19,9 +19,9 @@ message PriceSnapshot {
   ];
 
   string price = 2 [
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = false
+    (gogoproto.nullable)   = false
   ];
 
   // milliseconds since unix epoch

--- a/proto/nibiru/oracle/v1/state.proto
+++ b/proto/nibiru/oracle/v1/state.proto
@@ -12,10 +12,9 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/oracle/types";
 // a snapshot of the prices at a given point in time
 message PriceSnapshot {
   string pair = 1 [
-    (gogoproto.moretags) = "yaml:\"pair\"",
-    (gogoproto.customtype) =
-        "Pair",
-    (gogoproto.nullable) = false
+    (gogoproto.moretags)   = "yaml:\"pair\"",
+    (gogoproto.customtype) = "Pair",
+    (gogoproto.nullable)   = false
   ];
 
   string price = 2 [

--- a/proto/nibiru/oracle/v1/tx.proto
+++ b/proto/nibiru/oracle/v1/tx.proto
@@ -42,16 +42,16 @@ service Msg {
 // MsgAggregateExchangeRatePrevote represents a message to submit
 // aggregate exchange rate prevote.
 message MsgAggregateExchangeRatePrevote {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string hash = 1 [ (gogoproto.moretags) = "yaml:\"hash\"" ];
+  string hash = 1 [(gogoproto.moretags) = "yaml:\"hash\""];
   // Feeder is the Bech32 address of the price feeder. A validator may
   // specify multiple price feeders by delegating them consent. The validator
   // address is also a valid feeder by default.
-  string feeder = 2 [ (gogoproto.moretags) = "yaml:\"feeder\"" ];
+  string feeder = 2 [(gogoproto.moretags) = "yaml:\"feeder\""];
   // Validator is the Bech32 address to which the prevote will be credited.
-  string validator = 3 [ (gogoproto.moretags) = "yaml:\"validator\"" ];
+  string validator = 3 [(gogoproto.moretags) = "yaml:\"validator\""];
 }
 
 // MsgAggregateExchangeRatePrevoteResponse defines the
@@ -61,18 +61,18 @@ message MsgAggregateExchangeRatePrevoteResponse {}
 // MsgAggregateExchangeRateVote represents a message to submit
 // aggregate exchange rate vote.
 message MsgAggregateExchangeRateVote {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string salt = 1 [ (gogoproto.moretags) = "yaml:\"salt\"" ];
+  string salt           = 1 [(gogoproto.moretags) = "yaml:\"salt\""];
   string exchange_rates = 2
-      [ (gogoproto.moretags) = "yaml:\"exchange_rates\"" ];
+      [(gogoproto.moretags) = "yaml:\"exchange_rates\""];
   // Feeder is the Bech32 address of the price feeder. A validator may
   // specify multiple price feeders by delegating them consent. The validator
   // address is also a valid feeder by default.
-  string feeder = 3 [ (gogoproto.moretags) = "yaml:\"feeder\"" ];
+  string feeder = 3 [(gogoproto.moretags) = "yaml:\"feeder\""];
   // Validator is the Bech32 address to which the vote will be credited.
-  string validator = 4 [ (gogoproto.moretags) = "yaml:\"validator\"" ];
+  string validator = 4 [(gogoproto.moretags) = "yaml:\"validator\""];
 }
 
 // MsgAggregateExchangeRateVoteResponse defines the
@@ -82,11 +82,11 @@ message MsgAggregateExchangeRateVoteResponse {}
 // MsgDelegateFeedConsent represents a message to delegate oracle voting rights
 // to another address.
 message MsgDelegateFeedConsent {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string operator = 1 [ (gogoproto.moretags) = "yaml:\"operator\"" ];
-  string delegate = 2 [ (gogoproto.moretags) = "yaml:\"delegate\"" ];
+  string operator = 1 [(gogoproto.moretags) = "yaml:\"operator\""];
+  string delegate = 2 [(gogoproto.moretags) = "yaml:\"delegate\""];
 }
 
 // MsgDelegateFeedConsentResponse defines the Msg/DelegateFeedConsent response
@@ -94,18 +94,18 @@ message MsgDelegateFeedConsent {
 message MsgDelegateFeedConsentResponse {}
 
 message MsgEditOracleParams {
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal)           = false;
   option (gogoproto.goproto_getters) = false;
 
-  string sender = 1 [ (gogoproto.moretags) = "yaml:\"sender\"" ];
+  string sender = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
 
-  OracleParamsMsg params = 2 [ (gogoproto.moretags) = "yaml:\"params\"" ];
+  OracleParamsMsg params = 2 [(gogoproto.moretags) = "yaml:\"params\""];
 }
 
 message MsgEditOracleParamsResponse {}
 
 message OracleParamsMsg {
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal)            = true;
   option (gogoproto.goproto_stringer) = true;
 
   // VotePeriod defines the number of blocks during which voting takes place.
@@ -117,10 +117,10 @@ message OracleParamsMsg {
   // VoteThreshold specifies the minimum proportion of votes that must be
   // received for a ballot to pass.
   string vote_threshold = 2 [
-    (gogoproto.moretags) = "yaml:\"vote_threshold\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"vote_threshold\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = true
+    (gogoproto.nullable)   = true
   ];
   // RewardBand defines a maxium divergence that a price vote can have from the
   // weighted median in the ballot. If a vote lies within the valid range
@@ -131,10 +131,10 @@ message OracleParamsMsg {
   // Note that if the reward band is smaller than 1 standard
   // deviation, the band is taken to be 1 standard deviation.a price
   string reward_band = 3 [
-    (gogoproto.moretags) = "yaml:\"reward_band\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"reward_band\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = true
+    (gogoproto.nullable)   = true
   ];
   // The set of whitelisted markets, or asset pairs, for the module.
   // Ex. '["unibi:uusd","ubtc:uusd"]'
@@ -148,10 +148,10 @@ message OracleParamsMsg {
   // slashed in the event of slashing. `SlashFraction` specifies the exact
   // penalty for failing a voting period.
   string slash_fraction = 5 [
-    (gogoproto.moretags) = "yaml:\"slash_fraction\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"slash_fraction\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = true
+    (gogoproto.nullable)   = true
   ];
   // SlashWindow returns the number of voting periods that specify a
   // "slash window". After each slash window, all oracles that have missed more
@@ -162,18 +162,18 @@ message OracleParamsMsg {
     (gogoproto.nullable) = true
   ];
   string min_valid_per_window = 7 [
-    (gogoproto.moretags) = "yaml:\"min_valid_per_window\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"min_valid_per_window\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = true
+    (gogoproto.nullable)   = true
   ];
 
   // Amount of time to look back for TWAP calculations
   google.protobuf.Duration twap_lookback_window = 8 [
-    (gogoproto.nullable) = true,
+    (gogoproto.nullable)    = true,
     (gogoproto.stdduration) = true,
-    (gogoproto.jsontag) = "twap_lookback_window,omitempty",
-    (gogoproto.moretags) = "yaml:\"twap_lookback_window\""
+    (gogoproto.jsontag)     = "twap_lookback_window,omitempty",
+    (gogoproto.moretags)    = "yaml:\"twap_lookback_window\""
   ];
 
   // The minimum number of voters (i.e. oracle validators) per pair for it to be
@@ -185,10 +185,10 @@ message OracleParamsMsg {
 
   // The validator fee ratio that is given to validators every epoch.
   string validator_fee_ratio = 10 [
-    (gogoproto.moretags) = "yaml:\"validator_fee_ratio\"",
-    (cosmos_proto.scalar) = "cosmos.Dec",
+    (gogoproto.moretags)   = "yaml:\"validator_fee_ratio\"",
+    (cosmos_proto.scalar)  = "cosmos.Dec",
     (gogoproto.customtype) = "cosmossdk.io/math.LegacyDec",
-    (gogoproto.nullable) = true
+    (gogoproto.nullable)   = true
   ];
 
   uint64 expiration_blocks = 11 [

--- a/proto/nibiru/oracle/v1/tx.proto
+++ b/proto/nibiru/oracle/v1/tx.proto
@@ -28,13 +28,11 @@ service Msg {
   // DelegateFeedConsent defines a method for delegating oracle voting rights
   // to another address known as a price feeder.
   // Deprecated: x/oracle Msg RPCs are disabled on-chain (ErrOracleDeprecated).
-  rpc DelegateFeedConsent(MsgDelegateFeedConsent)
-      returns (MsgDelegateFeedConsentResponse) {
+  rpc DelegateFeedConsent(MsgDelegateFeedConsent) returns (MsgDelegateFeedConsentResponse) {
     option (google.api.http).post = "/nibiru/oracle/feeder-delegate";
   }
 
-  rpc EditOracleParams(MsgEditOracleParams)
-      returns (MsgEditOracleParamsResponse) {
+  rpc EditOracleParams(MsgEditOracleParams) returns (MsgEditOracleParamsResponse) {
     option (google.api.http).post = "/nibiru/oracle/params";
   }
 }
@@ -65,8 +63,7 @@ message MsgAggregateExchangeRateVote {
   option (gogoproto.goproto_getters) = false;
 
   string salt           = 1 [(gogoproto.moretags) = "yaml:\"salt\""];
-  string exchange_rates = 2
-      [(gogoproto.moretags) = "yaml:\"exchange_rates\""];
+  string exchange_rates = 2 [(gogoproto.moretags) = "yaml:\"exchange_rates\""];
   // Feeder is the Bech32 address of the price feeder. A validator may
   // specify multiple price feeders by delegating them consent. The validator
   // address is also a valid feeder by default.
@@ -109,10 +106,8 @@ message OracleParamsMsg {
   option (gogoproto.goproto_stringer) = true;
 
   // VotePeriod defines the number of blocks during which voting takes place.
-  uint64 vote_period = 1 [
-    (gogoproto.moretags) = "yaml:\"vote_period\"",
-    (gogoproto.nullable) = true
-  ];
+  uint64 vote_period = 1
+      [(gogoproto.moretags) = "yaml:\"vote_period\"", (gogoproto.nullable) = true];
 
   // VoteThreshold specifies the minimum proportion of votes that must be
   // received for a ballot to pass.
@@ -139,10 +134,9 @@ message OracleParamsMsg {
   // The set of whitelisted markets, or asset pairs, for the module.
   // Ex. '["unibi:uusd","ubtc:uusd"]'
   repeated string whitelist = 4 [
-    (gogoproto.moretags) = "yaml:\"whitelist\"",
-    (gogoproto.customtype) =
-        "Pair",
-    (gogoproto.nullable) = true
+    (gogoproto.moretags)   = "yaml:\"whitelist\"",
+    (gogoproto.customtype) = "Pair",
+    (gogoproto.nullable)   = true
   ];
   // SlashFraction returns the proportion of an oracle's stake that gets
   // slashed in the event of slashing. `SlashFraction` specifies the exact
@@ -157,10 +151,8 @@ message OracleParamsMsg {
   // "slash window". After each slash window, all oracles that have missed more
   // than the penalty threshold are slashed. Missing the penalty threshold is
   // synonymous with submitting fewer valid votes than `MinValidPerWindow`.
-  uint64 slash_window = 6 [
-    (gogoproto.moretags) = "yaml:\"slash_window\"",
-    (gogoproto.nullable) = true
-  ];
+  uint64 slash_window = 6
+      [(gogoproto.moretags) = "yaml:\"slash_window\"", (gogoproto.nullable) = true];
   string min_valid_per_window = 7 [
     (gogoproto.moretags)   = "yaml:\"min_valid_per_window\"",
     (cosmos_proto.scalar)  = "cosmos.Dec",
@@ -178,10 +170,7 @@ message OracleParamsMsg {
 
   // The minimum number of voters (i.e. oracle validators) per pair for it to be
   // considered a passing ballot. Recommended at least 4.
-  uint64 min_voters = 9 [
-    (gogoproto.moretags) = "yaml:\"min_voters\"",
-    (gogoproto.nullable) = true
-  ];
+  uint64 min_voters = 9 [(gogoproto.moretags) = "yaml:\"min_voters\"", (gogoproto.nullable) = true];
 
   // The validator fee ratio that is given to validators every epoch.
   string validator_fee_ratio = 10 [
@@ -191,8 +180,6 @@ message OracleParamsMsg {
     (gogoproto.nullable)   = true
   ];
 
-  uint64 expiration_blocks = 11 [
-    (gogoproto.moretags) = "yaml:\"expiration_blocks\"",
-    (gogoproto.nullable) = true
-  ];
+  uint64 expiration_blocks = 11
+      [(gogoproto.moretags) = "yaml:\"expiration_blocks\"", (gogoproto.nullable) = true];
 }

--- a/proto/nibiru/sudo/v1/event.proto
+++ b/proto/nibiru/sudo/v1/event.proto
@@ -10,7 +10,7 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/sudo";
 
 // EventUpdateSudoers: ABCI event emitted upon execution of "MsgEditSudoers".
 message EventUpdateSudoers {
-  nibiru.sudo.v1.Sudoers sudoers = 1 [ (gogoproto.nullable) = false ];
+  nibiru.sudo.v1.Sudoers sudoers = 1 [(gogoproto.nullable) = false];
 
   // Action is the type of update that occurred to the "sudoers"
   string action = 2;

--- a/proto/nibiru/sudo/v1/query.proto
+++ b/proto/nibiru/sudo/v1/query.proto
@@ -17,8 +17,7 @@ service Query {
   // QueryZeroGasActors returns the "ZeroGasActors" state. Zero gas actors are
   // a set of accounts that can execute zero gas transactions against a
   // whitelisted  set of smart contracts.
-  rpc QueryZeroGasActors(QueryZeroGasActorsRequest)
-      returns (QueryZeroGasActorsResponse) {
+  rpc QueryZeroGasActors(QueryZeroGasActorsRequest) returns (QueryZeroGasActorsResponse) {
     option (google.api.http).get = "/nibiru/sudo/zero_gas_actors";
   }
 }

--- a/proto/nibiru/sudo/v1/query.proto
+++ b/proto/nibiru/sudo/v1/query.proto
@@ -30,7 +30,7 @@ message QuerySudoersRequest {}
 // QuerySudoersResponse is the response type for the gRPC query method,
 // "/nibiru.sudo.v1.Query/QuerySudoers"
 message QuerySudoersResponse {
-  nibiru.sudo.v1.Sudoers sudoers = 1 [ (gogoproto.nullable) = false ];
+  nibiru.sudo.v1.Sudoers sudoers = 1 [(gogoproto.nullable) = false];
 }
 
 // QueryZeroGasActorsRequest is the request type for the gRPC query method,
@@ -40,5 +40,5 @@ message QueryZeroGasActorsRequest {}
 // QueryZeroGasActorsResponse is the response type for the gRPC query method,
 // "/nibiru.sudo.v1.Query/QueryZeroGasActors"
 message QueryZeroGasActorsResponse {
-  nibiru.sudo.v1.ZeroGasActors actors = 1 [ (gogoproto.nullable) = false ];
+  nibiru.sudo.v1.ZeroGasActors actors = 1 [(gogoproto.nullable) = false];
 }

--- a/proto/nibiru/sudo/v1/state.proto
+++ b/proto/nibiru/sudo/v1/state.proto
@@ -17,9 +17,9 @@ message Sudoers {
 
 // GenesisState: State for migrations and genesis for the x/sudo module.
 message GenesisState {
-  nibiru.sudo.v1.Sudoers sudoers = 1 [ (gogoproto.nullable) = false ];
-  nibiru.sudo.v1.ZeroGasActors zero_gas_actors = 2;
-  string wasm_block_hooks_contract = 3;
+  nibiru.sudo.v1.Sudoers       sudoers                   = 1 [(gogoproto.nullable) = false];
+  nibiru.sudo.v1.ZeroGasActors zero_gas_actors           = 2;
+  string                       wasm_block_hooks_contract = 3;
 }
 
 // ZeroGasActors: Actors that can execute zero gas transactions against a set of

--- a/proto/nibiru/sudo/v1/tx.proto
+++ b/proto/nibiru/sudo/v1/tx.proto
@@ -69,7 +69,7 @@ message MsgChangeRootResponse {}
 message MsgEditZeroGasActors {
   // Actors that can execute zero gas transactions against a set of
   // smart contracts.
-  nibiru.sudo.v1.ZeroGasActors actors = 1 [ (gogoproto.nullable) = false ];
+  nibiru.sudo.v1.ZeroGasActors actors = 1 [(gogoproto.nullable) = false];
 
   // Sender: Nibiru Bech32 Address for the signer of the transaction.
   string sender = 2;

--- a/proto/nibiru/sudo/v1/tx.proto
+++ b/proto/nibiru/sudo/v1/tx.proto
@@ -24,8 +24,7 @@ service Msg {
   // EditZeroGasActors updates the "ZeroGasActors" state. Zero gas actors are
   // a set of accounts that can execute zero gas transactions against a
   // whitelisted  set of smart contracts.
-  rpc EditZeroGasActors(MsgEditZeroGasActors)
-      returns (MsgEditZeroGasActorsResponse) {
+  rpc EditZeroGasActors(MsgEditZeroGasActors) returns (MsgEditZeroGasActorsResponse) {
     option (google.api.http).post = "/nibiru/sudo/edit_zero_gas_actors";
   }
 }

--- a/proto/nibiru/tokenfactory/v1/event.proto
+++ b/proto/nibiru/tokenfactory/v1/event.proto
@@ -9,34 +9,34 @@ import "gogoproto/gogo.proto";
 option go_package = "github.com/NibiruChain/nibiru/v2/x/tokenfactory/types";
 
 message EventCreateDenom {
-  string denom = 1;
+  string denom   = 1;
   string creator = 2;
 }
 
 message EventChangeAdmin {
-  string denom = 1;
+  string denom     = 1;
   string new_admin = 2;
   string old_admin = 3;
 }
 
 message EventMint {
   cosmos.base.v1beta1.Coin coin = 1
-      [ (gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false ];
+      [(gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false];
   string to_addr = 2;
-  string caller = 3;
+  string caller  = 3;
 }
 
 message EventBurn {
   cosmos.base.v1beta1.Coin coin = 1
-      [ (gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false ];
+      [(gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false];
   string from_addr = 2;
-  string caller = 3;
+  string caller    = 3;
 }
 
 message EventSetDenomMetadata {
   string denom = 1;
   // Metadata: Official x/bank metadata for the denom. All token factory denoms
   // are standard, native assets. The "metadata.base" is the denom.
-  cosmos.bank.v1beta1.Metadata metadata = 2 [ (gogoproto.nullable) = false ];
-  string caller = 3;
+  cosmos.bank.v1beta1.Metadata metadata = 2 [(gogoproto.nullable) = false];
+  string                       caller   = 3;
 }

--- a/proto/nibiru/tokenfactory/v1/query.proto
+++ b/proto/nibiru/tokenfactory/v1/query.proto
@@ -33,8 +33,7 @@ message QueryParamsRequest {}
 // QueryParamsResponse is the response type for the Query/Params RPC method.
 message QueryParamsResponse {
   // Module parameters stored in state
-  nibiru.tokenfactory.v1.ModuleParams params = 1
-      [(gogoproto.nullable) = false];
+  nibiru.tokenfactory.v1.ModuleParams params = 1 [(gogoproto.nullable) = false];
 }
 
 // QueryDenomsRequest: gRPC query for all denoms registered for a creator

--- a/proto/nibiru/tokenfactory/v1/query.proto
+++ b/proto/nibiru/tokenfactory/v1/query.proto
@@ -11,7 +11,6 @@ option go_package = "github.com/NibiruChain/nibiru/v2/x/tokenfactory/types";
 
 // Query defines the gRPC querier service.
 service Query {
-
   // Params retrieves the module params
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
     option (google.api.http).get = "/nibiru/tokenfactory/v1/params";
@@ -35,17 +34,23 @@ message QueryParamsRequest {}
 message QueryParamsResponse {
   // Module parameters stored in state
   nibiru.tokenfactory.v1.ModuleParams params = 1
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }
 
 // QueryDenomsRequest: gRPC query for all denoms registered for a creator
-message QueryDenomsRequest { string creator = 1; }
+message QueryDenomsRequest {
+  string creator = 1;
+}
 
 // QueryDenomsResponse: All registered denoms for a creator
-message QueryDenomsResponse { repeated string denoms = 1; }
+message QueryDenomsResponse {
+  repeated string denoms = 1;
+}
 
 // QueryDenomInfoRequest: gRPC query for the denom admin and x/bank metadata
-message QueryDenomInfoRequest { string denom = 1; }
+message QueryDenomInfoRequest {
+  string denom = 1;
+}
 
 // QueryDenomInfoResponse: All registered denoms for a creator
 message QueryDenomInfoResponse {
@@ -53,5 +58,5 @@ message QueryDenomInfoResponse {
   string admin = 1;
   // Metadata: Official x/bank metadata for the denom. All token factory denoms
   // are standard, native assets.
-  cosmos.bank.v1beta1.Metadata metadata = 2 [ (gogoproto.nullable) = false ];
+  cosmos.bank.v1beta1.Metadata metadata = 2 [(gogoproto.nullable) = false];
 }

--- a/proto/nibiru/tokenfactory/v1/state.proto
+++ b/proto/nibiru/tokenfactory/v1/state.proto
@@ -72,10 +72,8 @@ message TFDenom {
 message GenesisState {
   ModuleParams params = 1 [(gogoproto.nullable) = false];
 
-  repeated GenesisDenom factory_denoms = 2 [
-    (gogoproto.moretags) = "yaml:\"factory_denoms\"",
-    (gogoproto.nullable) = false
-  ];
+  repeated GenesisDenom factory_denoms = 2
+      [(gogoproto.moretags) = "yaml:\"factory_denoms\"", (gogoproto.nullable) = false];
 }
 
 // GenesisDenom defines a tokenfactory denoms in the genesis state.
@@ -83,8 +81,6 @@ message GenesisDenom {
   option (gogoproto.equal) = true;
 
   string                 denom              = 1 [(gogoproto.moretags) = "yaml:\"denom\""];
-  DenomAuthorityMetadata authority_metadata = 2 [
-    (gogoproto.moretags) = "yaml:\"authority_metadata\"",
-    (gogoproto.nullable) = false
-  ];
+  DenomAuthorityMetadata authority_metadata = 2
+      [(gogoproto.moretags) = "yaml:\"authority_metadata\"", (gogoproto.nullable) = false];
 }

--- a/proto/nibiru/tokenfactory/v1/state.proto
+++ b/proto/nibiru/tokenfactory/v1/state.proto
@@ -16,7 +16,7 @@ message DenomAuthorityMetadata {
 
   // Admin: Bech32 address of the admin for the tokefactory denom. Can be empty
   // for no admin.
-  string admin = 1 [ (gogoproto.moretags) = "yaml:\"admin\"" ];
+  string admin = 1 [(gogoproto.moretags) = "yaml:\"admin\""];
 }
 
 // ModuleParams defines the parameters for the tokenfactory module.
@@ -49,7 +49,7 @@ message ModuleParams {
   // Adds gas consumption to the execution of `MsgCreateDenom` as a method of
   // spam prevention. Defaults to 10 NIBI.
   uint64 denom_creation_gas_consume = 1
-      [ (gogoproto.moretags) = "yaml:\"denom_creation_gas_consume\"" ];
+      [(gogoproto.moretags) = "yaml:\"denom_creation_gas_consume\""];
 }
 
 // TFDenom is a token factory (TF) denom. The canonical representation is
@@ -70,7 +70,7 @@ message TFDenom {
 
 // GenesisState for the Token Factory module.
 message GenesisState {
-  ModuleParams params = 1 [ (gogoproto.nullable) = false ];
+  ModuleParams params = 1 [(gogoproto.nullable) = false];
 
   repeated GenesisDenom factory_denoms = 2 [
     (gogoproto.moretags) = "yaml:\"factory_denoms\"",
@@ -82,7 +82,7 @@ message GenesisState {
 message GenesisDenom {
   option (gogoproto.equal) = true;
 
-  string denom = 1 [ (gogoproto.moretags) = "yaml:\"denom\"" ];
+  string                 denom              = 1 [(gogoproto.moretags) = "yaml:\"denom\""];
   DenomAuthorityMetadata authority_metadata = 2 [
     (gogoproto.moretags) = "yaml:\"authority_metadata\"",
     (gogoproto.nullable) = false

--- a/proto/nibiru/tokenfactory/v1/tx.proto
+++ b/proto/nibiru/tokenfactory/v1/tx.proto
@@ -18,17 +18,14 @@ service Msg {
   rpc ChangeAdmin(MsgChangeAdmin) returns (MsgChangeAdminResponse);
   // UpdateModuleParams: A governance operation for updating the x/tokenfactory
   // module parameters.
-  rpc UpdateModuleParams(MsgUpdateModuleParams)
-      returns (MsgUpdateModuleParamsResponse);
+  rpc UpdateModuleParams(MsgUpdateModuleParams) returns (MsgUpdateModuleParamsResponse);
   rpc Mint(MsgMint) returns (MsgMintResponse);
   rpc Burn(MsgBurn) returns (MsgBurnResponse);
-  rpc SetDenomMetadata(MsgSetDenomMetadata)
-      returns (MsgSetDenomMetadataResponse);
+  rpc SetDenomMetadata(MsgSetDenomMetadata) returns (MsgSetDenomMetadataResponse);
 
   // SudoSetDenomMetadata: sdk.Msg (TxMsg) enabling Nibiru's "sudoers" to
   // change bank metadata. [SUDO] Only callable by sudoers.
-  rpc SudoSetDenomMetadata(MsgSudoSetDenomMetadata)
-      returns (MsgSudoSetDenomMetadataResponse);
+  rpc SudoSetDenomMetadata(MsgSudoSetDenomMetadata) returns (MsgSudoSetDenomMetadataResponse);
 
   // burns a native token such as unibi
   rpc BurnNative(MsgBurnNative) returns (MsgBurnNativeResponse);
@@ -49,8 +46,7 @@ message MsgCreateDenom {
 // MsgCreateDenomResponse is the return value of MsgCreateDenom
 message MsgCreateDenomResponse {
   // NewTokenDenom: identifier for the newly created token factory denom.
-  string new_token_denom = 1
-      [(gogoproto.moretags) = "yaml:\"new_token_denom\""];
+  string new_token_denom = 1 [(gogoproto.moretags) = "yaml:\"new_token_denom\""];
 }
 
 // MsgChangeAdmin is the sdk.Msg type for allowing an admin account to change
@@ -71,8 +67,7 @@ message MsgUpdateModuleParams {
   // Authority: Address of the governance module account.
   string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
-  nibiru.tokenfactory.v1.ModuleParams params = 2
-      [(gogoproto.nullable) = false];
+  nibiru.tokenfactory.v1.ModuleParams params = 2 [(gogoproto.nullable) = false];
 }
 
 // MsgUpdateModuleParamsResponse is the gRPC response for the
@@ -87,10 +82,7 @@ message MsgMint {
       [(gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false];
   // mint_to_addr: An address to which tokens will be minted. If blank,
   // tokens are minted to the "sender".
-  string mint_to = 3 [
-    (gogoproto.moretags) = "yaml:\"mint_to\"",
-    (gogoproto.nullable) = true
-  ];
+  string mint_to = 3 [(gogoproto.moretags) = "yaml:\"mint_to\"", (gogoproto.nullable) = true];
 }
 
 message MsgMintResponse {

--- a/proto/nibiru/tokenfactory/v1/tx.proto
+++ b/proto/nibiru/tokenfactory/v1/tx.proto
@@ -41,24 +41,24 @@ service Msg {
 //  - The resulting denom's admin is originally set to be the creator, but the
 //    admin can be changed later.
 message MsgCreateDenom {
-  string sender = 1 [ (gogoproto.moretags) = "yaml:\"sender\"" ];
+  string sender = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
   // subdenom can be up to 44 "alphanumeric" characters long.
-  string subdenom = 2 [ (gogoproto.moretags) = "yaml:\"subdenom\"" ];
+  string subdenom = 2 [(gogoproto.moretags) = "yaml:\"subdenom\""];
 }
 
 // MsgCreateDenomResponse is the return value of MsgCreateDenom
 message MsgCreateDenomResponse {
   // NewTokenDenom: identifier for the newly created token factory denom.
   string new_token_denom = 1
-      [ (gogoproto.moretags) = "yaml:\"new_token_denom\"" ];
+      [(gogoproto.moretags) = "yaml:\"new_token_denom\""];
 }
 
 // MsgChangeAdmin is the sdk.Msg type for allowing an admin account to change
 // admin of a denom to a new account
 message MsgChangeAdmin {
-  string sender = 1 [ (gogoproto.moretags) = "yaml:\"sender\"" ];
-  string denom = 2 [ (gogoproto.moretags) = "yaml:\"denom\"" ];
-  string new_admin = 3 [ (gogoproto.moretags) = "yaml:\"new_admin\"" ];
+  string sender    = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
+  string denom     = 2 [(gogoproto.moretags) = "yaml:\"denom\""];
+  string new_admin = 3 [(gogoproto.moretags) = "yaml:\"new_admin\""];
 }
 
 // MsgChangeAdminResponse is the gRPC response for the MsgChangeAdmin TxMsg.
@@ -69,10 +69,10 @@ message MsgUpdateModuleParams {
   option (cosmos.msg.v1.signer) = "authority";
 
   // Authority: Address of the governance module account.
-  string authority = 1 [ (cosmos_proto.scalar) = "cosmos.AddressString" ];
+  string authority = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 
   nibiru.tokenfactory.v1.ModuleParams params = 2
-      [ (gogoproto.nullable) = false ];
+      [(gogoproto.nullable) = false];
 }
 
 // MsgUpdateModuleParamsResponse is the gRPC response for the
@@ -81,10 +81,10 @@ message MsgUpdateModuleParamsResponse {}
 
 // MsgMint: sdk.Msg (TxMsg) where an denom admin mints more of the token.
 message MsgMint {
-  string sender = 1 [ (gogoproto.moretags) = "yaml:\"sender\"" ];
+  string sender = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
   // coin: The denom identifier and amount to mint.
   cosmos.base.v1beta1.Coin coin = 2
-      [ (gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false ];
+      [(gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false];
   // mint_to_addr: An address to which tokens will be minted. If blank,
   // tokens are minted to the "sender".
   string mint_to = 3 [
@@ -93,7 +93,9 @@ message MsgMint {
   ];
 }
 
-message MsgMintResponse { string mint_to = 1; }
+message MsgMintResponse {
+  string mint_to = 1;
+}
 
 // MsgBurn: sdk.Msg (TxMsg) where a denom admin burns some of the token.
 // The reason that the sender isn't automatically the "burn_from" address
@@ -101,12 +103,12 @@ message MsgMintResponse { string mint_to = 1; }
 // contract is the message signer and sender, while "burn_from" is based on the
 // contract logic.
 message MsgBurn {
-  string sender = 1 [ (gogoproto.moretags) = "yaml:\"sender\"" ];
+  string sender = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
   // coin: The denom identifier and amount to burn.
   cosmos.base.v1beta1.Coin coin = 2
-      [ (gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false ];
+      [(gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false];
   // burn_from: The address from which tokens will be burned.
-  string burn_from = 3 [ (gogoproto.moretags) = "yaml:\"burn_from\"" ];
+  string burn_from = 3 [(gogoproto.moretags) = "yaml:\"burn_from\""];
 }
 
 message MsgBurnResponse {}
@@ -114,11 +116,11 @@ message MsgBurnResponse {}
 // MsgSetDenomMetadata: sdk.Msg (TxMsg) enabling the denom admin to change its
 // bank metadata.
 message MsgSetDenomMetadata {
-  string sender = 1 [ (gogoproto.moretags) = "yaml:\"sender\"" ];
+  string sender = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
 
   // Metadata: Official x/bank metadata for the denom. All token factory denoms
   // are standard, native assets. The "metadata.base" is the denom.
-  cosmos.bank.v1beta1.Metadata metadata = 2 [ (gogoproto.nullable) = false ];
+  cosmos.bank.v1beta1.Metadata metadata = 2 [(gogoproto.nullable) = false];
 }
 
 message MsgSetDenomMetadataResponse {}
@@ -136,20 +138,20 @@ message MsgSetDenomMetadataResponse {}
 //
 // [FunToken Mechanism]: https://nibiru.fi/docs/evm/funtoken.html
 message MsgSudoSetDenomMetadata {
-  string sender = 1 [ (gogoproto.moretags) = "yaml:\"sender\"" ];
+  string sender = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
 
   // Metadata: Official x/bank metadata for the denom. The "metadata.base" is
   // the denom.
-  cosmos.bank.v1beta1.Metadata metadata = 2 [ (gogoproto.nullable) = false ];
+  cosmos.bank.v1beta1.Metadata metadata = 2 [(gogoproto.nullable) = false];
 }
 
 message MsgSudoSetDenomMetadataResponse {}
 
 // Burn a native token such as unibi
 message MsgBurnNative {
-  string sender = 1 [ (gogoproto.moretags) = "yaml:\"sender\"" ];
-  cosmos.base.v1beta1.Coin coin = 2
-      [ (gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false ];
+  string                   sender = 1 [(gogoproto.moretags) = "yaml:\"sender\""];
+  cosmos.base.v1beta1.Coin coin   = 2
+      [(gogoproto.moretags) = "yaml:\"coin\"", (gogoproto.nullable) = false];
 }
 
 message MsgBurnNativeResponse {}


### PR DESCRIPTION
# Modernize protobuf formatting and drop Docker proto tooling

Replaces the legacy `tendermintdev/docker-build-proto` image (amd64-only, unmaintained) with host-native `clang-format` and `buf`, fixing `just proto fmt` on Linux/arm64 (#2636). Adds a repo-root `.clang-format` policy and applies it across Nibiru, vendored Cosmos SDK, and IBC-Go proto trees. Also tightens EVM RPC tests to assert against confirmed receipts instead of arbitrary block waits.

- Closes https://github.com/NibiruChain/nibiru/issues/2636

## Key Changes

1. **Drop Docker from `contrib/scripts/proto.sh`** — `proto fmt`, `proto lint`, and `proto gen` now run on the host. The script auto-installs `clang-format` (apt/Homebrew) and `buf` (Go) when missing, and integrates with `contrib/bashlib.sh` for logging and path helpers.
1. **Add `.clang-format` and reformat proto trees** — Introduces an explicit protobuf style (Google-based, bracket spacing, 100-column limit) and runs `just proto fmt` across `proto/`, `lib/cosmos-sdk/proto/`, and `lib/ibc-go/proto/`.
1. **Update CI proto generation job** — The `proto-gen-go` workflow installs `clang-format` and pins `buf-setup-action` to v1.55.1 so generation matches local tooling without Docker.
1. **Stabilize EVM RPC tests** — `Test_SmartContract` waits for an eth receipt before checking pending-tx state; `TestNonceIncrementWithMultipleMsgsTx` asserts nonce growth after all receipts land instead of a fixed `WaitForNextBlock` + exact nonce equality.

## Appendix - Commits
- `fix(proto): Modernize protobuf formatting for gh #2636`
- `refactor(proto): Run just proto fmt`
- `docs(proto): Doc comments for bash in proto.sh script`
- `test(rpc): Synchronize assertions with transaction receipts`
