### PR TITLE
fix(wasmvm): Pin osxcross and retry apt in builder images

### DIFF
--- a/lib/wasmvm/builders/Dockerfile.cross
+++ b/lib/wasmvm/builders/Dockerfile.cross
@@ -23,10 +23,11 @@ RUN rustup target add x86_64-apple-darwin aarch64-apple-darwin x86_64-pc-windows
 # At some point we might want to use our own package.
 RUN git clone https://github.com/tpoechtrager/osxcross \
   && cd osxcross \
+  && git checkout 28b7b67c937f4c620a7bf1e7b6dbce057bb7691e \
   # Don't change file name when downloading because osxcross auto-detects the version from the name
   && wget -nc https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz \
   && mv MacOSX11.3.sdk.tar.xz tarballs/ \
-  && UNATTENDED=yes OSX_VERSION_MIN=10.10 ./build.sh \
+  && UNATTENDED=1 BUILD_FLAVOR=stable OSX_VERSION_MIN=10.10 ./build.sh \
   # Cleanups before Docker layer is finalized
   && rm -r tarballs/
 RUN chmod +rx /opt/osxcross

--- a/lib/wasmvm/builders/Dockerfile.debian
+++ b/lib/wasmvm/builders/Dockerfile.debian
@@ -3,8 +3,9 @@
 # August 31, 2026.
 FROM debian:11-slim
 
-RUN apt update -y \
-  && apt install -y gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu wget clang
+RUN apt-get -o Acquire::Retries=5 update -y \
+  && apt-get -o Acquire::Retries=5 install -y \
+    gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu wget clang
 
 ENV RUSTUP_HOME=/usr/local/rustup \
   CARGO_HOME=/usr/local/cargo \


### PR DESCRIPTION
# fix(wasmvm): Pin osxcross and retry apt in builder images

Wasm VM Darwin and Linux builder image builds were failing on `main`: Darwin hit an interactive `osxcross` prompt after upstream added build flavors, and Linux shared builds could die on transient Debian apt CDN resets. This pins `osxcross` and hardens apt retries so artifact CI can pass again.

- Closes https://github.com/NibiruChain/nibiru/issues/2707

## Key Changes

1. Pin `osxcross` to commit `28b7b67c937f4c620a7bf1e7b6dbce057bb7691e` and run `UNATTENDED=1 BUILD_FLAVOR=stable` in `lib/wasmvm/builders/Dockerfile.cross` so Darwin image builds stay non-interactive.
1. Use `apt-get` with `Acquire::Retries=5` in `lib/wasmvm/builders/Dockerfile.debian` to tolerate flaky `deb.debian.org` fetches.