### PR TITLE
docs: add OpenChainBench live RPC latency benchmark link

### DIFF
--- a/docs/dev/networks/index.md
+++ b/docs/dev/networks/index.md
@@ -122,3 +122,4 @@ nibid config # Prints your new config to verify correctness
 ## Related Pages
 
 - [Developer Hub: Build on Nibiru](../)
+- [OpenChainBench](https://openchainbench.com/benchmarks/nibiru-rpc) — live p50/p90/p99 latency leaderboard for free Nibiru RPC endpoints, updated every 60 s


### PR DESCRIPTION
Adds a reference to [OpenChainBench](https://openchainbench.com/benchmarks/nibiru-rpc) at the bottom of the Networks and RPCs page.

OpenChainBench is an open, independent benchmark that probes free public RPC endpoints every 60 seconds and publishes p50/p90/p99 latency results. Polkachu currently leads the Nibiru leaderboard at ~192 ms p50.

The link sits under "Related Pages" so it's unobtrusive and only surfaces for developers who want data to help them pick an endpoint.