### PR TITLE
refactor(eth): replace deprecated SignedIntValueEncoder with UintValu…

### DIFF
--- a/eth/state_encoder.go
+++ b/eth/state_encoder.go
@@ -3,7 +3,6 @@ package eth
 import (
 	fmt "fmt"
 
-	sdkmath "cosmossdk.io/math"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/NibiruChain/nibiru/v2/x/collections"
@@ -27,7 +26,8 @@ var (
 	// keEthHash: Implements a `collections.KeyEncoder` for an Ethereum hash.
 	KeyEncoderEthHash collections.KeyEncoder[gethcommon.Hash] = keEthHash{}
 
-	SignedIntValueEncoder collections.ValueEncoder[sdkmath.Int] = veSignedInt{}
+	// Deprecated
+	SignedIntValueEncoder = collections.IntValueEncoder
 )
 
 // collections ValueEncoder[[]byte]
@@ -76,40 +76,3 @@ func (keEthHash) Decode(bz []byte) (int, gethcommon.Hash) {
 	return gethcommon.HashLength, gethcommon.BytesToHash(bz)
 }
 func (keEthHash) Stringify(value gethcommon.Hash) string { return value.Hex() }
-
-// ------------------------------------------
-// SignedIntValueEncoder
-// ------------------------------------------
-
-type veSignedInt struct{}
-
-// Encode encodes the value T into bytes.
-// Encode(value T) []byte
-func (veSignedInt) Encode(v sdkmath.Int) []byte {
-	bz, err := v.Marshal()
-	if err != nil {
-		panic(fmt.Errorf("invalid math.Int %s: %w", v, err))
-	}
-	return bz
-}
-
-// Decode returns the type T given its bytes representation.
-// Decode(b []byte) T
-func (veSignedInt) Decode(bz []byte) sdkmath.Int {
-	n := new(sdkmath.Int)
-	err := n.Unmarshal(bz)
-	if err != nil {
-		panic(fmt.Errorf("decoding math.Int from bytes failed: %w", err))
-	}
-	return *n
-}
-
-// Stringify returns a string representation of T.
-func (veSignedInt) Stringify(v sdkmath.Int) string {
-	return v.String()
-}
-
-// Name returns the name of the object.
-func (veSignedInt) Name() string {
-	return "math.Int (signed)"
-}

--- a/evm/evmstate/evm_state.go
+++ b/evm/evmstate/evm_state.go
@@ -96,7 +96,7 @@ func NewEvmState(
 		NetWeiBlockDelta: collections.NewItem(
 			storeKey,
 			evm.KeyPrefixNetWeiBlockDelta,
-			eth.SignedIntValueEncoder,
+			collections.IntValueEncoder,
 		),
 		WasmPlugins: collections.NewMap(
 			storeKey,

--- a/x/bank/keeper/nibiru_ext.go
+++ b/x/bank/keeper/nibiru_ext.go
@@ -282,8 +282,8 @@ func (k BaseSendKeeper) getWeiStoreBalance(
 	ctx sdk.Context,
 	addr sdk.AccAddress,
 ) (storeBal *uint256.Int) {
-	balInt := k.weiStore.GetOr(ctx, addr, sdkmath.ZeroInt())
-	return uint256.MustFromBig(balInt.BigInt())
+	balUint := k.weiStore.GetOr(ctx, addr, sdkmath.ZeroUint())
+	return uint256.MustFromBig(balUint.BigInt())
 }
 
 func (k BaseSendKeeper) setWeiStoreBalance(
@@ -305,7 +305,9 @@ func (k BaseSendKeeper) setWeiStoreBalance(
 		return
 	}
 
-	k.weiStore.Insert(ctx, addr, sdkmath.NewIntFromBigInt(newStoreBal.ToBig()))
+	// sdkmath.Uint already enforces MaxBitLen and non-negativity; converting
+	// back to Int for callers that need signed math is safe via NewIntFromBigInt.
+	k.weiStore.Insert(ctx, addr, sdkmath.NewUintFromBigInt(newStoreBal.ToBig()))
 }
 
 // WeiBlockDelta is the net sum of all calls of [AddWei] and [SubWei] in the
@@ -327,7 +329,7 @@ func (k BaseSendKeeper) SumWeiStoreBals(ctx sdk.Context) sdkmath.Int {
 	iter := k.weiStore.Iterate(ctx, collections.Range[sdk.AccAddress]{})
 	totalStoreBalWei := sdkmath.ZeroInt()
 	for _, storeBalWei := range iter.Values() {
-		totalStoreBalWei = totalStoreBalWei.Add(storeBalWei)
+		totalStoreBalWei = totalStoreBalWei.Add(sdkmath.NewIntFromBigInt(storeBalWei.BigInt()))
 	}
 	return totalStoreBalWei
 }

--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -16,8 +16,6 @@ import (
 	"github.com/NibiruChain/nibiru/v2/lib/cosmos-sdk/x/bank/types"
 
 	"github.com/NibiruChain/nibiru/v2/x/collections"
-
-	"github.com/NibiruChain/nibiru/v2/eth"
 )
 
 // SendKeeper defines a module interface that facilitates the transfer of coins
@@ -74,7 +72,7 @@ type BaseSendKeeper struct {
 	// The [weiStore] is NOT necessarily the balance from [GetWeiBalance].
 	// Rather, it the key-value store that holds NIBI balances smaller than 1
 	// micronibi (unibi).
-	weiStore      collections.Map[sdk.AccAddress, sdkmath.Int]
+	weiStore      collections.Map[sdk.AccAddress, sdkmath.Uint]
 	weiBlockDelta collections.ItemTransient[sdkmath.Int]
 }
 
@@ -100,12 +98,12 @@ func NewBaseSendKeeper(
 			storeKey,
 			NAMESPACE_BALANCE_WEI,
 			collections.AccAddressKeyEncoder,
-			collections.IntValueEncoder,
+			collections.UintValueEncoder,
 		),
 		weiBlockDelta: collections.NewItemTransient(
 			transientStoreKey,
 			NAMESPACE_WEI_BLOCK_DELTA,
-			eth.SignedIntValueEncoder,
+			collections.IntValueEncoder,
 		),
 	}
 }

--- a/x/collections/value_encoder.go
+++ b/x/collections/value_encoder.go
@@ -15,6 +15,7 @@ var (
 	AccAddressValueEncoder ValueEncoder[sdk.AccAddress] = accAddressValueEncoder{}
 	DecValueEncoder        ValueEncoder[sdk.Dec]        = decValueEncoder{}
 	IntValueEncoder        ValueEncoder[sdkmath.Int]    = intValueEncoder{}
+	UintValueEncoder       ValueEncoder[sdkmath.Uint]   = uintValueEncoder{}
 	Uint64ValueEncoder     ValueEncoder[uint64]         = uint64Value{}
 )
 
@@ -85,25 +86,61 @@ func (a accAddressValueEncoder) Decode(b []byte) sdk.AccAddress        { return 
 func (a accAddressValueEncoder) Stringify(value sdk.AccAddress) string { return value.String() }
 func (a accAddressValueEncoder) Name() string                          { return "sdk.AccAddress" }
 
-// IntValueEncoder ValueEncoder[sdk.Int]
+// IntValueEncoder ValueEncoder[sdkmath.Int]
 
 type intValueEncoder struct{}
 
 func (intValueEncoder) Encode(value sdkmath.Int) []byte {
-	return IntKeyEncoder.Encode(value)
+	bz, err := value.Marshal()
+	if err != nil {
+		panic(fmt.Errorf("invalid math.Int %s: %w", value, err))
+	}
+	return bz
 }
 
 func (intValueEncoder) Decode(b []byte) sdkmath.Int {
-	_, got := IntKeyEncoder.Decode(b)
-	return got
+	n := new(sdkmath.Int)
+	if err := n.Unmarshal(b); err != nil {
+		panic(fmt.Errorf("decoding math.Int from bytes failed: %w", err))
+	}
+	return *n
 }
 
 func (intValueEncoder) Stringify(value sdkmath.Int) string {
-	return IntKeyEncoder.Stringify(value)
+	return value.String()
 }
 
 func (intValueEncoder) Name() string {
 	return "math.Int"
+}
+
+// UintValueEncoder ValueEncoder[sdkmath.Uint].
+
+type uintValueEncoder struct{}
+
+func (uintValueEncoder) Encode(value sdkmath.Uint) []byte {
+	if value.IsNil() {
+		panic("cannot encode invalid math.Uint")
+	}
+	be := value.BigInt().Bytes()
+	padded := make([]byte, maxIntKeyLen)
+	copy(padded[maxIntKeyLen-len(be):], be)
+	return padded
+}
+
+func (uintValueEncoder) Decode(b []byte) sdkmath.Uint {
+	if len(b) != maxIntKeyLen {
+		panic("invalid uint value length")
+	}
+	return sdkmath.NewUintFromBigInt(new(big.Int).SetBytes(b))
+}
+
+func (uintValueEncoder) Stringify(value sdkmath.Uint) string {
+	return value.String()
+}
+
+func (uintValueEncoder) Name() string {
+	return "math.Uint"
 }
 
 // IntKeyEncoder

--- a/x/collections/value_encoder_test.go
+++ b/x/collections/value_encoder_test.go
@@ -54,7 +54,7 @@ func (s *SuiteValueEncoder) TestUint64ValueEncoder() {
 	})
 }
 
-func (s *SuiteValueEncoder) TestIntEncoder() {
+func (s *SuiteValueEncoder) TestIntKeyEncoder() {
 	// we test our assumptions around int are correct.
 	outOfBounds := new(big.Int).Lsh(big.NewInt(1), 256)       // 2^256
 	maxBigInt := new(big.Int).Sub(outOfBounds, big.NewInt(1)) // 2^256 - 1
@@ -90,15 +90,63 @@ func (s *SuiteValueEncoder) TestIntEncoder() {
 	s.Panics(func() {
 		IntKeyEncoder.Encode(sdkmath.Int{})
 	})
+}
 
-	// test value encoder
-	value := sdk.NewInt(50_000)
-	valueBytes := IntValueEncoder.Encode(value)
-	gotValue := IntValueEncoder.Decode(valueBytes)
-	s.Equal(value, gotValue)
+func (s *SuiteValueEncoder) TestIntValueEncoderSigned() {
+	cases := []sdkmath.Int{
+		sdkmath.NewInt(-1),
+		sdkmath.NewInt(-50_000),
+		sdkmath.ZeroInt(),
+		sdkmath.NewInt(1),
+		sdkmath.NewInt(50_000),
+		sdkmath.NewIntFromBigInt(new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))),
+	}
+	for _, value := range cases {
+		s.Run(value.String(), func() {
+			assertValueBijective(s.T(), IntValueEncoder, value)
+		})
+	}
+}
 
-	// panics on invalid math.Int
+func (s *SuiteValueEncoder) TestUintValueEncoderFixedWidth() {
+	outOfBounds := new(big.Int).Lsh(big.NewInt(1), 256)       // 2^256
+	maxBigInt := new(big.Int).Sub(outOfBounds, big.NewInt(1)) // 2^256 - 1
+	maxUint := sdkmath.NewUintFromBigInt(maxBigInt)
+
+	cases := []struct {
+		name  string
+		value sdkmath.Uint
+	}{
+		{"zero", sdkmath.ZeroUint()},
+		{"one", sdkmath.NewUint(1)},
+		{"small", sdkmath.NewUint(100)},
+		{"fifty_thousand", sdkmath.NewUint(50_000)},
+		{"max", maxUint},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			encoded := UintValueEncoder.Encode(tc.value)
+			s.Equal(maxIntKeyLen, len(encoded), "must preserve fixed-width 32-byte format")
+
+			legacy := IntKeyEncoder.Encode(sdkmath.NewIntFromBigInt(tc.value.BigInt()))
+			s.Equal(legacy, encoded)
+
+			got := UintValueEncoder.Decode(encoded)
+			s.True(tc.value.Equal(got))
+			s.Equal(tc.value.String(), UintValueEncoder.Stringify(got))
+			s.Equal("math.Uint", UintValueEncoder.Name())
+		})
+	}
+
+	oldBytesFor100 := make([]byte, maxIntKeyLen)
+	oldBytesFor100[maxIntKeyLen-1] = 0x64 // 100
+	s.True(sdkmath.NewUint(100).Equal(UintValueEncoder.Decode(oldBytesFor100)))
+
 	s.Panics(func() {
-		IntValueEncoder.Encode(sdkmath.Int{})
+		UintValueEncoder.Encode(sdkmath.Uint{})
+	})
+	s.Panics(func() {
+		UintValueEncoder.Decode([]byte{0x01})
 	})
 }


### PR DESCRIPTION
…eEncoder

## Abstract

- Closes #2491

`collections.IntValueEncoder` used to delegate to `IntKeyEncoder`, which panics on negative or nil `sdkmath.Int` values. That was misleading for signed state (e.g. wei block deltas) and unsafe for callers that expected a general signed int encoder.

This PR splits signed value encoding from unsigned fixed-width encoding: `IntValueEncoder` now marshals signed `sdkmath.In`t, a new `UintValueEncoder` keeps the existing 32-byte big-endian format for non-negative persisted state, and `weiStore` is typed as `sdkmath.Uint`. `eth.SignedIntValueEncoder` is removed in favor of the generic collections encoder.