### PR TITLE
fix(passkey): broadcast account creation with explicit gas

### DIFF
--- a/passkey-bundler/README.md
+++ b/passkey-bundler/README.md
@@ -6,7 +6,9 @@ ships with health and metrics endpoints for operations.
 
 ## Features
 - JSON-RPC: `eth_chainId`, `eth_supportedEntryPoints`, `eth_sendUserOperation`, `eth_getUserOperationReceipt`.
-- Passkey helpers: `passkey_createAccount(qx,qy,factory?)`, `passkey_getLogs(limit)`.
+- Passkey helpers: `passkey_createAccount(qx,qy,factory?,gasLimit?)`, `passkey_getLogs(limit)`. Account creation always
+  broadcasts with a bounded explicit gas limit; the optional limit is a hex quantity and defaults to `0x16e360`
+  (1,500,000 gas).
 - Validation: entry point and chain ID enforcement, userOp schema checks, rate limiting, optional API key auth
   (`x-api-key` or `Authorization: Bearer <key>`).
 - Queue + retries: in-memory FIFO queue (tie-breaker `maxPriorityFeePerGas`), configurable concurrency, retries with

--- a/passkey-bundler/src/accountCreation.ts
+++ b/passkey-bundler/src/accountCreation.ts
@@ -1,0 +1,19 @@
+export const DEFAULT_ACCOUNT_CREATION_GAS_LIMIT = 1_500_000n
+export const MAX_ACCOUNT_CREATION_GAS_LIMIT = 5_000_000n
+
+export function parseAccountCreationGasLimit(input: unknown): bigint {
+  if (input === undefined || input === null) {
+    return DEFAULT_ACCOUNT_CREATION_GAS_LIMIT
+  }
+  if (typeof input !== "string" || !/^0x[0-9a-fA-F]+$/.test(input)) {
+    throw new Error("passkey_createAccount gas limit must be a hex quantity")
+  }
+
+  const gasLimit = BigInt(input)
+  if (gasLimit <= 0n || gasLimit > MAX_ACCOUNT_CREATION_GAS_LIMIT) {
+    throw new Error(
+      `passkey_createAccount gas limit must be between 1 and ${MAX_ACCOUNT_CREATION_GAS_LIMIT}`,
+    )
+  }
+  return gasLimit
+}

--- a/passkey-bundler/src/index.ts
+++ b/passkey-bundler/src/index.ts
@@ -3,6 +3,7 @@ import Fastify, { FastifyReply, FastifyRequest } from "fastify"
 import path from "node:path"
 import { Contract, Interface, JsonRpcProvider, Wallet, toBeHex } from "ethers"
 
+import { parseAccountCreationGasLimit } from "./accountCreation"
 import { loadConfig } from "./config"
 import { BundlerLogger } from "./logger"
 import { Metrics } from "./metrics"
@@ -379,6 +380,7 @@ async function handleCreatePasskeyAccount(params: any[], wallet: Wallet): Promis
   const qx = params[0] as string | undefined
   const qy = params[1] as string | undefined
   const factoryAddr = params[2] as string | undefined
+  const gasLimit = parseAccountCreationGasLimit(params[3])
 
   if (!factoryAddr) throw new Error("Factory address missing (param[2])")
   if (!qx || !qy) throw new Error("passkey_createAccount requires qx and qy")
@@ -386,7 +388,9 @@ async function handleCreatePasskeyAccount(params: any[], wallet: Wallet): Promis
   const iface = new Interface(FACTORY_ABI)
   const factory = new Contract(factoryAddr, iface, wallet)
   const predicted = (await factory.accountAddress(qx, qy)) as string
-  const tx = await factory.createAccount(qx, qy)
+  // Some Nibiru RPCs cannot estimate this factory call before the
+  // deterministic clone exists. An explicit limit guarantees a broadcast.
+  const tx = await factory.createAccount(qx, qy, { gasLimit })
   const receipt = await tx.wait()
   const account = parseAccountCreated(receipt?.logs, iface) ?? predicted
   return { account, txHash: receipt?.hash ?? tx.hash }

--- a/passkey-bundler/test/basic.test.ts
+++ b/passkey-bundler/test/basic.test.ts
@@ -4,6 +4,10 @@ import os from "node:os"
 import path from "node:path"
 import { test } from "node:test"
 
+import {
+  DEFAULT_ACCOUNT_CREATION_GAS_LIMIT,
+  parseAccountCreationGasLimit,
+} from "../src/accountCreation"
 import { loadConfig } from "../src/config"
 import { RateLimiter } from "../src/rateLimiter"
 import { SqliteStore } from "../src/store"
@@ -151,6 +155,25 @@ test("preVerificationGas estimate includes calldata and overhead", () => {
     },
   })
   assert.ok(pre > 30_000n)
+})
+
+test("passkey account creation defaults to explicit gas", () => {
+  assert.equal(
+    parseAccountCreationGasLimit(undefined),
+    DEFAULT_ACCOUNT_CREATION_GAS_LIMIT,
+  )
+})
+
+test("passkey account creation accepts only bounded hex overrides", () => {
+  assert.equal(parseAccountCreationGasLimit("0x16e360"), 1_500_000n)
+  assert.throws(
+    () => parseAccountCreationGasLimit("0x989680"),
+    /must be between 1 and/,
+  )
+  assert.throws(
+    () => parseAccountCreationGasLimit("1500000"),
+    /must be a hex quantity/,
+  )
 })
 
 test("sqlite store persists userOp records and receipts", async () => {


### PR DESCRIPTION
## Why

Sai web passkey PR #764 has a reproduced first-connect failure where `factory.createAccount` dies during `estimateGas` before any transaction is broadcast. The browser cannot reconcile that case because no bytecode can ever appear at the predicted account.

## What changed

- always pass an explicit bounded gas limit to `PasskeyAccountFactory.createAccount`
- keep older clients working with a 1,500,000 gas server default
- accept an optional fourth `passkey_createAccount` hex gas parameter for the refreshed web client
- reject malformed, zero, or excessive overrides above 5,000,000
- document and regression-test the helper boundary

## Verification

- `npm test` — 10/10 pass
- `npm run build` — ESM and DTS builds pass

## Rollout dependency

Deploy this bundler change before treating Sai web #764 first-connect as runtime-verified. The web PR sends the new explicit parameter, but existing deployed bundlers ignore it until this change lands.