### PR TITLE
refactor(eip712): use slices.SortFunc for key ordering

### DIFF
--- a/eth/eip712/types.go
+++ b/eth/eip712/types.go
@@ -4,7 +4,7 @@ package eip712
 import (
 	"bytes"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"golang.org/x/text/cases"
@@ -238,8 +238,8 @@ func sortedJSONKeys(json gjson.Result) ([]string, error) {
 		i++
 	}
 
-	sort.Slice(keys, func(i, j int) bool {
-		return strings.Compare(keys[i], keys[j]) > 0
+	slices.SortFunc(keys, func(a, b string) int {
+		return strings.Compare(b, a)
 	})
 
 	return keys, nil


### PR DESCRIPTION
## Abstract

- Closes  https://github.com/NibiruChain/nibiru/issues/2739

The EIP-712 key ordering code currently relies on an index-based `sort.Slice` callback. This PR replaces it with a typed `slices.SortFunc` comparator while preserving the existing descending key order.

## Testing Approach

- `go test ./eth/eip712/...`

## Why this Solution Works

The comparator returns the same ordering relation as before; it only compares values directly instead of looking them up by index.