### PR TITLE
test(evm): tolerate block indexer lag

### DIFF
--- a/eth/rpc/rpcapi/api_eth_test.go
+++ b/eth/rpc/rpcapi/api_eth_test.go
@@ -228,12 +228,25 @@ func (s *NodeSuite) Test_BlockNumber() {
 // Test_BlockByNumber EVM method: eth_getBlockByNumber
 func (s *NodeSuite) Test_BlockByNumber() {
 	networkBlockNumber, err := s.cli.LatestHeight()
-	s.NoError(err)
+	s.Require().NoError(err)
 
-	ethBlock, err := s.ethAPI.GetBlockByNumber(rpc.NewBlockNumber(big.NewInt(networkBlockNumber)), true)
-	s.NoError(err)
-	s.NotNil(ethBlock)
-	s.Equal(networkBlockNumber, int64(ethBlock["number"].(hexutil.Uint64)))
+	const maxBlockLag = int64(2)
+	var ethBlock map[string]any
+	var queriedBlockNumber int64
+	for blockLag := int64(0); blockLag <= maxBlockLag; blockLag++ {
+		queriedBlockNumber = networkBlockNumber - blockLag
+		ethBlock, err = s.ethAPI.GetBlockByNumber(
+			rpc.NewBlockNumber(big.NewInt(queriedBlockNumber)),
+			true,
+		)
+		if err == nil {
+			break
+		}
+	}
+
+	s.Require().NoError(err)
+	s.Require().NotNil(ethBlock)
+	s.Equal(queriedBlockNumber, int64(ethBlock["number"].(hexutil.Uint64)))
 }
 
 // Test_BalanceAt EVM method: eth_getBalance


### PR DESCRIPTION
## Abstract

Closes #2058.

Test_BlockByNumber reads the latest CometBFT height, while the EVM indexer can briefly trail it by one or two blocks. That race can return not found and previously allowed the test to continue into a nil-pointer panic.

This change:
- tries the reported height, then bounded fallbacks at heights -1 and -2;
- stops at the first successful indexed block;
- validates the returned block against the height actually queried;
- uses required assertions so lookup failures stop the test safely.

## Testing

- git diff --check
- Full localnet integration test not run locally because Go 1.25 and the Nibiru localnet are unavailable in this environment; repository CI should exercise the suite.