### PR TITLE
build(wasmvm): move release builders to Bookworm

### DIFF
--- a/lib/wasmvm/Makefile
+++ b/lib/wasmvm/Makefile
@@ -1,9 +1,9 @@
 .PHONY: all build build-rust build-go test
 
 # Builds the Rust library libwasmvm
-BUILDERS_PREFIX := cosmwasm/go-ext-builder:0018
+BUILDERS_PREFIX := cosmwasm/go-ext-builder:0019
 # Contains a full Go dev environment in order to run Go tests on the built library
-ALPINE_TESTER := cosmwasm/go-ext-builder:0018-alpine
+ALPINE_TESTER := cosmwasm/go-ext-builder:0019-alpine
 
 USER_ID := $(shell id -u)
 USER_GROUP = $(shell id -g)

--- a/lib/wasmvm/builders/Dockerfile.cross
+++ b/lib/wasmvm/builders/Dockerfile.cross
@@ -1,4 +1,4 @@
-FROM rust:1.90-bullseye
+FROM rust:1.90-bookworm
 
 # Install build dependencies
 RUN apt-get update \

--- a/lib/wasmvm/builders/Dockerfile.debian
+++ b/lib/wasmvm/builders/Dockerfile.debian
@@ -1,7 +1,7 @@
-# Use a Debian version old enough to keep glibc requirements low while still
-# having supported package repositories. Debian 11 "Bullseye" has LTS until
-# August 31, 2026.
-FROM debian:11-slim
+# Debian 12 "Bookworm" receives LTS through June 30, 2028. Bullseye reached
+# end of life on August 31, 2026, so its live security repository can no longer
+# provide a reliable builder input.
+FROM debian:12-slim
 
 RUN apt-get -o Acquire::Retries=5 update -y \
   && apt-get -o Acquire::Retries=5 install -y \

--- a/lib/wasmvm/builders/Makefile
+++ b/lib/wasmvm/builders/Makefile
@@ -1,6 +1,6 @@
 # Versioned by a simple counter that is not bound to a specific CosmWasm version
 # See builders/README.md
-BUILDERS_PREFIX := cosmwasm/go-ext-builder:0018
+BUILDERS_PREFIX := cosmwasm/go-ext-builder:0019
 
 .PHONY: docker-image-centos7
 docker-image-centos7:

--- a/lib/wasmvm/builders/README.md
+++ b/lib/wasmvm/builders/README.md
@@ -19,6 +19,11 @@ versions of the builder images.
 
 ## Changelog
 
+**Version 0019:**
+
+- Move the Debian and cross-compilation builders from end-of-life Bullseye to
+  supported Bookworm.
+
 **Version 0018:**
 
 - Update Rust to stable for Nibiru fork artifact builds.

--- a/lib/wasmvm/justfile
+++ b/lib/wasmvm/justfile
@@ -184,10 +184,10 @@ test-alpine:
   user_group="$(id -g)"
 
   just artifact-static
-  docker run --rm -u "${user_id}:${user_group}" -v "$repo_root":/mnt/testrun -w /mnt/testrun cosmwasm/go-ext-builder:0018-alpine go build -tags muslc ./lib/wasmvm/...
-  docker run --rm -u "${user_id}:${user_group}" -v "$repo_root":/mnt/testrun -w /mnt/testrun cosmwasm/go-ext-builder:0018-alpine go test -tags muslc -count=1 ./lib/wasmvm/...
-  docker run --rm -u "${user_id}:${user_group}" -v "$repo_root":/mnt/testrun -w /mnt/testrun cosmwasm/go-ext-builder:0018-alpine sh -c "cd lib/wasmvm && ./build_demo.sh"
-  docker run --rm -u "${user_id}:${user_group}" -v "$repo_root":/mnt/testrun -w /mnt/testrun/lib/wasmvm cosmwasm/go-ext-builder:0018-alpine file ./demo
+  docker run --rm -u "${user_id}:${user_group}" -v "$repo_root":/mnt/testrun -w /mnt/testrun cosmwasm/go-ext-builder:0019-alpine go build -tags muslc ./lib/wasmvm/...
+  docker run --rm -u "${user_id}:${user_group}" -v "$repo_root":/mnt/testrun -w /mnt/testrun cosmwasm/go-ext-builder:0019-alpine go test -tags muslc -count=1 ./lib/wasmvm/...
+  docker run --rm -u "${user_id}:${user_group}" -v "$repo_root":/mnt/testrun -w /mnt/testrun cosmwasm/go-ext-builder:0019-alpine sh -c "cd lib/wasmvm && ./build_demo.sh"
+  docker run --rm -u "${user_id}:${user_group}" -v "$repo_root":/mnt/testrun -w /mnt/testrun/lib/wasmvm cosmwasm/go-ext-builder:0019-alpine file ./demo
   for alpine_version in 3.18 3.17 3.16 3.15 3.14; do
     docker run --rm --read-only -v "$wasmvm_dir":/mnt/testrun -w /mnt/testrun "alpine:${alpine_version}" ./demo ./testdata/hackatom.wasm
   done
@@ -262,15 +262,15 @@ shellcheck:
 
 # Build the static musl Docker builder image.
 docker-image-static:
-  docker build --pull --progress=plain --platform=linux/amd64 builders -t cosmwasm/go-ext-builder:0018-alpine -f builders/Dockerfile.alpine
+  docker build --pull --progress=plain --platform=linux/amd64 builders -t cosmwasm/go-ext-builder:0019-alpine -f builders/Dockerfile.alpine
 
 # Build the Linux shared Docker builder image.
 docker-image-linux:
-  docker build --pull --progress=plain --platform=linux/amd64 builders -t cosmwasm/go-ext-builder:0018-debian -f builders/Dockerfile.debian
+  docker build --pull --progress=plain --platform=linux/amd64 builders -t cosmwasm/go-ext-builder:0019-debian -f builders/Dockerfile.debian
 
 # Build the Darwin and Windows cross Docker builder image.
 docker-image-cross:
-  docker build --pull --progress=plain builders -t cosmwasm/go-ext-builder:0018-cross -f builders/Dockerfile.cross
+  docker build --pull --progress=plain builders -t cosmwasm/go-ext-builder:0019-cross -f builders/Dockerfile.cross
 
 # Build static musl release artifacts.
 artifact-static:
@@ -281,7 +281,7 @@ artifact-static:
 
   rm -rf libwasmvm/target/aarch64-unknown-linux-musl/release
   rm -rf libwasmvm/target/x86_64-unknown-linux-musl/release
-  docker run --rm -u "${user_id}:${user_group}" -v "$PWD/libwasmvm":/code cosmwasm/go-ext-builder:0018-alpine
+  docker run --rm -u "${user_id}:${user_group}" -v "$PWD/libwasmvm":/code cosmwasm/go-ext-builder:0019-alpine
   cp libwasmvm/artifacts/libwasmvm_muslc.a internal/api
   cp libwasmvm/artifacts/libwasmvm_muslc.aarch64.a internal/api
   just update-bindings
@@ -292,7 +292,7 @@ artifact-linux:
   set -euo pipefail
   rm -rf libwasmvm/target/x86_64-unknown-linux-gnu/release
   rm -rf libwasmvm/target/aarch64-unknown-linux-gnu/release
-  docker run --rm -u "$(id -u):$(id -g)" -v "$PWD/libwasmvm:/code" cosmwasm/go-ext-builder:0018-debian build_linux.sh
+  docker run --rm -u "$(id -u):$(id -g)" -v "$PWD/libwasmvm:/code" cosmwasm/go-ext-builder:0019-debian build_linux.sh
   cp libwasmvm/artifacts/libwasmvm.x86_64.so internal/api
   cp libwasmvm/artifacts/libwasmvm.aarch64.so internal/api
   just update-bindings
@@ -306,11 +306,11 @@ artifact-darwin:
 
   rm -rf libwasmvm/target/x86_64-apple-darwin/release
   rm -rf libwasmvm/target/aarch64-apple-darwin/release
-  docker run --rm -u "${user_id}:${user_group}" -v "$PWD/libwasmvm":/code cosmwasm/go-ext-builder:0018-cross build_macos.sh
+  docker run --rm -u "${user_id}:${user_group}" -v "$PWD/libwasmvm":/code cosmwasm/go-ext-builder:0019-cross build_macos.sh
   cp libwasmvm/artifacts/libwasmvm.dylib internal/api
   rm -rf libwasmvm/target/x86_64-apple-darwin/release
   rm -rf libwasmvm/target/aarch64-apple-darwin/release
-  docker run --rm -u "${user_id}:${user_group}" -v "$PWD/libwasmvm":/code cosmwasm/go-ext-builder:0018-cross build_macos_static.sh
+  docker run --rm -u "${user_id}:${user_group}" -v "$PWD/libwasmvm":/code cosmwasm/go-ext-builder:0019-cross build_macos_static.sh
   cp libwasmvm/artifacts/libwasmvmstatic_darwin.a internal/api/libwasmvmstatic_darwin.a
   just update-bindings
 


### PR DESCRIPTION
# build(wasmvm): move release builders to Bookworm

Move the Debian and cross-compilation builder images from end-of-life Bullseye to Bookworm. The change restores live package installation for the WasmVM release-image jobs and publishes the updated builder set as version `0019`.

## Rationale

Bullseye reached end of life on August 31, 2026. Its live security repository returned package 404s while CI created the Linux shared and Darwin builder images. The failure occurred before any Rust or Go code compiled.

The builder version is part of the release-artifact contract. A Bookworm-based image must not reuse the `0018` tag, which identifies the Bullseye builder set. The Alpine builder itself does not change, but it moves with the common versioned image set.

## Key Changes

1. Use `debian:12-slim` for Linux shared-library builds and `rust:1.90-bookworm` for Darwin and Windows cross compilation.
1. Advance the builder-image prefix from `0018` to `0019` in Make and just recipes.
1. Document the Bookworm transition in the builder-image changelog.

## 1 - Supported builder inputs

```text
0018  -> Debian 11 Bullseye  -> live security packages retired
0019  -> Debian 12 Bookworm  -> supported Debian package repositories
```

The Linux shared and cross builders now use Bookworm, which Debian supports through June 2028. The static musl Dockerfile remains unchanged.

## 2 - Artifact compatibility boundary

```text
builder source  -> versioned image tag  -> release artifact build
Bookworm source -> 0019 image tag       -> new artifact baseline
```

Bookworm has a newer glibc than Bullseye. The `0019` tag makes that boundary explicit for release tooling and reviewers instead of silently producing Bookworm-built shared libraries under the old builder tag.
