### PR TITLE
feat(release): Add artifact-backed image publisher

### DIFF
--- a/.github/workflows/publish-private-release-image.yml
+++ b/.github/workflows/publish-private-release-image.yml
@@ -1,0 +1,92 @@
+# Publish a container from a public artifact release that was built elsewhere.
+#
+# This workflow exists for private-first releases. The regular release workflow
+# starts from a public v* source tag and builds its own artifacts. Do not use it
+# for a hotfix/v* record, whose attached archives are the release boundary.
+#
+# Run this workflow from main after the public hotfix/v<semver> release is
+# published. It derives the image tag from that input, verifies the uploaded
+# Linux archives, and publishes only ghcr.io/nibiruchain/nibiru:<semver>.
+# It never creates latest or architecture-suffixed public tags.
+name: Publish Private-First Release Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Published public artifact tag, for example hotfix/v2.19.0"
+        required: true
+        type: string
+
+# The short-lived workflow token can read this repository's release assets and
+# publish its linked container package. No personal access token is required.
+permissions:
+  contents: read
+  packages: write
+
+# A second manual run for the same release waits instead of racing to move the
+# same immutable-looking image tag. Do not cancel a run that may be uploading.
+concurrency:
+  group: private-first-release-image-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Verify artifacts and publish image
+    runs-on: ubuntu-latest
+
+    steps:
+      # Dispatching from another branch would run unreviewed workflow code.
+      # Keep the publisher anchored to main, where the reviewed script lives.
+      - name: Require a main-branch dispatch
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main" || {
+            echo "::error::Run this workflow from the main branch."
+            exit 1
+          }
+
+      - name: Check out the trusted publisher
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Validate the release tag and derive its image version
+        id: release
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          case "$RELEASE_TAG" in
+            hotfix/v*) ;;
+            *)
+              echo "::error::release_tag must start with hotfix/v."
+              exit 1
+              ;;
+          esac
+
+          version="${RELEASE_TAG#hotfix/v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::release_tag must end in a semver version."
+            exit 1
+          fi
+
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # gh reads GH_TOKEN. Docker reads GHCR_TOKEN. Both hold the same
+      # short-lived token, scoped by the permissions block above.
+      - name: Verify release assets and publish the multi-arch image
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GHCR_TOKEN: ${{ github.token }}
+          GHCR_USERNAME: ${{ github.actor }}
+        run: |
+          contrib/scripts/publish-release-image.sh \
+            --release-tag "${{ steps.release.outputs.tag }}" \
+            --version "${{ steps.release.outputs.version }}" \
+            --push

--- a/.github/workflows/publish-private-release-image.yml
+++ b/.github/workflows/publish-private-release-image.yml
@@ -1,13 +1,46 @@
 # Publish a container from a public artifact release that was built elsewhere.
 #
-# This workflow exists for private-first releases. The regular release workflow
-# starts from a public v* source tag and builds its own artifacts. Do not use it
-# for a hotfix/v* record, whose attached archives are the release boundary.
+# Private-first release procedure
+# -------------------------------
+# Use this workflow only when a release must distribute tested binaries before
+# its source changes can be published. The public repository's normal Release
+# workflow is source-first: a public v<semver> tag triggers a build from that
+# tag. That is the wrong mechanism for this case because it would rebuild from
+# public source rather than package the already-tested private-release binary.
 #
-# Run this workflow from main after the public hotfix/v<semver> release is
-# published. It derives the image tag from that input, verifies the uploaded
-# Linux archives, and publishes only ghcr.io/nibiruchain/nibiru:<semver>.
-# It never creates latest or architecture-suffixed public tags.
+# 1. In the private release repository, merge the required public-main history
+#    into the private release line. Tag the exact private release commit as
+#    v<semver>, let private CI build the native archives, and verify its
+#    checksum manifest. The private release must contain Linux amd64 and arm64,
+#    Darwin amd64 and arm64, universal Darwin, and the checksum manifest.
+#
+# 2. In this public repository, create annotated tag hotfix/v<semver> at an
+#    appropriate public-main commit. Do not create public tag v<semver> yet.
+#    Publish a GitHub release on hotfix/v<semver>, then upload the verified
+#    private CI archives and their unchanged checksum manifest as its assets.
+#    Compare the public asset digests with the private manifest before making
+#    the public artifact release visible.
+#
+#    The hotfix tag is an artifact distribution record, not the private source
+#    commit. It deliberately avoids the v* trigger in release.yml. Publishing
+#    these release assets makes the compiled binaries available. It does not
+#    publish the private source tree or make a public-source release claim.
+#
+# 3. Merge this workflow to public main. In Actions, select this workflow, run
+#    it from main, and enter the published public release tag exactly, for
+#    example hotfix/v2.19.0. The input is the only operator-controlled value.
+#    The workflow derives image tag 2.19.0, verifies the attached Linux files,
+#    and publishes ghcr.io/nibiruchain/nibiru:2.19.0.
+#
+# 4. Inspect the pushed manifest for linux/amd64 and linux/arm64. Do not add
+#    latest, a hotfix-prefixed image tag, or architecture-suffixed public tags.
+#    When the source is ready for public release, follow the ordinary v<semver>
+#    source-release process separately.
+#
+# This workflow reads only the public artifact release. It uses its short-lived
+# GITHUB_TOKEN with packages: write, not a personal access token. A run fails
+# before publication if the tag is not hotfix/v<semver>, the release is a draft,
+# an expected archive is missing, or either Linux archive fails SHA-256 checks.
 name: Publish Private-First Release Image
 
 on:

--- a/.github/workflows/publish-private-release-image.yml
+++ b/.github/workflows/publish-private-release-image.yml
@@ -32,6 +32,12 @@
 #    The workflow derives image tag 2.19.0, verifies the attached Linux files,
 #    and publishes ghcr.io/nibiruchain/nibiru:2.19.0.
 #
+#    Before merging, a developer can run command `just release-image-smoke
+#    hotfix/v<semver> <semver>` on an ARM64 or AMD64 Docker host. The command
+#    builds both platform images from the same downloaded archives and runs
+#    command `nibid version --long` in each container. It does not log in to
+#    GHCR or publish an image.
+#
 # 4. Inspect the pushed manifest for linux/amd64 and linux/arm64. Do not add
 #    latest, a hotfix-prefixed image tag, or architecture-suffixed public tags.
 #    When the source is ready for public release, follow the ordinary v<semver>

--- a/contrib/scripts/publish-release-image.sh
+++ b/contrib/scripts/publish-release-image.sh
@@ -7,8 +7,10 @@ image="ghcr.io/nibiruchain/nibiru"
 release_tag=""
 version=""
 push=false
+smoke_test=false
 dry_run=false
 tmp_dir=""
+smoke_tags=()
 
 usage() {
   cat <<'EOF'
@@ -24,6 +26,7 @@ Required:
 
 Options:
   --push                Publish <image>:<version> to GHCR after verification.
+  --smoke-test          Build and run each Linux image locally without pushing.
   --repo <owner/repo>   GitHub release repository. Default: NibiruChain/nibiru
   --image <image>       Container image. Default: ghcr.io/nibiruchain/nibiru
   --dry-run             Print the planned operation and exit.
@@ -46,6 +49,10 @@ fail() {
 }
 
 cleanup() {
+  local tag
+  for tag in "${smoke_tags[@]}"; do
+    docker image rm --force "$tag" >/dev/null 2>&1 || true
+  done
   if [[ -n "$tmp_dir" && -d "$tmp_dir" ]]; then
     rm -rf -- "$tmp_dir"
   fi
@@ -82,6 +89,10 @@ while [[ $# -gt 0 ]]; do
       push=true
       shift
       ;;
+    --smoke-test)
+      smoke_test=true
+      shift
+      ;;
     --dry-run)
       dry_run=true
       shift
@@ -102,11 +113,15 @@ done
 [[ "$release_tag" == "v${version}" || "$release_tag" == */"v${version}" ]] || fail "release tag must end in v${version}"
 [[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail "invalid repository: $repo"
 [[ "$image" =~ ^ghcr.io/[A-Za-z0-9._/-]+$ ]] || fail "image must be a GHCR image: $image"
+[[ "$push" == false || "$smoke_test" == false ]] || fail "--push and --smoke-test cannot be used together"
 
 if [[ "$dry_run" == true ]]; then
   log "would verify release $repo@$release_tag and build $image:$version"
   if [[ "$push" == true ]]; then
     log "would publish $image:$version"
+  fi
+  if [[ "$smoke_test" == true ]]; then
+    log "would build and run local linux/amd64 and linux/arm64 smoke images"
   fi
   exit 0
 fi
@@ -117,8 +132,10 @@ require_command jq
 require_command sha256sum
 require_command tar
 
-if [[ "$push" == true ]]; then
+if [[ "$push" == true || "$smoke_test" == true ]]; then
   require_command docker
+fi
+if [[ "$push" == true ]]; then
   [[ -n "${GHCR_TOKEN:-}" ]] || fail "GHCR_TOKEN is required with --push"
 fi
 
@@ -171,6 +188,29 @@ tar -xzf "$download_dir/nibid_${version}_linux_arm64.tar.gz" -C "$source_dir/dis
 [[ -x "$source_dir/dist/arm64/nibid" ]] || fail "arm64 archive does not contain an executable nibid"
 
 log "verified release assets from $release_url"
+if [[ "$smoke_test" == true ]]; then
+  for architecture in amd64 arm64; do
+    platform="linux/$architecture"
+    smoke_tag="nibiru-release-smoke-$$:${version}-${architecture}"
+    smoke_tags+=("$smoke_tag")
+
+    log "building local $platform image from verified artifacts"
+    docker buildx build "$source_dir" \
+      --target release \
+      --build-arg src=external \
+      --platform "$platform" \
+      --tag "$smoke_tag" \
+      --load
+
+    log "running nibid version --long in local $platform image"
+    version_output="$(docker run --rm --platform "$platform" "$smoke_tag" version --long)"
+    printf '%s\n' "$version_output"
+    grep -Fx "version: $version" <<<"$version_output" >/dev/null || fail "local $platform image reports an unexpected nibid version"
+  done
+  log "local smoke test passed for linux/amd64 and linux/arm64"
+  exit 0
+fi
+
 if [[ "$push" == false ]]; then
   log "verification complete. Re-run with --push to publish $image:$version."
   exit 0

--- a/contrib/scripts/publish-release-image.sh
+++ b/contrib/scripts/publish-release-image.sh
@@ -29,7 +29,9 @@ Options:
   --dry-run             Print the planned operation and exit.
   -h, --help            Show this help.
 
-Publishing requires GHCR_TOKEN with GitHub Packages write permission. Set
+Publishing requires GHCR_TOKEN with permission to write GitHub Packages. For a
+local run, use a classic personal access token. In GitHub Actions, map the
+workflow GITHUB_TOKEN from a job with packages: write to GHCR_TOKEN. Set
 GHCR_USERNAME to override the authenticated GitHub username used for login.
 EOF
 }

--- a/contrib/scripts/publish-release-image.sh
+++ b/contrib/scripts/publish-release-image.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Build a multi-architecture GHCR image from binaries attached to a public release.
+set -Eeuo pipefail
+
+repo="NibiruChain/nibiru"
+image="ghcr.io/nibiruchain/nibiru"
+release_tag=""
+version=""
+push=false
+dry_run=false
+tmp_dir=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  publish-release-image.sh --release-tag <tag> --version <version> [options]
+
+Download and verify Linux release artifacts, then optionally publish them as a
+multi-architecture image. Verification is the default and never changes GHCR.
+
+Required:
+  --release-tag <tag>   Published GitHub release tag, such as hotfix/v2.19.0
+  --version <version>   Image version, such as 2.19.0
+
+Options:
+  --push                Publish <image>:<version> to GHCR after verification.
+  --repo <owner/repo>   GitHub release repository. Default: NibiruChain/nibiru
+  --image <image>       Container image. Default: ghcr.io/nibiruchain/nibiru
+  --dry-run             Print the planned operation and exit.
+  -h, --help            Show this help.
+
+Publishing requires GHCR_TOKEN with GitHub Packages write permission. Set
+GHCR_USERNAME to override the authenticated GitHub username used for login.
+EOF
+}
+
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+fail() {
+  log "error: $*"
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$tmp_dir" && -d "$tmp_dir" ]]; then
+    rm -rf -- "$tmp_dir"
+  fi
+}
+trap cleanup EXIT
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release-tag)
+      [[ $# -ge 2 ]] || fail "--release-tag requires a value"
+      release_tag="$2"
+      shift 2
+      ;;
+    --version)
+      [[ $# -ge 2 ]] || fail "--version requires a value"
+      version="$2"
+      shift 2
+      ;;
+    --repo)
+      [[ $# -ge 2 ]] || fail "--repo requires a value"
+      repo="$2"
+      shift 2
+      ;;
+    --image)
+      [[ $# -ge 2 ]] || fail "--image requires a value"
+      image="$2"
+      shift 2
+      ;;
+    --push)
+      push=true
+      shift
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -n "$release_tag" ]] || fail "--release-tag is required"
+[[ -n "$version" ]] || fail "--version is required"
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]] || fail "version must be semver-like: $version"
+[[ "$release_tag" == "v${version}" || "$release_tag" == */"v${version}" ]] || fail "release tag must end in v${version}"
+[[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail "invalid repository: $repo"
+[[ "$image" =~ ^ghcr.io/[A-Za-z0-9._/-]+$ ]] || fail "image must be a GHCR image: $image"
+
+if [[ "$dry_run" == true ]]; then
+  log "would verify release $repo@$release_tag and build $image:$version"
+  if [[ "$push" == true ]]; then
+    log "would publish $image:$version"
+  fi
+  exit 0
+fi
+
+require_command gh
+require_command git
+require_command jq
+require_command sha256sum
+require_command tar
+
+if [[ "$push" == true ]]; then
+  require_command docker
+  [[ -n "${GHCR_TOKEN:-}" ]] || fail "GHCR_TOKEN is required with --push"
+fi
+
+release_json="$(gh release view "$release_tag" --repo "$repo" --json isDraft,assets,url)"
+if [[ "$(jq -r '.isDraft' <<<"$release_json")" == "true" ]]; then
+  fail "release $release_tag is still a draft; publish it before building its container"
+fi
+
+release_url="$(jq -r '.url' <<<"$release_json")"
+assets=(
+  "nibid_${version}_checksums.txt"
+  "nibid_${version}_darwin_all.tar.gz"
+  "nibid_${version}_darwin_amd64.tar.gz"
+  "nibid_${version}_darwin_arm64.tar.gz"
+  "nibid_${version}_linux_amd64.tar.gz"
+  "nibid_${version}_linux_arm64.tar.gz"
+)
+for asset in "${assets[@]}"; do
+  jq -e --arg name "$asset" '.assets | any(.name == $name)' <<<"$release_json" >/dev/null || fail "release is missing asset: $asset"
+done
+
+tmp_dir="$(mktemp -d -t nibiru-release-image.XXXXXX)"
+download_dir="$tmp_dir/downloads"
+source_dir="$tmp_dir/source"
+mkdir -p "$download_dir"
+
+download_assets=(
+  "nibid_${version}_checksums.txt"
+  "nibid_${version}_linux_amd64.tar.gz"
+  "nibid_${version}_linux_arm64.tar.gz"
+)
+for asset in "${download_assets[@]}"; do
+  log "downloading $asset"
+  gh release download "$release_tag" --repo "$repo" --dir "$download_dir" --pattern "$asset"
+done
+
+manifest="$download_dir/nibid_${version}_checksums.txt"
+linux_manifest="$download_dir/linux-checksums.txt"
+grep -E "^[[:xdigit:]]{64}  nibid_${version}_linux_(amd64|arm64)\\.tar\\.gz$" "$manifest" > "$linux_manifest"
+[[ "$(wc -l < "$linux_manifest")" -eq 2 ]] || fail "checksum manifest must contain exactly two Linux archives"
+(cd "$download_dir" && sha256sum -c "$(basename "$linux_manifest")")
+
+log "cloning source for $release_tag"
+git clone --quiet --depth 1 --branch "$release_tag" "https://github.com/$repo.git" "$source_dir"
+release_commit="$(git -C "$source_dir" rev-parse HEAD)"
+mkdir -p "$source_dir/dist/amd64" "$source_dir/dist/arm64"
+tar -xzf "$download_dir/nibid_${version}_linux_amd64.tar.gz" -C "$source_dir/dist/amd64"
+tar -xzf "$download_dir/nibid_${version}_linux_arm64.tar.gz" -C "$source_dir/dist/arm64"
+[[ -x "$source_dir/dist/amd64/nibid" ]] || fail "amd64 archive does not contain an executable nibid"
+[[ -x "$source_dir/dist/arm64/nibid" ]] || fail "arm64 archive does not contain an executable nibid"
+
+log "verified release assets from $release_url"
+if [[ "$push" == false ]]; then
+  log "verification complete. Re-run with --push to publish $image:$version."
+  exit 0
+fi
+
+ghcr_username="${GHCR_USERNAME:-$(gh api user --jq .login)}"
+log "logging in to GHCR as $ghcr_username"
+printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$ghcr_username" --password-stdin
+
+log "building and publishing $image:$version from verified artifacts"
+docker buildx build "$source_dir" \
+  --target release \
+  --build-arg src=external \
+  --platform linux/amd64,linux/arm64 \
+  --tag "$image:$version" \
+  --label "org.opencontainers.image.source=https://github.com/$repo" \
+  --label "org.opencontainers.image.url=$release_url" \
+  --label "org.opencontainers.image.revision=$release_commit" \
+  --label "org.opencontainers.image.version=$version" \
+  --push
+
+manifest_json="$(docker buildx imagetools inspect --raw "$image:$version")"
+for architecture in amd64 arm64; do
+  jq -e --arg architecture "$architecture" \
+    '.manifests | any(.platform.os == "linux" and .platform.architecture == $architecture)' \
+    <<<"$manifest_json" >/dev/null || fail "published image is missing linux/$architecture"
+done
+log "published $image:$version with linux/amd64 and linux/arm64 manifests"

--- a/justfile
+++ b/justfile
@@ -240,6 +240,10 @@ release-publish:
 release-image-verify release_tag version:
     contrib/scripts/publish-release-image.sh --release-tag '{{release_tag}}' --version '{{version}}'
 
+# Build and execute local amd64 and arm64 images from verified public release artifacts.
+release-image-smoke release_tag version:
+    contrib/scripts/publish-release-image.sh --release-tag '{{release_tag}}' --version '{{version}}' --smoke-test
+
 # Publish a verified public release as ghcr.io/nibiruchain/nibiru:<version>.
 [confirm]
 release-image-publish release_tag version:

--- a/justfile
+++ b/justfile
@@ -236,6 +236,15 @@ test-release:
 release-publish:
     make release
 
+# Verify a public release's artifacts before publishing its container image.
+release-image-verify release_tag version:
+    contrib/scripts/publish-release-image.sh --release-tag '{{release_tag}}' --version '{{version}}'
+
+# Publish a verified public release as ghcr.io/nibiruchain/nibiru:<version>.
+[confirm]
+release-image-publish release_tag version:
+    contrib/scripts/publish-release-image.sh --release-tag '{{release_tag}}' --version '{{version}}' --push
+
 [private]
 _go-test-pkgs:
     #!/usr/bin/env bash


### PR DESCRIPTION
# Publish private-first release images from verified public artifacts

This adds a manual, public-repository path for turning verified release
archives into `ghcr.io/nibiruchain/nibiru:<version>` without rebuilding those
archives from public source.

## Rationale

File `.github/workflows/release.yml` owns ordinary public source releases. Its
`v<version>` trigger builds from the tagged public source. A private-first
release has a different boundary: private CI produces and verifies the
archives, while the public repository publishes those exact archive bytes and
their checksum manifest. The container must use those files, or it is no
longer the same distribution the release record describes.

## Key Changes

1. Add command `contrib/scripts/publish-release-image.sh` to check the release
   contents, validate the Linux SHA-256 entries, construct an external-artifact
   Docker context, and inspect the published multi-architecture manifest.
1. Add `main`-only workflow `Publish Private-First Release Image`. It accepts
   only a published `hotfix/v<semver>` release, derives its image tag, and uses
   `GITHUB_TOKEN` with `packages: write` to publish after verification.
1. Add commands `just release-image-verify`, `just release-image-smoke`, and
   `just release-image-publish`. The smoke command builds both Linux images
   locally and runs `nibid version --long` without contacting GHCR.

## 1 - Container provenance

```text
private CI release archives
        |
        v
public hotfix/v<version> artifact release
        |
        v
checksum validation and external Docker context
        |
        v
ghcr.io/nibiruchain/nibiru:<version>
```

The public `hotfix/v<version>` tag records the artifact distribution event. It
does not claim that public source produced the private CI archives. The
workflow does not accept ordinary `v<version>` tags, create `latest`, or
publish architecture-suffixed tags.

## 2 - Local image execution

The smoke command downloads the public assets, builds the `linux/amd64` and
`linux/arm64` images separately, and runs command `nibid version --long` in
each container. That covers the Dockerfile's architecture selection before the
manual workflow uses its repository-scoped token to make the one remote change.
